### PR TITLE
Fixed bug in Aws::Crt::Optional causing copies to cause memory errors.

### DIFF
--- a/include/aws/crt/JsonObject.h
+++ b/include/aws/crt/JsonObject.h
@@ -50,7 +50,7 @@ namespace Aws
              * Moves the ownership of the internal JSON DOM.
              * No copying is performed.
              */
-            JsonObject(JsonObject &&value);
+            JsonObject(JsonObject &&value) noexcept;
 
             ~JsonObject();
 
@@ -66,7 +66,7 @@ namespace Aws
              * @warning This will result in invalidating any outstanding views of the current DOM. However, views
              * to the moved-from DOM would still valid.
              */
-            JsonObject &operator=(JsonObject &&other);
+            JsonObject &operator=(JsonObject &&other) noexcept;
 
             bool operator==(const JsonObject &other) const;
             bool operator!=(const JsonObject &other) const;

--- a/include/aws/crt/Optional.h
+++ b/include/aws/crt/Optional.h
@@ -79,7 +79,7 @@ namespace Aws
                 }
             }
 
-            Optional(Optional<T> &&other) noexcept
+            Optional(Optional<T> &&other)
             {
                 if (other.m_value)
                 {

--- a/include/aws/crt/Optional.h
+++ b/include/aws/crt/Optional.h
@@ -73,6 +73,10 @@ namespace Aws
                     new (&m_storage) T(*other.m_value);
                     m_value = reinterpret_cast<T *>(&m_storage);
                 }
+                else
+                {
+                    m_value = nullptr;
+                }
             }
 
             Optional(Optional<T> &&other) noexcept
@@ -82,7 +86,10 @@ namespace Aws
                     new (&m_storage) T(std::forward<T>(*other.m_value));
                     m_value = reinterpret_cast<T *>(&m_storage);
                 }
-                other.m_value = nullptr;
+                else
+                {
+                    m_value = nullptr;
+                }
             }
 
             Optional &operator=(const Optional &other)
@@ -109,9 +116,8 @@ namespace Aws
 
                 if (other.m_value)
                 {
-                    new (&m_storage) T();
+                    new (&m_storage) T(*other.m_value);
                     m_value = reinterpret_cast<T *>(&m_storage);
-                    *m_value = *other.m_value;
                 }
 
                 return *this;
@@ -141,9 +147,8 @@ namespace Aws
 
                 if (other.m_value)
                 {
-                    new (&m_storage) T();
+                    new (&m_storage) T(*other.m_value);
                     m_value = reinterpret_cast<T *>(&m_storage);
-                    *m_value = *other.m_value;
                 }
 
                 return *this;
@@ -158,18 +163,23 @@ namespace Aws
 
                 if (m_value)
                 {
-                    m_value->~T();
+                    if (other.m_value)
+                    {
+                        *m_value = std::forward(*other.m_value);
+                    }
+                    else
+                    {
+                        m_value->~T();
+                        m_value = nullptr;
+                    }
+
+                    return *this;
                 }
 
                 if (other.m_value)
                 {
                     new (&m_storage) T(std::forward<U>(*other.m_value));
                     m_value = reinterpret_cast<T *>(&m_storage);
-                    other.m_value = nullptr;
-                }
-                else
-                {
-                    m_value = nullptr;
                 }
 
                 return *this;

--- a/samples/mqtt_pub_sub/main.cpp
+++ b/samples/mqtt_pub_sub/main.cpp
@@ -253,7 +253,7 @@ int main(int argc, char *argv[])
             conditionVariable.notify_one();
         };
 
-        connection->Subscribe(topic.c_str(), AWS_MQTT_QOS_AT_MOST_ONCE, onPublish, onSubAck);
+        connection->Subscribe(topic.c_str(), AWS_MQTT_QOS_AT_LEAST_ONCE, onPublish, onSubAck);
         conditionVariable.wait(uniqueLock);
 
         while (true)
@@ -286,7 +286,7 @@ int main(int argc, char *argv[])
                     fprintf(stdout, "Operation failed with error %s\n", aws_error_debug_str(errorCode));
                 }
             };
