### PR TITLE
Fix spelling of OnConnectionInterupted

### DIFF
--- a/include/aws/crt/crypto/HMAC.h
+++ b/include/aws/crt/crypto/HMAC.h
@@ -28,7 +28,7 @@ namespace Aws
             /**
              * Computes a SHA256 HMAC with secret over input, and writes the digest to output. If truncateTo is
              * non-zero, the digest will be truncated to the value of truncateTo. Returns true on success. If this
-             * function fails, Aws::Crt::LastError() will contain the error that occured. Unless you're using
+             * function fails, Aws::Crt::LastError() will contain the error that occurred. Unless you're using
              * 'truncateTo', output should have a minimum capacity of SHA256_HMAC_DIGEST_SIZE.
              */
             bool AWS_CRT_CPP_API ComputeSHA256HMAC(
@@ -41,7 +41,7 @@ namespace Aws
             /**
              * Computes a SHA256 HMAC using the default allocator with secret over input, and writes the digest to
              * output. If truncateTo is non-zero, the digest will be truncated to the value of truncateTo. Returns true
-             * on success. If this function fails, Aws::Crt::LastError() will contain the error that occured. Unless
+             * on success. If this function fails, Aws::Crt::LastError() will contain the error that occurred. Unless
              * you're using 'truncateTo', output should have a minimum capacity of SHA256_HMAC_DIGEST_SIZE.
              */
             bool AWS_CRT_CPP_API ComputeSHA256HMAC(
@@ -51,7 +51,7 @@ namespace Aws
                 size_t truncateTo = 0) noexcept;
             /**
              * Streaming HMAC object. The typical use case is for computing the HMAC of an object that is too large to
-             * load into memory. You can call Update() mutliple times as you load chunks of data into memory. When
+             * load into memory. You can call Update() multiple times as you load chunks of data into memory. When
              * you're finished simply call Digest(). After Digest() is called, this object is no longer usable.
              */
             class AWS_CRT_CPP_API HMAC final

--- a/include/aws/crt/crypto/Hash.h
+++ b/include/aws/crt/crypto/Hash.h
@@ -29,7 +29,7 @@ namespace Aws
             /**
              * Computes a SHA256 Hash over input, and writes the digest to output. If truncateTo is non-zero, the digest
              * will be truncated to the value of truncateTo. Returns true on success. If this function fails,
-             * Aws::Crt::LastError() will contain the error that occured. Unless you're using 'truncateTo', output
+             * Aws::Crt::LastError() will contain the error that occurred. Unless you're using 'truncateTo', output
              * should have a minimum capacity of SHA256_DIGEST_SIZE.
              */
             bool AWS_CRT_CPP_API ComputeSHA256(
@@ -41,7 +41,7 @@ namespace Aws
             /**
              * Computes a SHA256 Hash using the default allocator over input, and writes the digest to output. If
              * truncateTo is non-zero, the digest will be truncated to the value of truncateTo. Returns true on success.
-             * If this function fails, Aws::Crt::LastError() will contain the error that occured. Unless you're using
+             * If this function fails, Aws::Crt::LastError() will contain the error that occurred. Unless you're using
              * 'truncateTo', output should have a minimum capacity of SHA256_DIGEST_SIZE.
              */
             bool AWS_CRT_CPP_API
@@ -50,7 +50,7 @@ namespace Aws
             /**
              * Computes a MD5 Hash over input, and writes the digest to output. If truncateTo is non-zero, the digest
              * will be truncated to the value of truncateTo. Returns true on success. If this function fails,
-             * Aws::Crt::LastError() will contain the error that occured. Unless you're using 'truncateTo',
+             * Aws::Crt::LastError() will contain the error that occurred. Unless you're using 'truncateTo',
              * output should have a minimum capacity of MD5_DIGEST_SIZE.
              */
             bool AWS_CRT_CPP_API ComputeMD5(
@@ -62,14 +62,14 @@ namespace Aws
             /**
              * Computes a MD5 Hash using the default allocator over input, and writes the digest to output. If
              * truncateTo is non-zero, the digest will be truncated to the value of truncateTo. Returns true on success.
-             * If this function fails, Aws::Crt::LastError() will contain the error that occured. Unless you're using
+             * If this function fails, Aws::Crt::LastError() will contain the error that occurred. Unless you're using
              * 'truncateTo', output should have a minimum capacity of MD5_DIGEST_SIZE.
              */
             bool AWS_CRT_CPP_API ComputeMD5(const ByteCursor &input, ByteBuf &output, size_t truncateTo = 0) noexcept;
 
             /**
              * Streaming Hash object. The typical use case is for computing the hash of an object that is too large to
-             * load into memory. You can call Update() mutliple times as you load chunks of data into memory. When
+             * load into memory. You can call Update() multiple times as you load chunks of data into memory. When
              * you're finished simply call Digest(). After Digest() is called, this object is no longer usable.
              */
             class AWS_CRT_CPP_API Hash final

--- a/include/aws/crt/mqtt/MqttClient.h
+++ b/include/aws/crt/mqtt/MqttClient.h
@@ -49,7 +49,7 @@ namespace Aws
             /**
              * Invoked Upon Connection loss.
              */
-            using OnConnectionInteruptedHandler = std::function<void(MqttConnection &connection, int error)>;
+            using OnConnectionInterruptedHandler = std::function<void(MqttConnection &connection, int error)>;
 
             /**
              * Invoked Upon Connection resumed.
@@ -58,7 +58,7 @@ namespace Aws
                 std::function<void(MqttConnection &connection, ReturnCode connectCode, bool sessionPresent)>;
 
             /**
-             * Invoked when a connack message is received, or an error occured.
+             * Invoked when a connack message is received, or an error occurred.
              */
             using OnConnectionCompletedHandler = std::function<
                 void(MqttConnection &connection, int errorCode, ReturnCode returnCode, bool sessionPresent)>;
@@ -141,7 +141,7 @@ namespace Aws
                 bool Disconnect() noexcept;
 
                 /**
-                 * Subcribes to topicFilter. OnPublishRecievedHandler will be invoked from an event-loop
+                 * Subscribes to topicFilter. OnPublishReceivedHandler will be invoked from an event-loop
                  * thread upon an incoming Publish message. OnSubAckHandler will be invoked
                  * upon receipt of a suback message.
                  */
@@ -152,7 +152,7 @@ namespace Aws
                     OnSubAckHandler &&onSubAck) noexcept;
 
                 /**
-                 * Subcribes to multiple topicFilters. OnPublishRecievedHandler will be invoked from an event-loop
+                 * Subscribes to multiple topicFilters. OnPublishReceivedHandler will be invoked from an event-loop
                  * thread upon an incoming Publish message. OnMultiSubAckHandler will be invoked
                  * upon receipt of a suback message.
                  */
@@ -183,7 +183,7 @@ namespace Aws
                  */
                 void Ping();
 
-                OnConnectionInteruptedHandler OnConnectionInterupted;
+                OnConnectionInterruptedHandler OnConnectionInterrupted;
                 OnConnectionResumedHandler OnConnectionResumed;
                 OnConnectionCompletedHandler OnConnectionCompleted;
                 OnDisconnectHandler OnDisconnect;

--- a/samples/mqtt_pub_sub/main.cpp
+++ b/samples/mqtt_pub_sub/main.cpp
@@ -170,7 +170,7 @@ int main(int argc, char *argv[])
 
     /*
      * Since no exceptions are used, always check the bool operator
-     * when an error could have occured.
+     * when an error could have occurred.
      */
     if (!mqttClient)
     {
@@ -224,7 +224,7 @@ int main(int argc, char *argv[])
         conditionVariable.notify_one();
     };
 
-    auto onInterupted = [&](Mqtt::MqttConnection &, int error) {
+    auto onInterrupted = [&](Mqtt::MqttConnection &, int error) {
         fprintf(stdout, "Connection interrupted with error %s\n", ErrorDebugString(error));
     };
 
@@ -244,7 +244,7 @@ int main(int argc, char *argv[])
 
     connection->OnConnectionCompleted = std::move(onConnectionCompleted);
     connection->OnDisconnect = std::move(onDisconnect);
-    connection->OnConnectionInterupted = std::move(onInterupted);
+    connection->OnConnectionInterrupted = std::move(onInterrupted);
     connection->OnConnectionResumed = std::move(onResumed);
 
     /*
@@ -288,7 +288,7 @@ int main(int argc, char *argv[])
          * This is invoked upon the receipt of a Publish on a subscribed topic.
          */
         auto onPublish = [&](Mqtt::MqttConnection &, const String &topic, const ByteBuf &byteBuf) {
-            fprintf(stdout, "Publish recieved on topic %s\n", topic.c_str());
+            fprintf(stdout, "Publish received on topic %s\n", topic.c_str());
             fprintf(stdout, "\n Message:\n");
             fwrite(byteBuf.buffer, 1, byteBuf.len, stdout);
             fprintf(stdout, "\n");

--- a/source/mqtt/MqttClient.cpp
+++ b/source/mqtt/MqttClient.cpp
@@ -29,9 +29,9 @@ namespace Aws
             {
                 auto connWrapper = reinterpret_cast<MqttConnection *>(userData);
                 connWrapper->m_connectionState = ConnectionState::Connecting;
-                if (connWrapper->OnConnectionInterupted)
+                if (connWrapper->OnConnectionInterrupted)
                 {
-                    connWrapper->OnConnectionInterupted(*connWrapper, errorCode);
+                    connWrapper->OnConnectionInterrupted(*connWrapper, errorCode);
                 }
             }
 


### PR DESCRIPTION
I wanted to see if there were any OTHER mis-spellings in the public API so installed [code-spell-checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker), perused the /include folder,  and fixing anything I saw with global find-replace. That's why so many unimportant comments and log-statements got sucked up into this PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
