### PR TITLE
Added aws-c-cal as an export dependency to the cmake config template

### DIFF
--- a/cmake/aws-crt-cpp-config.cmake
+++ b/cmake/aws-crt-cpp-config.cmake
@@ -1,5 +1,6 @@
 include(CMakeFindDependencyMacro)
 
 find_dependency(aws-c-mqtt)
+find_dependency(aws-c-cal)
 
 include(${CMAKE_CURRENT_LIST_DIR}/@CMAKE_PROJECT_NAME@-targets.cmake)


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-iot-device-sdk-cpp-v2/pull/7

*Description of changes:* Added aws-c-cal as an export dependency to the cmake config template


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
