### PR TITLE
Stream wrapper + tests

### DIFF
--- a/include/aws/crt/Types.h
+++ b/include/aws/crt/Types.h
@@ -45,7 +45,7 @@ namespace Aws
         namespace Io
         {
             using SocketOptions = aws_socket_options;
-            using IoStream = std::basic_iostream<char, std::char_traits<char>>;
+            using IStream = std::basic_istream<char, std::char_traits<char>>;
         } // namespace Io
 
         namespace Mqtt

--- a/include/aws/crt/Types.h
+++ b/include/aws/crt/Types.h
@@ -45,7 +45,8 @@ namespace Aws
         namespace Io
         {
             using SocketOptions = aws_socket_options;
-        }
+            using IoStream = std::basic_iostream<char, std::char_traits<char>>;
+        } // namespace Io
 
         namespace Mqtt
         {

--- a/include/aws/crt/io/Stream.h
+++ b/include/aws/crt/io/Stream.h
@@ -29,7 +29,7 @@ namespace Aws
              * Factory to create a aws-c-io input stream subclass from a C++ stream
              */
             AWS_CRT_CPP_API aws_input_stream *AwsInputStreamNewCpp(
-                const std::shared_ptr<Aws::Crt::Io::IoStream> &stream,
+                const std::shared_ptr<Aws::Crt::Io::IStream> &stream,
                 Aws::Crt::Allocator *allocator = DefaultAllocator()) noexcept;
         } // namespace Io
     }     // namespace Crt

--- a/include/aws/crt/io/Stream.h
+++ b/include/aws/crt/io/Stream.h
@@ -1,0 +1,36 @@
+#pragma once
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/crt/Exports.h>
+#include <aws/crt/Types.h>
+
+struct aws_input_stream;
+
+namespace Aws
+{
+    namespace Crt
+    {
+        namespace Io
+        {
+            /*
+             * Factory to create a aws-c-io input stream subclass from a C++ stream
+             */
+            AWS_CRT_CPP_API aws_input_stream *AwsInputStreamNewCpp(
+                const std::shared_ptr<Aws::Crt::Io::IoStream> &stream,
+                Aws::Crt::Allocator *allocator = DefaultAllocator()) noexcept;
+        } // namespace Io
+    }     // namespace Crt
+} // namespace Aws

