### PR TITLE
Blocking shutdown

### DIFF
--- a/include/aws/crt/http/HttpConnectionManager.h
+++ b/include/aws/crt/http/HttpConnectionManager.h
@@ -86,11 +86,17 @@ namespace Aws
                     const HttpClientConnectionManagerOptions &options,
                     Allocator *allocator = DefaultAllocator()) noexcept;
 
+                static void OnShutdownCallback(void *user_data);
+
                 Allocator *m_allocator;
 
                 aws_http_connection_manager *m_connectionManager;
 
                 HttpClientConnectionManagerOptions m_options;
+
+                std::mutex m_shutdownLock;
+                std::condition_variable m_shutdownSignal;
+                bool m_hasShutdown;
 
                 static void s_onConnectionSetup(
                     aws_http_connection *connection,


### PR DESCRIPTION
Delay connection manager destructor completion until after C object has shutdown completely.  Consider adding an option to bypass this in the future.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
