### PR TITLE
Fixed default cmake build without a specified CMAKE_BUILD_TYPE.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,12 @@ if (NOT CMAKE_CXX_STANDARD)
     set(CMAKE_CXX_STANDARD 11)
 endif()
 
-set(AWS_CRT_CPP_VERSION "v0.5.6")
+if (NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "RelWithDebInfo")
+endif()
+
+set(AWS_CRT_CPP_VERSION "v0.6.2")
+
 configure_file(include/aws/crt/Config.h.in ${CMAKE_CURRENT_LIST_DIR}/include/aws/crt/Config.h @ONLY)
 
 if (BUILD_DEPS)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ C++ wrapper around the aws-c-* libraries. Provides Cross-Platform Transport Prot
 * aws-c-common: Cross-platform primitives and data structures.
 * aws-c-io: Cross-platform event-loops, non-blocking I/O, and TLS implementations.
 * aws-c-mqtt: MQTT client.
+* aws-c-auth: Auth signers such as Aws-auth sigv4
+* aws-c-http: HTTP 1.1 client, and websockets (H2 coming soon)
 
 More protocols and utilities are coming soon, so stay tuned.
 


### PR DESCRIPTION


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
