### PR TITLE
Remove Mqtt::ConnectionState enum

### DIFF
--- a/include/aws/crt/mqtt/MqttClient.h
+++ b/include/aws/crt/mqtt/MqttClient.h
@@ -37,15 +37,6 @@ namespace Aws
             class MqttClient;
             class MqttConnection;
 
-            enum class ConnectionState
-            {
-                Init,
-                Connecting,
-                Connected,
-                Disconnected,
-                Error,
-            };
-
             /**
              * Invoked Upon Connection loss.
              */
@@ -112,7 +103,6 @@ namespace Aws
 
                 operator bool() const noexcept;
                 int LastError() const noexcept;
-                inline ConnectionState GetConnectionState() const noexcept { return m_connectionState; }
 
                 /**
                  * Sets LastWill for the connection. The memory backing payload must outlive the connection.
@@ -191,7 +181,6 @@ namespace Aws
               private:
                 aws_mqtt_client *m_owningClient;
                 aws_mqtt_client_connection *m_underlyingConnection;
-                std::atomic<ConnectionState> m_connectionState;
                 String m_hostName;
                 uint16_t m_port;
                 Io::TlsConnectionOptions m_tlsOptions;

--- a/samples/mqtt_pub_sub/main.cpp
+++ b/samples/mqtt_pub_sub/main.cpp
@@ -179,7 +179,6 @@ int main(int argc, char *argv[])
         else
         {
             fprintf(stdout, "Connection completed with return code %d\n", returnCode);
-            fprintf(stdout, "Connection state %d\n", static_cast<int>(connection->GetConnectionState()));
             connectionSucceeded = true;
         }
         {
@@ -200,7 +199,7 @@ int main(int argc, char *argv[])
      */
     auto onDisconnect = [&](Mqtt::MqttConnection &conn) {
         {
-            fprintf(stdout, "Connection state %d\n", static_cast<int>(conn.GetConnectionState()));
+            fprintf(stdout, "Disconnect completed\n");
             std::lock_guard<std::mutex> lockGuard(mutex);
             connectionClosed = true;
         }
@@ -217,6 +216,7 @@ int main(int argc, char *argv[])
      * This will use default ping behavior of 1 hour and 3 second timeouts.
      * If you want different behavior, those arguments go into slots 3 & 4.
      */
+    fprintf(stdout, "Connecting...\n");
     if (!connection->Connect(clientId.c_str(), false))
     {
         fprintf(stderr, "MQTT Connection failed with error %s\n", ErrorDebugString(connection->LastError()));


### PR DESCRIPTION
The underlying aws-c-mqtt implementation does not feature "connection state" as part of its public API, the user is informed of state changes via callbacks (OnConnected, OnConnectionInterrupted, OnConnectionResumed, OnDisconnect).

The state enum was meant here as a convenience feature, but it has introduced confusion, and it's not consistently implemented across the different language CRTs. If a public state enum is found to be desirable, it should be implemented in aws-c-mqtt and reflected consistently in all the language CRTs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
