### PR TITLE
Fix InitClientWithMtlsPkcs12 function header.

### DIFF
--- a/include/aws/crt/io/TlsOptions.h
+++ b/include/aws/crt/io/TlsOptions.h
@@ -79,7 +79,7 @@ namespace Aws
                 static TlsContextOptions InitClientWithMtlsPkcs12(
                     const char *pkcs12_path,
                     const char *pkcs12_pwd,
-                    Allocator *allocator = DefaultAllocator) noexcept;
+                    Allocator *allocator = DefaultAllocator()) noexcept;
 #endif
 
                 /**


### PR DESCRIPTION
Fixed the InitClientWithMtlsPkcs12 function header for macOS.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
