### PR TITLE
Initialize "MqttConnection::m_onAnyCbData" to avoid crash in destructor.

### DIFF
--- a/source/mqtt/MqttClient.cpp
+++ b/source/mqtt/MqttClient.cpp
@@ -264,8 +264,8 @@ namespace Aws
                 const Io::SocketOptions &socketOptions,
                 const Crt::Io::TlsContext &tlsContext,
                 bool useWebsocket) noexcept
-                : m_owningClient(client), m_tlsContext(tlsContext), m_tlsOptions(tlsContext.NewConnectionOptions()),
-                  m_useTls(true), m_useWebsocket(useWebsocket)
+                : m_owningClient(client), m_onAnyCbData(nullptr), m_tlsContext(tlsContext),
+                  m_tlsOptions(tlsContext.NewConnectionOptions()), m_useTls(true), m_useWebsocket(useWebsocket)
             {
                 s_connectionInit(this, hostName, port, socketOptions);
             }


### PR DESCRIPTION
While integrating Aws::Iot::MqttClient into a library, I noticed a crash in [~MqttConnection()](https://github.com/awslabs/aws-crt-cpp/blob/bef3faf55a670e2a428f87efb30734aef1e91f6c/source/mqtt/MqttClient.cpp#L293). The problem can be reproduced by removing lines [281](https://github.com/awslabs/aws-crt-cpp/blob/bef3faf55a670e2a428f87efb30734aef1e91f6c/samples/mqtt_pub_sub/main.cpp#L281)-371 in the sample program:

```diff
diff --git a/samples/mqtt_pub_sub/main.cpp b/samples/mqtt_pub_sub/main.cpp
index 0e2b5f6..f75d820 100644
--- a/samples/mqtt_pub_sub/main.cpp
+++ b/samples/mqtt_pub_sub/main.cpp
@@ -277,7 +280,7 @@ int main(int argc, char *argv[])
     connection->OnDisconnect = std::move(onDisconnect);
     connection->OnConnectionInterrupted = std::move(onInterrupted);
     connection->OnConnectionResumed = std::move(onResumed);
-
+#if 0
     connection->SetOnMessageHandler([](Mqtt::MqttConnection &, const String &topic, const ByteBuf &payload) {
        fprintf(stdout, "Generic Publish received on topic %s, payload:\n", topic.c_str());
        fwrite(payload.buffer, 1, payload.len, stdout);
@@ -369,11 +372,11 @@ int main(int argc, char *argv[])
             topic.c_str(), [&](Mqtt::MqttConnection &, uint16_t, int) { conditionVariable.notify_one(); });
         conditionVariable.wait(uniqueLock);
     }
-
+#endif
     /* Disconnect */
     if (connection->Disconnect())
     {
-        conditionVariable.wait(uniqueLock, [&]() { return connectionClosed; });
+//        conditionVariable.wait(uniqueLock, [&]() { return connectionClosed; });
     }
     return 0;
 }
```

The crash is caused by one of the constructors not initializing the `m_onAnyCbData` field. This PR fixes that direct problem, but I think it would be better to use _default member initializers_ or _delegating constructors_ (subsuming ```MqttConnection::s_connectionInit()```) to ensure all fields are initialized also in the future and to avoid repetition.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