-            connection->Publish(topic.c_str(), AWS_MQTT_QOS_AT_MOST_ONCE, false, payload, onPublishComplete);
+            connection->Publish(topic.c_str(), AWS_MQTT_QOS_AT_LEAST_ONCE, false, payload, onPublishComplete);
         }
 
         /*

--- a/source/JsonObject.cpp
+++ b/source/JsonObject.cpp
@@ -50,7 +50,7 @@ namespace Aws
         {
         }
 
-        JsonObject::JsonObject(JsonObject &&value)
+        JsonObject::JsonObject(JsonObject &&value) noexcept
             : m_value(value.m_value), m_wasParseSuccessful(value.m_wasParseSuccessful),
               m_errorMessage(std::move(value.m_errorMessage))
         {
@@ -75,7 +75,7 @@ namespace Aws
             return *this;
         }
 
-        JsonObject &JsonObject::operator=(JsonObject &&other)
+        JsonObject &JsonObject::operator=(JsonObject &&other) noexcept
         {
             if (this == &other)
             {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,9 @@ add_test_case(HttpClientConnectionManagerResourceSafety)
 add_test_case(HttpClientConnectionWithPendingAcquisitions)
 add_test_case(HttpClientConnectionWithPendingAcquisitionsAndClosedConnections)
 add_test_case(DefaultResolution)
+add_test_case(OptionalCopySafety)
+add_test_case(OptionalMoveSafety)
+add_test_case(OptionalCopyAndMoveSemantics)
 
 generate_cpp_test_driver(${TEST_BINARY_NAME})
 

--- a/tests/JsonParserTest.cpp
+++ b/tests/JsonParserTest.cpp
@@ -103,6 +103,7 @@ static int s_JsonExplicitNullTest(struct aws_allocator *allocator, void *ctx)
     Aws::Crt::JsonObject doc;
     Aws::Crt::JsonObject nullObject;
     nullObject.AsNull();
+
     doc.WithObject("testKey", nullObject);
 
     auto str = doc.View().WriteCompact(true);

--- a/tests/OptionalMemorySafetyTest.cpp
+++ b/tests/OptionalMemorySafetyTest.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#include <aws/crt/Api.h>
+#include <aws/crt/Optional.h>
+#include <aws/testing/aws_test_harness.h>
+
+const char *s_test_str = "This is a string, that should be long enough to avoid small string optimizations";
+
+static int s_OptionalCopySafety(struct aws_allocator *allocator, void *ctx)
+{
+    (void)ctx;
+    Aws::Crt::ApiHandle apiHandle(allocator);
+
+    Aws::Crt::Optional<Aws::Crt::String> str1(s_test_str);
+    Aws::Crt::Optional<Aws::Crt::String> strCpyAssigned = str1;
+    Aws::Crt::Optional<Aws::Crt::String> strCpyConstructedOptional(strCpyAssigned);
+    Aws::Crt::Optional<Aws::Crt::String> strCpyConstructedValue(*strCpyAssigned);
+
+    // now force data access just to check there's a segfault hiding somewhere.
+    ASSERT_STR_EQUALS(s_test_str, str1->c_str());
+    ASSERT_STR_EQUALS(s_test_str, strCpyAssigned->c_str());
+    ASSERT_STR_EQUALS(s_test_str, strCpyConstructedOptional->c_str());
+    ASSERT_STR_EQUALS(s_test_str, strCpyConstructedValue->c_str());
+
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(OptionalCopySafety, s_OptionalCopySafety)
+
+static int s_OptionalMoveSafety(struct aws_allocator *allocator, void *ctx)
+{
+    (void)ctx;
+    Aws::Crt::ApiHandle apiHandle(allocator);
+
+    Aws::Crt::Optional<Aws::Crt::String> str1(s_test_str);
+    Aws::Crt::Optional<Aws::Crt::String> strMoveAssigned = std::move(str1);
+    ASSERT_STR_EQUALS(s_test_str, strMoveAssigned->c_str());
+
+    Aws::Crt::Optional<Aws::Crt::String> strMoveValueAssigned = std::move(*strMoveAssigned);
+    ASSERT_STR_EQUALS(s_test_str, strMoveValueAssigned->c_str());
+
+    Aws::Crt::Optional<Aws::Crt::String> strMoveConstructed(std::move(strMoveValueAssigned));
+    ASSERT_STR_EQUALS(s_test_str, strMoveConstructed->c_str());
+
+    Aws::Crt::Optional<Aws::Crt::String> strMoveValueConstructed(std::move(*strMoveConstructed));
+    ASSERT_STR_EQUALS(s_test_str, strMoveValueConstructed->c_str());
+
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(OptionalMoveSafety, s_OptionalMoveSafety)
+
+class CopyMoveTester
+{
+  public:
+    CopyMoveTester() : m_copied(false), m_moved(false) {}
+    CopyMoveTester(const CopyMoveTester &other) : m_copied(true), m_moved(false) {}
+    CopyMoveTester(CopyMoveTester &&other) : m_copied(false), m_moved(true) {}
+
+    CopyMoveTester &operator=(const CopyMoveTester &other)
+    {
+        m_copied = true;
+        m_moved = false;
+        return *this;
+    }
+    CopyMoveTester &operator=(CopyMoveTester &&other)
+    {
+        m_copied = false;
+        m_moved = true;
+        return *this;
+    }
+
+    ~CopyMoveTester() {}
+
+    bool m_copied;
+    bool m_moved;
+};
+
+static int s_OptionalCopyAndMoveSemantics(struct aws_allocator *allocator, void *ctx)
+{
+    (void)ctx;
+    Aws::Crt::ApiHandle apiHandle(allocator);
+
+    CopyMoveTester initialItem;
+    ASSERT_FALSE(initialItem.m_copied);
+    ASSERT_FALSE(initialItem.m_moved);
+
+    Aws::Crt::Optional<CopyMoveTester> copyConstructedValue(initialItem);
+    ASSERT_TRUE(copyConstructedValue->m_copied);
+    ASSERT_FALSE(copyConstructedValue->m_moved);
+
+    Aws::Crt::Optional<CopyMoveTester> copyConstructedOptional(copyConstructedValue);
+    ASSERT_TRUE(copyConstructedOptional->m_copied);
+    ASSERT_FALSE(copyConstructedOptional->m_moved);
+
+    Aws::Crt::Optional<CopyMoveTester> copyAssignedValue = initialItem;
+    ASSERT_TRUE(copyAssignedValue->m_copied);
+    ASSERT_FALSE(copyAssignedValue->m_moved);
+
+    Aws::Crt::Optional<CopyMoveTester> copyAssignedOptional = copyConstructedOptional;
+    ASSERT_TRUE(copyAssignedOptional->m_copied);
+    ASSERT_FALSE(copyAssignedOptional->m_moved);
+
+    Aws::Crt::Optional<CopyMoveTester> moveConstructedValue(std::move(initialItem));
+    ASSERT_FALSE(moveConstructedValue->m_copied);
+    ASSERT_TRUE(moveConstructedValue->m_moved);
+
+    Aws::Crt::Optional<CopyMoveTester> moveConstructedOptional(std::move(moveConstructedValue));
+    ASSERT_FALSE(moveConstructedOptional->m_copied);
+    ASSERT_TRUE(moveConstructedOptional->m_moved);
+
+    Aws::Crt::Optional<CopyMoveTester> moveAssignedValue = std::move(*moveConstructedOptional);
+    ASSERT_FALSE(moveAssignedValue->m_copied);
+    ASSERT_TRUE(moveAssignedValue->m_moved);
+
+    Aws::Crt::Optional<CopyMoveTester> moveAssignedOptional = std::move(moveAssignedValue);
+    ASSERT_FALSE(moveAssignedOptional->m_copied);
+    ASSERT_TRUE(moveAssignedOptional->m_moved);
+
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(OptionalCopyAndMoveSemantics, s_OptionalCopyAndMoveSemantics)

--- a/tests/OptionalMemorySafetyTest.cpp
+++ b/tests/OptionalMemorySafetyTest.cpp
@@ -28,7 +28,7 @@ static int s_OptionalCopySafety(struct aws_allocator *allocator, void *ctx)
     Aws::Crt::Optional<Aws::Crt::String> strCpyConstructedOptional(strCpyAssigned);
     Aws::Crt::Optional<Aws::Crt::String> strCpyConstructedValue(*strCpyAssigned);
 
-    // now force data access just to check there's a not segfault hiding somewhere.
+    // now force data access just to check there's not a segfault hiding somewhere.
     ASSERT_STR_EQUALS(s_test_str, str1->c_str());
     ASSERT_STR_EQUALS(s_test_str, strCpyAssigned->c_str());
     ASSERT_STR_EQUALS(s_test_str, strCpyConstructedOptional->c_str());

--- a/tests/OptionalMemorySafetyTest.cpp
+++ b/tests/OptionalMemorySafetyTest.cpp
@@ -28,7 +28,7 @@ static int s_OptionalCopySafety(struct aws_allocator *allocator, void *ctx)
     Aws::Crt::Optional<Aws::Crt::String> strCpyConstructedOptional(strCpyAssigned);
     Aws::Crt::Optional<Aws::Crt::String> strCpyConstructedValue(*strCpyAssigned);
 
-    // now force data access just to check there's a segfault hiding somewhere.
+    // now force data access just to check there's a not segfault hiding somewhere.
     ASSERT_STR_EQUALS(s_test_str, str1->c_str());
     ASSERT_STR_EQUALS(s_test_str, strCpyAssigned->c_str());
     ASSERT_STR_EQUALS(s_test_str, strCpyConstructedOptional->c_str());


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