--- a/source/io/Stream.cpp
+++ b/source/io/Stream.cpp
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/crt/io/Stream.h>
+
+#include <aws/io/stream.h>
+
+static std::ios_base::seekdir s_stream_seek_basis_to_seekdir(enum aws_stream_seek_basis basis)
+{
+    switch (basis)
+    {
+        case AWS_SSB_BEGIN:
+            return std::ios_base::beg;
+
+        case AWS_SSB_END:
+            return std::ios_base::end;
+    }
+
+    return std::ios_base::beg;
+}
+
+struct aws_input_stream_cpp_impl
+{
+    std::shared_ptr<Aws::Crt::Io::IoStream> stream;
+};
+
+static int s_aws_input_stream_cpp_seek(
+    struct aws_input_stream *stream,
+    aws_off_t offset,
+    enum aws_stream_seek_basis basis)
+{
+    aws_input_stream_cpp_impl *impl = static_cast<aws_input_stream_cpp_impl *>(stream->impl);
+    impl->stream->seekg(Aws::Crt::Io::IoStream::off_type(offset), s_stream_seek_basis_to_seekdir(basis));
+
+    return AWS_OP_SUCCESS;
+}
+
+static int s_aws_input_stream_cpp_read(struct aws_input_stream *stream, struct aws_byte_buf *dest, size_t *amount_read)
+{
+    aws_input_stream_cpp_impl *impl = static_cast<aws_input_stream_cpp_impl *>(stream->impl);
+
+    impl->stream->read(reinterpret_cast<char *>(dest->buffer + dest->len), dest->capacity - dest->len);
+    *amount_read = impl->stream->gcount();
+
+    dest->len += *amount_read;
+
+    return AWS_OP_SUCCESS;
+}
+
+static int s_aws_input_stream_cpp_get_status(struct aws_input_stream *stream, struct aws_stream_status *status)
+{
+    aws_input_stream_cpp_impl *impl = static_cast<aws_input_stream_cpp_impl *>(stream->impl);
+
+    status->is_end_of_stream = impl->stream->eof();
+    status->is_valid = impl->stream->good();
+
+    return AWS_OP_SUCCESS;
+}
+
+static int s_aws_input_stream_cpp_get_length(struct aws_input_stream *stream, int64_t *length)
+{
+    aws_input_stream_cpp_impl *impl = static_cast<aws_input_stream_cpp_impl *>(stream->impl);
+
+    auto currentPosition = impl->stream->tellg();
+
+    impl->stream->seekg(0, std::ios_base::end);
+
+    if (impl->stream->good())
+    {
+        *length = static_cast<int64_t>(impl->stream->tellg());
+    }
+    else
+    {
+        *length = 0;
+    }
+
+    impl->stream->seekg(currentPosition);
+
+    return AWS_OP_SUCCESS;
+}
+
+static void s_aws_input_stream_cpp_clean_up(struct aws_input_stream *stream)
+{
+    aws_input_stream_cpp_impl *impl = static_cast<aws_input_stream_cpp_impl *>(stream->impl);
+
+    impl->stream = nullptr;
+}
+
+static struct aws_input_stream_vtable s_aws_input_stream_cpp_vtable = {s_aws_input_stream_cpp_seek,
+                                                                       s_aws_input_stream_cpp_read,
+                                                                       s_aws_input_stream_cpp_get_status,
+                                                                       s_aws_input_stream_cpp_get_length,
+                                                                       s_aws_input_stream_cpp_clean_up};
+
+namespace Aws
+{
+    namespace Crt
+    {
+        namespace Io
+        {
+            struct aws_input_stream *AwsInputStreamNewCpp(
+                const std::shared_ptr<Aws::Crt::Io::IoStream> &stream,
+                Aws::Crt::Allocator *allocator) noexcept
+            {
+                struct aws_input_stream *input_stream = NULL;
+                struct aws_input_stream_cpp_impl *impl = NULL;
+
+                aws_mem_acquire_many(
+                    allocator,
+                    2,
+                    &input_stream,
+                    sizeof(struct aws_input_stream),
+                    &impl,
+                    sizeof(struct aws_input_stream_cpp_impl));
+
+                if (!input_stream)
+                {
+                    return NULL;
+                }
+
+                AWS_ZERO_STRUCT(*input_stream);
+                AWS_ZERO_STRUCT(*impl);
+
+                input_stream->allocator = allocator;
+                input_stream->vtable = &s_aws_input_stream_cpp_vtable;
+                input_stream->impl = impl;
+
+                impl->stream = stream;
+
+                return input_stream;
+            }
+        } // namespace Io
+    }     // namespace Crt
+} // namespace Aws

--- a/source/io/Stream.cpp
+++ b/source/io/Stream.cpp
@@ -33,7 +33,7 @@ static std::ios_base::seekdir s_stream_seek_basis_to_seekdir(enum aws_stream_see
 
 struct aws_input_stream_cpp_impl
 {
-    std::shared_ptr<Aws::Crt::Io::IoStream> stream;
+    std::shared_ptr<Aws::Crt::Io::IStream> stream;
 };
 
 static int s_aws_input_stream_cpp_seek(
@@ -42,7 +42,7 @@ static int s_aws_input_stream_cpp_seek(
     enum aws_stream_seek_basis basis)
 {
     aws_input_stream_cpp_impl *impl = static_cast<aws_input_stream_cpp_impl *>(stream->impl);
-    impl->stream->seekg(Aws::Crt::Io::IoStream::off_type(offset), s_stream_seek_basis_to_seekdir(basis));
+    impl->stream->seekg(Aws::Crt::Io::IStream::off_type(offset), s_stream_seek_basis_to_seekdir(basis));
 
     return AWS_OP_SUCCESS;
 }
@@ -111,7 +111,7 @@ namespace Aws
         namespace Io
         {
             struct aws_input_stream *AwsInputStreamNewCpp(
-                const std::shared_ptr<Aws::Crt::Io::IoStream> &stream,
+                const std::shared_ptr<Aws::Crt::Io::IStream> &stream,
                 Aws::Crt::Allocator *allocator) noexcept
             {
                 struct aws_input_stream *input_stream = NULL;

--- a/source/io/Stream.cpp
+++ b/source/io/Stream.cpp
@@ -52,7 +52,7 @@ static int s_aws_input_stream_cpp_read(struct aws_input_stream *stream, struct a
     aws_input_stream_cpp_impl *impl = static_cast<aws_input_stream_cpp_impl *>(stream->impl);
 
     impl->stream->read(reinterpret_cast<char *>(dest->buffer + dest->len), dest->capacity - dest->len);
-    *amount_read = impl->stream->gcount();
+    *amount_read = static_cast<size_t>(impl->stream->gcount());
 
     dest->len += *amount_read;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,12 @@ add_test_case(DefaultResolution)
 add_test_case(OptionalCopySafety)
 add_test_case(OptionalMoveSafety)
 add_test_case(OptionalCopyAndMoveSemantics)
+add_test_case(StreamTestCreateDestroyWrapperFirst)
+add_test_case(StreamTestCreateDestroyWrapperLast)
+add_test_case(StreamTestLength)
+add_test_case(StreamTestRead)
+add_test_case(StreamTestSeekBegin)
+add_test_case(StreamTestSeekEnd)
 
 generate_cpp_test_driver(${TEST_BINARY_NAME})
 

--- a/tests/StreamTest.cpp
+++ b/tests/StreamTest.cpp
@@ -30,7 +30,7 @@ static int s_StreamTestCreateDestroyWrapperFirst(struct aws_allocator *allocator
 
     {
         auto string_stream = std::make_shared<std::stringstream>("SomethingInteresting");
-        auto stream = std::static_pointer_cast<Aws::Crt::Io::IoStream>(string_stream);
+        auto stream = std::static_pointer_cast<Aws::Crt::Io::IStream>(string_stream);
 
         aws_input_stream *wrapped_stream = Aws::Crt::Io::AwsInputStreamNewCpp(stream);
 
@@ -54,7 +54,7 @@ static int s_StreamTestCreateDestroyWrapperLast(struct aws_allocator *allocator,
 
         {
             auto string_stream = std::make_shared<std::stringstream>("SomethingInteresting");
-            auto stream = std::static_pointer_cast<Aws::Crt::Io::IoStream>(string_stream);
+            auto stream = std::static_pointer_cast<Aws::Crt::Io::IStream>(string_stream);
 
             wrapped_stream = Aws::Crt::Io::AwsInputStreamNewCpp(stream);
 
@@ -78,7 +78,7 @@ static int s_StreamTestLength(struct aws_allocator *allocator, void *ctx)
 
     {
         auto string_stream = std::make_shared<std::stringstream>(STREAM_CONTENTS);
-        auto stream = std::static_pointer_cast<Aws::Crt::Io::IoStream>(string_stream);
+        auto stream = std::static_pointer_cast<Aws::Crt::Io::IStream>(string_stream);
 
         aws_input_stream *wrapped_stream = Aws::Crt::Io::AwsInputStreamNewCpp(stream);
 
@@ -101,7 +101,7 @@ static int s_StreamTestRead(struct aws_allocator *allocator, void *ctx)
 
     {
         auto string_stream = std::make_shared<std::stringstream>(STREAM_CONTENTS);
-        auto stream = std::static_pointer_cast<Aws::Crt::Io::IoStream>(string_stream);
+        auto stream = std::static_pointer_cast<Aws::Crt::Io::IStream>(string_stream);
 
         aws_input_stream *wrapped_stream = Aws::Crt::Io::AwsInputStreamNewCpp(stream);
 
@@ -133,7 +133,7 @@ static int s_StreamTestSeekBegin(struct aws_allocator *allocator, void *ctx)
 
     {
         auto string_stream = std::make_shared<std::stringstream>(STREAM_CONTENTS);
-        auto stream = std::static_pointer_cast<Aws::Crt::Io::IoStream>(string_stream);
+        auto stream = std::static_pointer_cast<Aws::Crt::Io::IStream>(string_stream);
 
         aws_input_stream *wrapped_stream = Aws::Crt::Io::AwsInputStreamNewCpp(stream);
 
@@ -167,7 +167,7 @@ static int s_StreamTestSeekEnd(struct aws_allocator *allocator, void *ctx)
 
     {
         auto string_stream = std::make_shared<std::stringstream>(STREAM_CONTENTS);
-        auto stream = std::static_pointer_cast<Aws::Crt::Io::IoStream>(string_stream);
+        auto stream = std::static_pointer_cast<Aws::Crt::Io::IStream>(string_stream);
 
         aws_input_stream *wrapped_stream = Aws::Crt::Io::AwsInputStreamNewCpp(stream);
 

--- a/tests/StreamTest.cpp
+++ b/tests/StreamTest.cpp
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#include <aws/crt/Api.h>
+
+#include <aws/crt/io/Stream.h>
+
+#include <aws/common/byte_buf.h>
+#include <aws/io/stream.h>
+
+#include <aws/testing/aws_test_harness.h>
+
+#include <sstream>
+
+static int s_StreamTestCreateDestroyWrapperFirst(struct aws_allocator *allocator, void *ctx)
+{
+    (void)ctx;
+    Aws::Crt::ApiHandle apiHandle(allocator);
+
+    {
+        auto string_stream = std::make_shared<std::stringstream>("SomethingInteresting");
+        auto stream = std::static_pointer_cast<Aws::Crt::Io::IoStream>(string_stream);
+
+        aws_input_stream *wrapped_stream = Aws::Crt::Io::AwsInputStreamNewCpp(stream);
+
+        ASSERT_TRUE(wrapped_stream != nullptr);
+
+        aws_input_stream_destroy(wrapped_stream);
+    }
+
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(StreamTestCreateDestroyWrapperFirst, s_StreamTestCreateDestroyWrapperFirst)
+
+static int s_StreamTestCreateDestroyWrapperLast(struct aws_allocator *allocator, void *ctx)
+{
+    (void)ctx;
+    Aws::Crt::ApiHandle apiHandle(allocator);
+
+    {
+        aws_input_stream *wrapped_stream = nullptr;
+
+        {
+            auto string_stream = std::make_shared<std::stringstream>("SomethingInteresting");
+            auto stream = std::static_pointer_cast<Aws::Crt::Io::IoStream>(string_stream);
+
+            wrapped_stream = Aws::Crt::Io::AwsInputStreamNewCpp(stream);
+
+            ASSERT_TRUE(wrapped_stream != nullptr);
+        }
+
+        aws_input_stream_destroy(wrapped_stream);
+    }
+
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(StreamTestCreateDestroyWrapperLast, s_StreamTestCreateDestroyWrapperLast)
+
+static const char *STREAM_CONTENTS = "SomeContents";
+
+static int s_StreamTestLength(struct aws_allocator *allocator, void *ctx)
+{
+    (void)ctx;
+    Aws::Crt::ApiHandle apiHandle(allocator);
+
+    {
+        auto string_stream = std::make_shared<std::stringstream>(STREAM_CONTENTS);
+        auto stream = std::static_pointer_cast<Aws::Crt::Io::IoStream>(string_stream);
+
+        aws_input_stream *wrapped_stream = Aws::Crt::Io::AwsInputStreamNewCpp(stream);
+
+        int64_t length = 0;
+        ASSERT_SUCCESS(aws_input_stream_get_length(wrapped_stream, &length));
+        ASSERT_TRUE(length == strlen(STREAM_CONTENTS));
+
+        aws_input_stream_destroy(wrapped_stream);
+    }
+
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(StreamTestLength, s_StreamTestLength)
+
+static int s_StreamTestRead(struct aws_allocator *allocator, void *ctx)
+{
+    (void)ctx;
+    Aws::Crt::ApiHandle apiHandle(allocator);
+
+    {
+        auto string_stream = std::make_shared<std::stringstream>(STREAM_CONTENTS);
+        auto stream = std::static_pointer_cast<Aws::Crt::Io::IoStream>(string_stream);
+
+        aws_input_stream *wrapped_stream = Aws::Crt::Io::AwsInputStreamNewCpp(stream);
+
+        aws_byte_buf buffer;
+        AWS_ZERO_STRUCT(buffer);
+        aws_byte_buf_init(&buffer, allocator, 256);
+
+        size_t read = 0;
+        aws_input_stream_read(wrapped_stream, &buffer, &read);
+
+        ASSERT_TRUE(read == strlen(STREAM_CONTENTS));
+        ASSERT_BIN_ARRAYS_EQUALS(STREAM_CONTENTS, read, buffer.buffer, read);
+
+        aws_byte_buf_clean_up(&buffer);
+        aws_input_stream_destroy(wrapped_stream);
+    }
+
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(StreamTestRead, s_StreamTestRead)
+
+static const aws_off_t BEGIN_SEEK_OFFSET = 4;
+
+static int s_StreamTestSeekBegin(struct aws_allocator *allocator, void *ctx)
+{
+    (void)ctx;
+    Aws::Crt::ApiHandle apiHandle(allocator);
+
+    {
+        auto string_stream = std::make_shared<std::stringstream>(STREAM_CONTENTS);
+        auto stream = std::static_pointer_cast<Aws::Crt::Io::IoStream>(string_stream);
+
+        aws_input_stream *wrapped_stream = Aws::Crt::Io::AwsInputStreamNewCpp(stream);
+
+        ASSERT_SUCCESS(aws_input_stream_seek(wrapped_stream, BEGIN_SEEK_OFFSET, AWS_SSB_BEGIN));
+
+        aws_byte_buf buffer;
+        AWS_ZERO_STRUCT(buffer);
+        aws_byte_buf_init(&buffer, allocator, 256);
+
+        size_t read = 0;
+        aws_input_stream_read(wrapped_stream, &buffer, &read);
+
+        ASSERT_TRUE(read == strlen(STREAM_CONTENTS) - BEGIN_SEEK_OFFSET);
+        ASSERT_BIN_ARRAYS_EQUALS(STREAM_CONTENTS + BEGIN_SEEK_OFFSET, read, buffer.buffer, read);
+
+        aws_byte_buf_clean_up(&buffer);
+        aws_input_stream_destroy(wrapped_stream);
+    }
+
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(StreamTestSeekBegin, s_StreamTestSeekBegin)
+
+static const aws_off_t END_SEEK_OFFSET = -4;
+
+static int s_StreamTestSeekEnd(struct aws_allocator *allocator, void *ctx)
+{
+    (void)ctx;
+    Aws::Crt::ApiHandle apiHandle(allocator);
+
+    {
+        auto string_stream = std::make_shared<std::stringstream>(STREAM_CONTENTS);
+        auto stream = std::static_pointer_cast<Aws::Crt::Io::IoStream>(string_stream);
+
+        aws_input_stream *wrapped_stream = Aws::Crt::Io::AwsInputStreamNewCpp(stream);
+
+        ASSERT_SUCCESS(aws_input_stream_seek(wrapped_stream, END_SEEK_OFFSET, AWS_SSB_END));
+
+        aws_byte_buf buffer;
+        AWS_ZERO_STRUCT(buffer);
+        aws_byte_buf_init(&buffer, allocator, 256);
+
+        size_t read = 0;
+        aws_input_stream_read(wrapped_stream, &buffer, &read);
+
+        ASSERT_TRUE(read == -END_SEEK_OFFSET);
+        ASSERT_BIN_ARRAYS_EQUALS(
+            STREAM_CONTENTS + strlen(STREAM_CONTENTS) + END_SEEK_OFFSET, read, buffer.buffer, read);
+
+        aws_byte_buf_clean_up(&buffer);
+        aws_input_stream_destroy(wrapped_stream);
+    }
+
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(StreamTestSeekEnd, s_StreamTestSeekEnd)


### PR DESCRIPTION
Converts from basic C++ streams into aws-c streams, allowing users to use C++ streams as http request bodies.

This lets us give a C++ stream interface to the Http Request wrapper.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
