### PR TITLE
Adding support to the canary for multipart upload for large objects.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,3 +297,4 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_PROJECT_NAME}-config.cmake"
 
 enable_testing()
 add_subdirectory(tests)
+add_subdirectory(canary)

--- a/canary/CMakeLists.txt
+++ b/canary/CMakeLists.txt
@@ -1,0 +1,37 @@
+project(aws-crt-cpp-canary CXX)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_INSTALL_PREFIX}/lib/cmake")
+
+file(GLOB CANARY_SRC
+       "*.cpp"
+)
+
+set(CANARY_PROJECT_NAME aws-crt-cpp-canary)
+add_executable(${CANARY_PROJECT_NAME} ${CANARY_SRC})
+set_target_properties(${CANARY_PROJECT_NAME} PROPERTIES LINKER_LANGUAGE CXX)
+set_target_properties(${CANARY_PROJECT_NAME} PROPERTIES CXX_STANDARD ${CMAKE_CXX_STANDARD})
+
+set(CMAKE_C_FLAGS_DEBUGOPT "")
+
+#set warnings
+if (MSVC)
+    target_compile_options(${CANARY_PROJECT_NAME} PRIVATE /W4 /WX /wd4068)
+else ()
+    target_compile_options(${CANARY_PROJECT_NAME} PRIVATE -Wall -Wno-long-long -pedantic -Werror)
+endif ()
+
+if (CMAKE_BUILD_TYPE STREQUAL "" OR CMAKE_BUILD_TYPE MATCHES Debug)
+    target_compile_definitions(${CANARY_PROJECT_NAME} PRIVATE "-DDEBUG_BUILD")
+endif ()
+
+target_include_directories(${CANARY_PROJECT_NAME} PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>)
+
+target_link_libraries(${CANARY_PROJECT_NAME} aws-crt-cpp)
+
+install(
+        TARGETS ${CANARY_PROJECT_NAME}
+        RUNTIME DESTINATION bin COMPONENT Runtime
+)
+

--- a/canary/CanaryApp.cpp
+++ b/canary/CanaryApp.cpp
@@ -1,0 +1,97 @@
+#include "CanaryApp.h"
+#include "CanaryUtil.h"
+#include "MeasureTransferRate.h"
+#include "MetricsPublisher.h"
+#include "S3ObjectTransport.h"
+extern "C"
+{
+#include <aws/common/command_line_parser.h>
+}
+
+#include <aws/crt/Api.h>
+#include <aws/crt/Types.h>
+#include <aws/crt/auth/Credentials.h>
+
+using namespace Aws::Crt;
+
+CanaryApp::CanaryApp(int argc, char *argv[])
+    : traceAllocator(aws_mem_tracer_new(DefaultAllocator(), NULL, AWS_MEMTRACE_BYTES, 0)), apiHandle(traceAllocator),
+      eventLoopGroup(traceAllocator), defaultHostResolver(eventLoopGroup, 60, 1000, traceAllocator),
+      bootstrap(eventLoopGroup, defaultHostResolver, traceAllocator), platformName(CanaryUtil::GetPlatformName()),
+      toolName("NA"), instanceType("unknown"), region("us-west-2"), cutOffTimeSmallObjects(10.0),
+      cutOffTimeLargeObjects(10.0), measureLargeTransfer(false), measureSmallTransfer(false)
+{
+    apiHandle.InitializeLogging(LogLevel::Info, stderr);
+
+    Auth::CredentialsProviderChainDefaultConfig chainConfig;
+    chainConfig.Bootstrap = &bootstrap;
+
+    credsProvider = Auth::CredentialsProvider::CreateCredentialsProviderChainDefault(chainConfig, traceAllocator);
+    signer = MakeShared<Auth::Sigv4HttpRequestSigner>(traceAllocator, traceAllocator);
+
+    Io::TlsContextOptions tlsContextOptions = Io::TlsContextOptions::InitDefaultClient(traceAllocator);
+    tlsContext = Io::TlsContext(tlsContextOptions, Io::TlsMode::CLIENT, traceAllocator);
+
+    enum class CLIOption
+    {
+        ToolName,
+        InstanceType,
+        CutOffTimeSmall,
+        CutOffTimelarge,
+        MeasureLargeTransfer,
+        MeasureSmallTransfer,
+
+        MAX
+    };
+
+    const aws_cli_option options[] = {{"toolName", AWS_CLI_OPTIONS_REQUIRED_ARGUMENT, NULL, 't'},
+                                      {"instanceType", AWS_CLI_OPTIONS_REQUIRED_ARGUMENT, NULL, 'i'},
+                                      {"cutOffTimeSmall", AWS_CLI_OPTIONS_REQUIRED_ARGUMENT, NULL, 'c'},
+                                      {"cutOffTimeLarge", AWS_CLI_OPTIONS_REQUIRED_ARGUMENT, NULL, 'C'},
+                                      {"measureLargeTransfer", AWS_CLI_OPTIONS_NO_ARGUMENT, NULL, 'l'},
+                                      {"measureSmallTransfer", AWS_CLI_OPTIONS_NO_ARGUMENT, NULL, 's'}};
+
+    const char *optstring = "t:i:c:C:ls";
+    toolName = argc >= 1 ? argv[0] : "NA";
+
+    size_t dirStart = toolName.rfind('\\');
+
+    if (dirStart != String::npos)
+    {
+        toolName = toolName.substr(dirStart + 1);
+    }
+
+    int cliOptionIndex = 0;
+
+    while (aws_cli_getopt_long(argc, argv, optstring, options, &cliOptionIndex) != -1)
+    {
+        switch ((CLIOption)cliOptionIndex)
+        {
+            case CLIOption::ToolName:
+                toolName = aws_cli_optarg;
+                break;
+            case CLIOption::InstanceType:
+                instanceType = aws_cli_optarg;
+                break;
+            case CLIOption::CutOffTimeSmall:
+                cutOffTimeSmallObjects = atof(aws_cli_optarg);
+                break;
+            case CLIOption::CutOffTimelarge:
+                cutOffTimeLargeObjects = atof(aws_cli_optarg);
+                break;
+            case CLIOption::MeasureLargeTransfer:
+                measureLargeTransfer = true;
+                break;
+            case CLIOption::MeasureSmallTransfer:
+                measureSmallTransfer = true;
+                break;
+            default:
+                AWS_LOGF_ERROR(AWS_LS_CRT_CPP_CANARY, "Unknown CLI option used.");
+                break;
+        }
+    }
+
+    publisher = MakeShared<MetricsPublisher>(g_allocator, *this, "CRT-CPP-Canary");
+    transport = MakeShared<S3ObjectTransport>(g_allocator, *this, "aws-crt-canary-bucket-rc");
+    measureTransferRate = MakeShared<MeasureTransferRate>(g_allocator, *this);
+}

--- a/canary/CanaryApp.h
+++ b/canary/CanaryApp.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <aws/common/logging.h>
+#include <aws/common/system_info.h>
+#include <aws/crt/Api.h>
+#include <aws/crt/auth/Credentials.h>
+#include <aws/crt/auth/Sigv4Signing.h>
+
+class MetricsPublisher;
+class S3ObjectTransport;
+class MeasureTransferRate;
+
+struct CanaryApp
+{
+    CanaryApp(int argc, char *argv[]);
+
+    Aws::Crt::Allocator *traceAllocator;
+    Aws::Crt::ApiHandle apiHandle;
+    Aws::Crt::Io::EventLoopGroup eventLoopGroup;
+    Aws::Crt::Io::DefaultHostResolver defaultHostResolver;
+    Aws::Crt::Io::ClientBootstrap bootstrap;
+    Aws::Crt::Io::TlsContext tlsContext;
+    std::shared_ptr<Aws::Crt::Auth::ICredentialsProvider> credsProvider;
+    std::shared_ptr<Aws::Crt::Auth::Sigv4HttpRequestSigner> signer;
+    Aws::Crt::String platformName;
+    Aws::Crt::String toolName;
+    Aws::Crt::String instanceType;
+    Aws::Crt::String region;
+    double cutOffTimeSmallObjects;
+    double cutOffTimeLargeObjects;
+    bool measureLargeTransfer;
+    bool measureSmallTransfer;
+
+    std::shared_ptr<MetricsPublisher> publisher;
+    std::shared_ptr<S3ObjectTransport> transport;
+    std::shared_ptr<MeasureTransferRate> measureTransferRate;
+};

--- a/canary/CanaryUtil.cpp
+++ b/canary/CanaryUtil.cpp
@@ -1,0 +1,56 @@
+#include "CanaryUtil.h"
+#ifdef unix
+#    include <sys/utsname.h>
+#endif
+
+using namespace Aws::Crt;
+
+int32_t CanaryUtil::GetSwitchIndex(int argc, char *argv[], const char *switchName)
+{
+    for (int i = 1; i < argc; ++i)
+    {
+        if (!strcmp(switchName, argv[i]))
+        {
+            return i;
+        }
+    }
+
+    return -1;
+}
+
+bool CanaryUtil::HasSwitch(int argc, char *argv[], const char *switchName)
+{
+    return GetSwitchIndex(argc, argv, switchName) >= 0;
+}
+
+bool CanaryUtil::GetSwitchVariable(int argc, char *argv[], const char *switchName, String &outValue)
+{
+    int32_t switchIndex = GetSwitchIndex(argc, argv, switchName);
+
+    if (switchIndex == -1)
+    {
+        return false;
+    }
+
+    int32_t switchValueIndex = switchIndex + 1;
+
+    if (switchValueIndex < argc)
+    {
+        outValue = argv[switchValueIndex];
+    }
+
+    return true;
+}
+
+String CanaryUtil::GetPlatformName()
+{
+#ifdef WIN32
+    return "windows";
+#elif unix
+    struct utsname unameResult;
+    uname(&unameResult);
+    return unameResult.sysname;
+#else
+    return "unknown";
+#endif
+}

--- a/canary/CanaryUtil.cpp
+++ b/canary/CanaryUtil.cpp
@@ -5,43 +5,6 @@
 
 using namespace Aws::Crt;
 
-int32_t CanaryUtil::GetSwitchIndex(int argc, char *argv[], const char *switchName)
-{
-    for (int i = 1; i < argc; ++i)
-    {
-        if (!strcmp(switchName, argv[i]))
-        {
-            return i;
-        }
-    }
-
-    return -1;
-}
-
-bool CanaryUtil::HasSwitch(int argc, char *argv[], const char *switchName)
-{
-    return GetSwitchIndex(argc, argv, switchName) >= 0;
-}
-
-bool CanaryUtil::GetSwitchVariable(int argc, char *argv[], const char *switchName, String &outValue)
-{
-    int32_t switchIndex = GetSwitchIndex(argc, argv, switchName);
-
-    if (switchIndex == -1)
-    {
-        return false;
-    }
-
-    int32_t switchValueIndex = switchIndex + 1;
-
-    if (switchValueIndex < argc)
-    {
-        outValue = argv[switchValueIndex];
-    }
-
-    return true;
-}
-
 String CanaryUtil::GetPlatformName()
 {
 #ifdef WIN32

--- a/canary/CanaryUtil.h
+++ b/canary/CanaryUtil.h
@@ -8,11 +8,5 @@ class CanaryUtil
   public:
     CanaryUtil() = delete;
 
-    static int32_t GetSwitchIndex(int argc, char *argv[], const char *switchName);
-
-    static bool HasSwitch(int argc, char *argv[], const char *switchName);
-
-    static bool GetSwitchVariable(int argc, char *argv[], const char *switchName, Aws::Crt::String &outValue);
-
     static Aws::Crt::String GetPlatformName();
 };

--- a/canary/CanaryUtil.h
+++ b/canary/CanaryUtil.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <aws/crt/Types.h>
+#include <inttypes.h>
+
+class CanaryUtil
+{
+  public:
+    CanaryUtil() = delete;
+
+    static int32_t GetSwitchIndex(int argc, char *argv[], const char *switchName);
+
+    static bool HasSwitch(int argc, char *argv[], const char *switchName);
+
+    static bool GetSwitchVariable(int argc, char *argv[], const char *switchName, Aws::Crt::String &outValue);
+
+    static Aws::Crt::String GetPlatformName();
+};

--- a/canary/MeasureTransferRate.cpp
+++ b/canary/MeasureTransferRate.cpp
@@ -1,0 +1,328 @@
+#include "MeasureTransferRate.h"
+#include "CanaryUtil.h"
+#include "MetricsPublisher.h"
+#include "S3ObjectTransport.h"
+#include <aws/common/system_info.h>
+
+using namespace Aws::Crt;
+
+const char MeasureTransferRate::BodyTemplate[] =
+    "This is a test string for use with canary testing against Amazon Simple Storage Service";
+
+const size_t MeasureTransferRate::SmallObjectSize = 16 * 1024 * 1024;
+const size_t MeasureTransferRate::LargeObjectSize = 10 * S3ObjectTransport::MaxPartSizeBytes;
+
+aws_input_stream_vtable MeasureTransferRate::s_templateStreamVTable = {s_templateStreamSeek,
+                                                                       s_templateStreamRead,
+                                                                       s_templateStreamGetStatus,
+                                                                       s_templateStreamGetLength,
+                                                                       s_templateStreamDestroy};
+
+int MeasureTransferRate::s_templateStreamRead(struct aws_input_stream *stream, struct aws_byte_buf *dest)
+{
+    auto templateStream = static_cast<TemplateStream *>(stream->impl);
+
+    size_t totalBufferSpace = dest->capacity - dest->len;
+    size_t unwritten = templateStream->length - templateStream->written;
+    size_t totalToWrite = totalBufferSpace > unwritten ? unwritten : totalBufferSpace;
+    size_t writtenOut = 0;
+
+    while (totalToWrite)
+    {
+        size_t toWrite =
+            AWS_ARRAY_SIZE(BodyTemplate) - 1 > totalToWrite ? totalToWrite : AWS_ARRAY_SIZE(BodyTemplate) - 1;
+        ByteCursor outCur = ByteCursorFromArray((const uint8_t *)BodyTemplate, toWrite);
+
+        aws_byte_buf_append(dest, &outCur);
+
+        writtenOut += toWrite;
+        totalToWrite = totalToWrite - toWrite;
+    }
+
+    templateStream->written += writtenOut;
+
+    if (templateStream->length == templateStream->written)
+    {
+        Metric uploadMetric;
+        uploadMetric.MetricName = "BytesUp";
+        uploadMetric.Timestamp = DateTime::Now();
+        uploadMetric.Value = (double)templateStream->length;
+        uploadMetric.Unit = MetricUnit::Bytes;
+
+        templateStream->publisher->AddDataPoint(uploadMetric);
+    }
+
+    return AWS_OP_SUCCESS;
+}
+
+int MeasureTransferRate::s_templateStreamGetStatus(struct aws_input_stream *stream, struct aws_stream_status *status)
+{
+    auto templateStream = static_cast<TemplateStream *>(stream->impl);
+
+    status->is_end_of_stream = templateStream->written == templateStream->length;
+    status->is_valid = !status->is_end_of_stream;
+
+    return AWS_OP_SUCCESS;
+}
+
+int MeasureTransferRate::s_templateStreamSeek(
+    struct aws_input_stream *stream,
+    aws_off_t offset,
+    enum aws_stream_seek_basis basis)
+{
+    (void)offset;
+    (void)basis;
+
+    auto templateStream = static_cast<TemplateStream *>(stream->impl);
+    templateStream->written = 0;
+    return AWS_OP_SUCCESS;
+}
+
+int MeasureTransferRate::s_templateStreamGetLength(struct aws_input_stream *stream, int64_t *length)
+{
+    auto templateStream = static_cast<TemplateStream *>(stream->impl);
+    *length = templateStream->length;
+    return AWS_OP_SUCCESS;
+}
+
+void MeasureTransferRate::s_templateStreamDestroy(struct aws_input_stream *stream)
+{
+    auto templateStream = static_cast<TemplateStream *>(stream->impl);
+    Delete(templateStream, stream->allocator);
+}
+
+aws_input_stream *MeasureTransferRate::s_createTemplateStream(
+    Allocator *alloc,
+    MetricsPublisher *publisher,
+    size_t length)
+{
+    auto templateStream = New<TemplateStream>(alloc);
+    templateStream->publisher = publisher;
+    templateStream->length = length;
+    templateStream->written = 0;
+    templateStream->inputStream.allocator = alloc;
+    templateStream->inputStream.impl = templateStream;
+    templateStream->inputStream.vtable = &s_templateStreamVTable;
+
+    return &templateStream->inputStream;
+}
+
+void MeasureTransferRate::MeasureSmallObjectTransfer(
+    Allocator *allocator,
+    S3ObjectTransport &transport,
+    MetricsPublisher &publisher,
+    double cutOffTime)
+{
+    uint32_t threadCount = static_cast<uint32_t>(aws_system_info_processor_count());
+    uint32_t maxInFlight = threadCount * 10;
+
+    PerformMeasurement(
+        allocator,
+        transport,
+        publisher,
+        maxInFlight,
+        SmallObjectSize,
+        cutOffTime,
+        MeasureTransferRate::s_TransferSmallObject);
+}
+
+void MeasureTransferRate::MeasureLargeObjectTransfer(
+    Allocator *allocator,
+    S3ObjectTransport &transport,
+    MetricsPublisher &publisher,
+    double cutOffTime)
+{
+    PerformMeasurement(
+        allocator, transport, publisher, 2, LargeObjectSize, cutOffTime, MeasureTransferRate::s_TransferLargeObject);
+}
+
+template <typename TPeformTransferType>
+void MeasureTransferRate::PerformMeasurement(
+    Allocator *allocator,
+    S3ObjectTransport &transport,
+    MetricsPublisher &publisher,
+    uint32_t maxConcurrentTransfers,
+    uint64_t objectSize,
+    double cutOffTime,
+    const TPeformTransferType &&performTransfer)
+{
+    bool continueInitiatingTransfers = true;
+    uint64_t counter = INT64_MAX;
+    std::atomic<size_t> inFlightUploads(0);
+    std::atomic<size_t> inFlightUploadOrDownload(0);
+
+    time_t initialTime;
+    time(&initialTime);
+
+    while (continueInitiatingTransfers || inFlightUploadOrDownload > 0)
+    {
+        if (counter == 0)
+        {
+            counter = INT64_MAX;
+        }
+
+        while (continueInitiatingTransfers && inFlightUploads < maxConcurrentTransfers)
+        {
+            StringStream keyStream;
+            keyStream << "crt-canary-obj-" << counter--;
+            ++inFlightUploads;
+            ++inFlightUploadOrDownload;
+            auto key = keyStream.str();
+
+            NotifyUploadFinished notifyUploadFinished =
+                [&publisher, &inFlightUploads, &inFlightUploadOrDownload](int32_t errorCode) {
+                    --inFlightUploads;
+
+                    if (errorCode == AWS_ERROR_SUCCESS)
+                    {
+                        Metric successMetric;
+                        successMetric.MetricName = "SuccessfulTransfer";
+                        successMetric.Unit = MetricUnit::Count;
+                        successMetric.Value = 1;
+                        successMetric.Timestamp = DateTime::Now();
+
+                        publisher.AddDataPoint(successMetric);
+                    }
+                    else
+                    {
+                        Metric failureMetric;
+                        failureMetric.MetricName = "FailedTransfer";
+                        failureMetric.Unit = MetricUnit::Count;
+                        failureMetric.Value = 1;
+                        failureMetric.Timestamp = DateTime::Now();
+
+                        publisher.AddDataPoint(failureMetric);
+
+                        --inFlightUploadOrDownload;
+                    }
+                };
+
+            NotifyDownloadProgress notifyDownloadProgress = [&publisher](uint64_t dataLength) {
+                std::shared_ptr<Metric> downMetric = MakeShared<Metric>(g_allocator);
+                downMetric->MetricName = "BytesDown";
+                downMetric->Unit = MetricUnit::Bytes;
+                downMetric->Value = static_cast<double>(dataLength);
+                downMetric->Timestamp = DateTime::Now();
+                publisher.AddDataPoint(*downMetric);
+            };
+
+            NotifyDownloadFinished notifyDownloadFinished = [&publisher, &inFlightUploadOrDownload](int32_t errorCode) {
+                if (errorCode == AWS_ERROR_SUCCESS)
+                {
+                    Metric successMetric;
+                    successMetric.MetricName = "SuccessfulTransfer";
+                    successMetric.Unit = MetricUnit::Count;
+                    successMetric.Value = 1;
+                    successMetric.Timestamp = DateTime::Now();
+
+                    publisher.AddDataPoint(successMetric);
+                }
+                else
+                {
+                    Metric failureMetric;
+                    failureMetric.MetricName = "FailedTransfer";
+                    failureMetric.Unit = MetricUnit::Count;
+                    failureMetric.Value = 1;
+                    failureMetric.Timestamp = DateTime::Now();
+
+                    publisher.AddDataPoint(failureMetric);
+                }
+
+                --inFlightUploadOrDownload;
+            };
+
+            performTransfer(
+                allocator,
+                transport,
+                publisher,
+                key,
+                objectSize,
+                notifyUploadFinished,
+                notifyDownloadProgress,
+                notifyDownloadFinished);
+        }
+
+        Metric memMetric;
+        memMetric.Unit = MetricUnit::Bytes;
+        memMetric.Value = (double)aws_mem_tracer_bytes(allocator);
+        memMetric.Timestamp = DateTime::Now();
+        memMetric.MetricName = "BytesAllocated";
+        publisher.AddDataPoint(memMetric);
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+
+        time_t currentTime;
+        time(&currentTime);
+        double elapsedSeconds = difftime(currentTime, initialTime);
+        continueInitiatingTransfers = elapsedSeconds <= cutOffTime;
+    }
+
+    publisher.WaitForLastPublish();
+}
+
+void MeasureTransferRate::s_TransferSmallObject(
+    Allocator *allocator,
+    S3ObjectTransport &transport,
+    MetricsPublisher &publisher,
+    const String &key,
+    uint64_t objectSize,
+    const NotifyUploadFinished &notifyUploadFinished,
+    const NotifyDownloadProgress &notifyDownloadProgress,
+    const NotifyDownloadFinished &notifyDownloadFinished)
+{
+    transport.PutObject(
+        key,
+        s_createTemplateStream(allocator, &publisher, objectSize),
+        [&transport, key, notifyUploadFinished, notifyDownloadProgress, notifyDownloadFinished](
+            int32_t errorCode, std::shared_ptr<Aws::Crt::String>) {
+            notifyUploadFinished(errorCode);
+
+            if (errorCode != AWS_ERROR_SUCCESS)
+            {
+                notifyDownloadFinished(AWS_ERROR_UNKNOWN);
+                return;
+            }
+
+            transport.GetObject(
+                key,
+                [notifyDownloadProgress](const Http::HttpStream &, const ByteCursor &cur) {
+                    notifyDownloadProgress(cur.len);
+                },
+                [notifyDownloadFinished](int32_t errorCode) { notifyDownloadFinished(errorCode); });
+        });
+}
+
+void MeasureTransferRate::s_TransferLargeObject(
+    Allocator *allocator,
+    S3ObjectTransport &transport,
+    MetricsPublisher &publisher,
+    const String &key,
+    uint64_t objectSize,
+    const NotifyUploadFinished &notifyUploadFinished,
+    const NotifyDownloadProgress &notifyDownloadProgress,
+    const NotifyDownloadFinished &notifyDownloadFinished)
+{
+    transport.PutObjectMultipart(
+        key,
+        objectSize,
+        [allocator, &publisher](const MultipartTransferState::PartInfo &partInfo) {
+            return s_createTemplateStream(allocator, &publisher, partInfo.sizeInBytes);
+        },
+        [&transport, key, notifyUploadFinished, notifyDownloadProgress, notifyDownloadFinished](
+            int32_t errorCode, uint32_t numParts) {
+            notifyUploadFinished(errorCode);
+
+            if (errorCode != AWS_ERROR_SUCCESS)
+            {
+                return;
+            }
+
+            transport.GetObjectMultipart(
+                key,
+                numParts,
+                [notifyDownloadProgress](const MultipartTransferState::PartInfo &partInfo, const ByteCursor &cur) {
+                    (void)partInfo;
+                    notifyDownloadProgress(cur.len);
+                },
+                [notifyDownloadFinished](int32_t errorCode) { notifyDownloadFinished(errorCode); });
+        });
+}

--- a/canary/MeasureTransferRate.cpp
+++ b/canary/MeasureTransferRate.cpp
@@ -1,7 +1,9 @@
 #include "MeasureTransferRate.h"
+#include "CanaryApp.h"
 #include "CanaryUtil.h"
 #include "MetricsPublisher.h"
 #include "S3ObjectTransport.h"
+#include <aws/common/clock.h>
 #include <aws/common/system_info.h>
 
 using namespace Aws::Crt;
@@ -11,6 +13,12 @@ const char MeasureTransferRate::BodyTemplate[] =
 
 const size_t MeasureTransferRate::SmallObjectSize = 16 * 1024 * 1024;
 const size_t MeasureTransferRate::LargeObjectSize = 10 * S3ObjectTransport::MaxPartSizeBytes;
+const std::chrono::milliseconds MeasureTransferRate::AllocationMetricFrequency(250);
+const uint64_t MeasureTransferRate::AllocationMetricFrequencyNS = aws_timestamp_convert(
+    MeasureTransferRate::AllocationMetricFrequency.count(),
+    AWS_TIMESTAMP_SECS,
+    AWS_TIMESTAMP_NANOS,
+    NULL);
 
 aws_input_stream_vtable MeasureTransferRate::s_templateStreamVTable = {s_templateStreamSeek,
                                                                        s_templateStreamRead,
@@ -39,6 +47,8 @@ int MeasureTransferRate::s_templateStreamRead(struct aws_input_stream *stream, s
         totalToWrite = totalToWrite - toWrite;
     }
 
+    // A quick way for us to measure how much data we've actually written to S3 storage.  (This working is reliant
+    // on this function only being used when we are reading data from the stream while sending that data to S3.)
     templateStream->written += writtenOut;
 
     if (templateStream->length == templateStream->written)
@@ -107,45 +117,41 @@ aws_input_stream *MeasureTransferRate::s_createTemplateStream(
     return &templateStream->inputStream;
 }
 
-void MeasureTransferRate::MeasureSmallObjectTransfer(
-    Allocator *allocator,
-    S3ObjectTransport &transport,
-    MetricsPublisher &publisher,
-    double cutOffTime)
+MeasureTransferRate::MeasureTransferRate(CanaryApp &canaryApp) : m_canaryApp(canaryApp)
+{
+    m_schedulingLoop = aws_event_loop_group_get_next_loop(canaryApp.eventLoopGroup.GetUnderlyingHandle());
+
+    AWS_ZERO_STRUCT(m_measureAllocationsTask);
+    aws_task_init(
+        &m_measureAllocationsTask, MeasureTransferRate::s_MeasureAllocations, reinterpret_cast<void *>(this), nullptr);
+}
+
+void MeasureTransferRate::MeasureSmallObjectTransfer()
 {
     uint32_t threadCount = static_cast<uint32_t>(aws_system_info_processor_count());
     uint32_t maxInFlight = threadCount * 10;
 
     PerformMeasurement(
-        allocator,
-        transport,
-        publisher,
-        maxInFlight,
-        SmallObjectSize,
-        cutOffTime,
-        MeasureTransferRate::s_TransferSmallObject);
+        maxInFlight, SmallObjectSize, m_canaryApp.cutOffTimeSmallObjects, MeasureTransferRate::s_TransferSmallObject);
 }
 
-void MeasureTransferRate::MeasureLargeObjectTransfer(
-    Allocator *allocator,
-    S3ObjectTransport &transport,
-    MetricsPublisher &publisher,
-    double cutOffTime)
+void MeasureTransferRate::MeasureLargeObjectTransfer()
 {
     PerformMeasurement(
-        allocator, transport, publisher, 2, LargeObjectSize, cutOffTime, MeasureTransferRate::s_TransferLargeObject);
+        2, LargeObjectSize, m_canaryApp.cutOffTimeLargeObjects, MeasureTransferRate::s_TransferLargeObject);
 }
 
 template <typename TPeformTransferType>
 void MeasureTransferRate::PerformMeasurement(
-    Allocator *allocator,
-    S3ObjectTransport &transport,
-    MetricsPublisher &publisher,
     uint32_t maxConcurrentTransfers,
     uint64_t objectSize,
     double cutOffTime,
     const TPeformTransferType &&performTransfer)
 {
+    ScheduleMeasureAllocationsTask();
+
+    std::shared_ptr<MetricsPublisher> publisher = m_canaryApp.publisher;
+
     bool continueInitiatingTransfers = true;
     uint64_t counter = INT64_MAX;
     std::atomic<size_t> inFlightUploads(0);
@@ -170,7 +176,7 @@ void MeasureTransferRate::PerformMeasurement(
             auto key = keyStream.str();
 
             NotifyUploadFinished notifyUploadFinished =
-                [&publisher, &inFlightUploads, &inFlightUploadOrDownload](int32_t errorCode) {
+                [publisher, &inFlightUploads, &inFlightUploadOrDownload](int32_t errorCode) {
                     --inFlightUploads;
 
                     if (errorCode == AWS_ERROR_SUCCESS)
@@ -181,7 +187,7 @@ void MeasureTransferRate::PerformMeasurement(
                         successMetric.Value = 1;
                         successMetric.Timestamp = DateTime::Now();
 
-                        publisher.AddDataPoint(successMetric);
+                        publisher->AddDataPoint(successMetric);
                     }
                     else
                     {
@@ -191,22 +197,22 @@ void MeasureTransferRate::PerformMeasurement(
                         failureMetric.Value = 1;
                         failureMetric.Timestamp = DateTime::Now();
 
-                        publisher.AddDataPoint(failureMetric);
+                        publisher->AddDataPoint(failureMetric);
 
                         --inFlightUploadOrDownload;
                     }
                 };
 
-            NotifyDownloadProgress notifyDownloadProgress = [&publisher](uint64_t dataLength) {
+            NotifyDownloadProgress notifyDownloadProgress = [publisher](uint64_t dataLength) {
                 std::shared_ptr<Metric> downMetric = MakeShared<Metric>(g_allocator);
                 downMetric->MetricName = "BytesDown";
                 downMetric->Unit = MetricUnit::Bytes;
                 downMetric->Value = static_cast<double>(dataLength);
                 downMetric->Timestamp = DateTime::Now();
-                publisher.AddDataPoint(*downMetric);
+                publisher->AddDataPoint(*downMetric);
             };
 
-            NotifyDownloadFinished notifyDownloadFinished = [&publisher, &inFlightUploadOrDownload](int32_t errorCode) {
+            NotifyDownloadFinished notifyDownloadFinished = [publisher, &inFlightUploadOrDownload](int32_t errorCode) {
                 if (errorCode == AWS_ERROR_SUCCESS)
                 {
                     Metric successMetric;
@@ -215,7 +221,7 @@ void MeasureTransferRate::PerformMeasurement(
                     successMetric.Value = 1;
                     successMetric.Timestamp = DateTime::Now();
 
-                    publisher.AddDataPoint(successMetric);
+                    publisher->AddDataPoint(successMetric);
                 }
                 else
                 {
@@ -225,29 +231,16 @@ void MeasureTransferRate::PerformMeasurement(
                     failureMetric.Value = 1;
                     failureMetric.Timestamp = DateTime::Now();
 
-                    publisher.AddDataPoint(failureMetric);
+                    publisher->AddDataPoint(failureMetric);
                 }
 
                 --inFlightUploadOrDownload;
             };
 
             performTransfer(
-                allocator,
-                transport,
-                publisher,
-                key,
-                objectSize,
-                notifyUploadFinished,
-                notifyDownloadProgress,
-                notifyDownloadFinished);
+                *this, key, objectSize, notifyUploadFinished, notifyDownloadProgress, notifyDownloadFinished);
         }
 
-        Metric memMetric;
-        memMetric.Unit = MetricUnit::Bytes;
-        memMetric.Value = (double)aws_mem_tracer_bytes(allocator);
-        memMetric.Timestamp = DateTime::Now();
-        memMetric.MetricName = "BytesAllocated";
-        publisher.AddDataPoint(memMetric);
         std::this_thread::sleep_for(std::chrono::seconds(1));
 
         time_t currentTime;
@@ -256,23 +249,28 @@ void MeasureTransferRate::PerformMeasurement(
         continueInitiatingTransfers = elapsedSeconds <= cutOffTime;
     }
 
-    publisher.WaitForLastPublish();
+    aws_event_loop_cancel_task(m_schedulingLoop, &m_measureAllocationsTask);
+
+    publisher->WaitForLastPublish();
 }
 
 void MeasureTransferRate::s_TransferSmallObject(
-    Allocator *allocator,
-    S3ObjectTransport &transport,
-    MetricsPublisher &publisher,
+    MeasureTransferRate &measureTransferRate,
     const String &key,
     uint64_t objectSize,
     const NotifyUploadFinished &notifyUploadFinished,
     const NotifyDownloadProgress &notifyDownloadProgress,
     const NotifyDownloadFinished &notifyDownloadFinished)
 {
-    transport.PutObject(
+    CanaryApp &canaryApp = measureTransferRate.m_canaryApp;
+    Allocator *allocator = canaryApp.traceAllocator;
+    std::shared_ptr<MetricsPublisher> publisher = canaryApp.publisher;
+    std::shared_ptr<S3ObjectTransport> transport = canaryApp.transport;
+
+    transport->PutObject(
         key,
-        s_createTemplateStream(allocator, &publisher, objectSize),
-        [&transport, key, notifyUploadFinished, notifyDownloadProgress, notifyDownloadFinished](
+        s_createTemplateStream(allocator, publisher.get(), objectSize),
+        [transport, key, notifyUploadFinished, notifyDownloadProgress, notifyDownloadFinished](
             int32_t errorCode, std::shared_ptr<Aws::Crt::String>) {
             notifyUploadFinished(errorCode);
 
@@ -282,7 +280,7 @@ void MeasureTransferRate::s_TransferSmallObject(
                 return;
             }
 
-            transport.GetObject(
+            transport->GetObject(
                 key,
                 [notifyDownloadProgress](const Http::HttpStream &, const ByteCursor &cur) {
                     notifyDownloadProgress(cur.len);
@@ -292,22 +290,25 @@ void MeasureTransferRate::s_TransferSmallObject(
 }
 
 void MeasureTransferRate::s_TransferLargeObject(
-    Allocator *allocator,
-    S3ObjectTransport &transport,
-    MetricsPublisher &publisher,
+    MeasureTransferRate &measureTransferRate,
     const String &key,
     uint64_t objectSize,
     const NotifyUploadFinished &notifyUploadFinished,
     const NotifyDownloadProgress &notifyDownloadProgress,
     const NotifyDownloadFinished &notifyDownloadFinished)
 {
-    transport.PutObjectMultipart(
+    CanaryApp &canaryApp = measureTransferRate.m_canaryApp;
+    Allocator *allocator = canaryApp.traceAllocator;
+    std::shared_ptr<MetricsPublisher> publisher = canaryApp.publisher;
+    std::shared_ptr<S3ObjectTransport> transport = canaryApp.transport;
+
+    transport->PutObjectMultipart(
         key,
         objectSize,
-        [allocator, &publisher](const MultipartTransferState::PartInfo &partInfo) {
-            return s_createTemplateStream(allocator, &publisher, partInfo.sizeInBytes);
+        [allocator, publisher](const MultipartTransferState::PartInfo &partInfo) {
+            return s_createTemplateStream(allocator, publisher.get(), partInfo.sizeInBytes);
         },
-        [&transport, key, notifyUploadFinished, notifyDownloadProgress, notifyDownloadFinished](
+        [transport, key, notifyUploadFinished, notifyDownloadProgress, notifyDownloadFinished](
             int32_t errorCode, uint32_t numParts) {
             notifyUploadFinished(errorCode);
 
@@ -316,7 +317,7 @@ void MeasureTransferRate::s_TransferLargeObject(
                 return;
             }
 
-            transport.GetObjectMultipart(
+            transport->GetObjectMultipart(
                 key,
                 numParts,
                 [notifyDownloadProgress](const MultipartTransferState::PartInfo &partInfo, const ByteCursor &cur) {
@@ -325,4 +326,36 @@ void MeasureTransferRate::s_TransferLargeObject(
                 },
                 [notifyDownloadFinished](int32_t errorCode) { notifyDownloadFinished(errorCode); });
         });
+}
+
+void MeasureTransferRate::ScheduleMeasureAllocationsTask()
+{
+    uint64_t now = 0;
+    aws_event_loop_current_clock_time(m_schedulingLoop, &now);
+    aws_event_loop_schedule_task_future(
+        m_schedulingLoop, &m_measureAllocationsTask, now + MeasureTransferRate::AllocationMetricFrequencyNS);
+}
+
+void MeasureTransferRate::s_MeasureAllocations(aws_task *task, void *arg, aws_task_status status)
+{
+    (void)task;
+
+    if (status != AWS_TASK_STATUS_RUN_READY)
+    {
+        return;
+    }
+
+    MeasureTransferRate *measureTransferRate = reinterpret_cast<MeasureTransferRate *>(arg);
+    CanaryApp &canaryApp = measureTransferRate->m_canaryApp;
+    Allocator *traceAllocator = canaryApp.traceAllocator;
+    std::shared_ptr<MetricsPublisher> publisher = canaryApp.publisher;
+
+    Metric memMetric;
+    memMetric.Unit = MetricUnit::Bytes;
+    memMetric.Value = (double)aws_mem_tracer_bytes(traceAllocator);
+    memMetric.Timestamp = DateTime::Now();
+    memMetric.MetricName = "BytesAllocated";
+    publisher->AddDataPoint(memMetric);
+
+    measureTransferRate->ScheduleMeasureAllocationsTask();
 }

--- a/canary/MeasureTransferRate.h
+++ b/canary/MeasureTransferRate.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <aws/crt/StlAllocator.h>
+#include <aws/crt/Types.h>
+#include <aws/io/stream.h>
+#include <functional>
+
+class S3ObjectTransport;
+class MetricsPublisher;
+
+class MeasureTransferRate
+{
+  public:
+    void MeasureSmallObjectTransfer(
+        Aws::Crt::Allocator *allocator,
+        S3ObjectTransport &transport,
+        MetricsPublisher &publisher,
+        double cutOffTime);
+
+    void MeasureLargeObjectTransfer(
+        Aws::Crt::Allocator *allocator,
+        S3ObjectTransport &transport,
+        MetricsPublisher &publisher,
+        double cutOffTime);
+
+  private:
+    struct TemplateStream
+    {
+        aws_input_stream inputStream;
+        MetricsPublisher *publisher;
+        size_t length;
+        size_t written;
+    };
+
+    using NotifyUploadFinished = std::function<void(int32_t errorCode)>;
+    using NotifyDownloadProgress = std::function<void(uint64_t dataLength)>;
+    using NotifyDownloadFinished = std::function<void(int32_t errorCode)>;
+    using PerformTransfer = std::function<void(
+        Aws::Crt::Allocator *allocator,
+        S3ObjectTransport &transport,
+        MetricsPublisher &publisher,
+        const Aws::Crt::String &key,
+        uint64_t objectSize,
+        const NotifyUploadFinished &notifyUploadFinished,
+        const NotifyDownloadFinished &notifyDownloadFinished)>;
+
+    static const char BodyTemplate[];
+    static const size_t SmallObjectSize;
+    static const size_t LargeObjectSize;
+
+    static aws_input_stream_vtable s_templateStreamVTable;
+
+    static int s_templateStreamRead(struct aws_input_stream *stream, struct aws_byte_buf *dest);
+    static int s_templateStreamGetStatus(struct aws_input_stream *stream, struct aws_stream_status *status);
+    static int s_templateStreamSeek(
+        struct aws_input_stream *stream,
+        aws_off_t offset,
+        enum aws_stream_seek_basis basis);
+    static int s_templateStreamGetLength(struct aws_input_stream *stream, int64_t *length);
+    static void s_templateStreamDestroy(struct aws_input_stream *stream);
+    static aws_input_stream *s_createTemplateStream(
+        Aws::Crt::Allocator *allocator,
+        MetricsPublisher *publisher,
+        size_t length);
+
+    template <typename TPeformTransferType>
+    void PerformMeasurement(
+        Aws::Crt::Allocator *allocator,
+        S3ObjectTransport &transport,
+        MetricsPublisher &publisher,
+        uint32_t maxConcurrentTransfers,
+        uint64_t objectSize,
+        double cutOffTime,
+        const TPeformTransferType &&performTransfer);
+
+    static void s_TransferSmallObject(
+        Aws::Crt::Allocator *allocator,
+        S3ObjectTransport &transport,
+        MetricsPublisher &publisher,
+        const Aws::Crt::String &key,
+        uint64_t objectSize,
+        const NotifyUploadFinished &notifyUploadFinished,
+        const NotifyDownloadProgress &notifyDownloadProgress,
+        const NotifyDownloadFinished &notifyDownloadFinished);
+
+    static void s_TransferLargeObject(
+        Aws::Crt::Allocator *allocator,
+        S3ObjectTransport &transport,
+        MetricsPublisher &publisher,
+        const Aws::Crt::String &key,
+        uint64_t objectSize,
+        const NotifyUploadFinished &notifyUploadFinished,
+        const NotifyDownloadProgress &notifyDownloadProgress,
+        const NotifyDownloadFinished &notifyDownloadFinished);
+};

--- a/canary/MetricsPublisher.cpp
+++ b/canary/MetricsPublisher.cpp
@@ -215,13 +215,13 @@ void MetricsPublisher::s_OnPublishTask(aws_task *task, void *arg, aws_task_statu
             ByteCursor path = ByteCursorFromCString("/");
             request->SetPath(path);
 
-            auto signingConfig = MakeShared<Auth::AwsSigningConfig>(g_allocator, g_allocator);
-            signingConfig->SetRegion(publisher->m_region);
-            signingConfig->SetCredentialsProvider(publisher->m_credsProvider);
-            signingConfig->SetService("monitoring");
-            signingConfig->SetSignBody(true);
-            signingConfig->SetSigningTimepoint(DateTime::Now());
-            signingConfig->SetSigningAlgorithm(Auth::SigningAlgorithm::SigV4Header);
+            Auth::AwsSigningConfig signingConfig(g_allocator);
+            signingConfig.SetRegion(publisher->m_region);
+            signingConfig.SetCredentialsProvider(publisher->m_credsProvider);
+            signingConfig.SetService("monitoring");
+            signingConfig.SetBodySigningType(Auth::BodySigningType::SignBody);
+            signingConfig.SetSigningTimepoint(DateTime::Now());
+            signingConfig.SetSigningAlgorithm(Auth::SigningAlgorithm::SigV4Header);
 
             publisher->m_signer->SignRequest(
                 request,

--- a/canary/MetricsPublisher.cpp
+++ b/canary/MetricsPublisher.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#include "MetricsPublisher.h"
+
+#include <aws/crt/http/HttpConnectionManager.h>
+
+#include <aws/common/clock.h>
+#include <aws/common/task_scheduler.h>
+
+using namespace Aws::Crt;
+
+MetricsPublisher::MetricsPublisher(const Aws::Crt::String region,
+                                   Aws::Crt::Io::TlsContext &tlsContext,
+                                   Aws::Crt::Io::ClientBootstrap &clientBootstrap,
+                                   Aws::Crt::Io::EventLoopGroup &elGroup,
+                                   const std::shared_ptr<Aws::Crt::Auth::ICredentialsProvider> &credsProvider,
+                                   const std::shared_ptr<Aws::Crt::Auth::Sigv4HttpRequestSigner> &signer,
+                                   std::chrono::seconds publishFrequency) : m_signer(signer), m_credsProvider(credsProvider),
+        m_elGroup(elGroup)
+{
+    AWS_ZERO_STRUCT(m_publishTask);
+    m_publishFrequencyNs = aws_timestamp_convert(publishFrequency.count(), AWS_TIMESTAMP_SECS, AWS_TIMESTAMP_NANOS, NULL);
+    m_publishTask.fn = MetricsPublisher::s_OnPublishTask;
+    m_publishTask.arg = this;
+
+    Http::HttpClientConnectionManagerOptions connectionManagerOptions;
+    connectionManagerOptions.ConnectionOptions.HostName = "monitoring." + region + "amazonaws.com";
+    connectionManagerOptions.ConnectionOptions.Port = 443;
+    connectionManagerOptions.ConnectionOptions.SocketOptions.SetConnectTimeoutMs(3000);
+    connectionManagerOptions.ConnectionOptions.SocketOptions.SetSocketType(AWS_SOCKET_STREAM);
+    connectionManagerOptions.ConnectionOptions.InitialWindowSize = SIZE_MAX;
+
+    connectionManagerOptions.ConnectionOptions.TlsOptions = tlsContext.NewConnectionOptions();
+    auto serverName = ByteCursorFromCString(connectionManagerOptions.ConnectionOptions.HostName.c_str());
+    connectionManagerOptions.ConnectionOptions.TlsOptions->SetServerName(serverName);
+    connectionManagerOptions.ConnectionOptions.Bootstrap = &clientBootstrap;
+    connectionManagerOptions.MaxConnections = 2;
+
+    m_connManager = Http::HttpClientConnectionManager::NewClientConnectionManager(connectionManagerOptions, g_allocator);
+
+    
+}

--- a/canary/MetricsPublisher.cpp
+++ b/canary/MetricsPublisher.cpp
@@ -33,6 +33,8 @@ MetricsPublisher::MetricsPublisher(
     std::chrono::seconds publishFrequency)
     : m_signer(signer), m_credsProvider(credsProvider), m_elGroup(elGroup), m_region(region)
 {
+    (void)m_elGroup;
+
     AWS_ZERO_STRUCT(m_publishTask);
     m_publishFrequencyNs =
         aws_timestamp_convert(publishFrequency.count(), AWS_TIMESTAMP_SECS, AWS_TIMESTAMP_NANOS, NULL);

--- a/canary/MetricsPublisher.cpp
+++ b/canary/MetricsPublisher.cpp
@@ -15,20 +15,23 @@
 #include "MetricsPublisher.h"
 
 #include <aws/crt/http/HttpConnectionManager.h>
+#include <aws/crt/http/HttpRequestResponse.h>
 
 #include <aws/common/clock.h>
 #include <aws/common/task_scheduler.h>
+#include <iostream>
 
 using namespace Aws::Crt;
 
-MetricsPublisher::MetricsPublisher(const Aws::Crt::String region,
+MetricsPublisher::MetricsPublisher(const Aws::Crt::String &region,
                                    Aws::Crt::Io::TlsContext &tlsContext,
                                    Aws::Crt::Io::ClientBootstrap &clientBootstrap,
                                    Aws::Crt::Io::EventLoopGroup &elGroup,
                                    const std::shared_ptr<Aws::Crt::Auth::ICredentialsProvider> &credsProvider,
                                    const std::shared_ptr<Aws::Crt::Auth::Sigv4HttpRequestSigner> &signer,
                                    std::chrono::seconds publishFrequency) : m_signer(signer), m_credsProvider(credsProvider),
-        m_elGroup(elGroup)
+        m_elGroup(elGroup),
+        m_region(region)
 {
     AWS_ZERO_STRUCT(m_publishTask);
     m_publishFrequencyNs = aws_timestamp_convert(publishFrequency.count(), AWS_TIMESTAMP_SECS, AWS_TIMESTAMP_NANOS, NULL);
@@ -36,19 +39,180 @@ MetricsPublisher::MetricsPublisher(const Aws::Crt::String region,
     m_publishTask.arg = this;
 
     Http::HttpClientConnectionManagerOptions connectionManagerOptions;
-    connectionManagerOptions.ConnectionOptions.HostName = "monitoring." + region + "amazonaws.com";
+    connectionManagerOptions.ConnectionOptions.HostName = "monitoring." + m_region + ".amazonaws.com";
     connectionManagerOptions.ConnectionOptions.Port = 443;
     connectionManagerOptions.ConnectionOptions.SocketOptions.SetConnectTimeoutMs(3000);
     connectionManagerOptions.ConnectionOptions.SocketOptions.SetSocketType(AWS_SOCKET_STREAM);
     connectionManagerOptions.ConnectionOptions.InitialWindowSize = SIZE_MAX;
 
-    connectionManagerOptions.ConnectionOptions.TlsOptions = tlsContext.NewConnectionOptions();
-    auto serverName = ByteCursorFromCString(connectionManagerOptions.ConnectionOptions.HostName.c_str());
-    connectionManagerOptions.ConnectionOptions.TlsOptions->SetServerName(serverName);
+    aws_byte_cursor serverName = ByteCursorFromCString(connectionManagerOptions.ConnectionOptions.HostName.c_str());
+
+    auto connOptions = tlsContext.NewConnectionOptions();
+    connOptions.SetServerName(serverName);
+    connectionManagerOptions.ConnectionOptions.TlsOptions = connOptions;
     connectionManagerOptions.ConnectionOptions.Bootstrap = &clientBootstrap;
     connectionManagerOptions.MaxConnections = 2;
 
     m_connManager = Http::HttpClientConnectionManager::NewClientConnectionManager(connectionManagerOptions, g_allocator);
 
-    
+    m_schedulingLoop = aws_event_loop_group_get_next_loop(elGroup.GetUnderlyingHandle());
+    uint64_t now = 0;
+    aws_event_loop_current_clock_time(m_schedulingLoop, &now);
+    aws_event_loop_schedule_task_future(m_schedulingLoop, &m_publishTask, now + m_publishFrequencyNs);
+
+    m_hostHeader.name = ByteCursorFromCString("host");
+    m_hostHeader.value = ByteCursorFromCString(m_region.c_str());
+
+    m_contentTypeHeader.name = ByteCursorFromCString("content-type");
+    m_contentTypeHeader.value = ByteCursorFromCString("application/x-www-form-urlencoded");
+
+    m_apiVersionHeader.name = ByteCursorFromCString("x-amz-api-version");
+    m_apiVersionHeader.value = ByteCursorFromCString("2011-06-15");
+}
+
+MetricsPublisher::~MetricsPublisher() {
+    aws_event_loop_cancel_task(m_schedulingLoop, &m_publishTask);
+}
+
+static const char *s_UnitToStr(MetricUnit unit) {
+    static const char *s_unitStr[] = {
+            "Seconds",
+            "Microseconds",
+            "Milliseconds",
+            "Bytes",
+            "Kilobytes",
+            "Megabytes",
+            "Gigabytes",
+            "Terabytes",
+            "Bits",
+            "Kilobits",
+            "Gigabits",
+            "Terabits",
+            "Percent",
+            "Count",
+            "Bytes%2FSecond",
+            "Kilobytes%2FSecond",
+            "Megabytes%2FSecond",
+            "Gigabytes%2FSecond",
+            "Terabytes%2FSecond",
+            "Bits%2FSecond",
+            "Kilobits%2FSecond",
+            "Megabits%2FSecond",
+            "Gigabits%2FSecond",
+            "Terabits%2FSecond",
+            "Counts%2FSecond",
+            "None",
+    };
+
+    auto index = static_cast<size_t>(unit);
+    if (index >= AWS_ARRAY_SIZE(s_unitStr)) {
+        return "None";
+    }
+    return s_unitStr[index];
+}
+
+void MetricsPublisher::PreparePayload(Aws::Crt::StringStream& bodyStream) {
+    bodyStream << "Action=PutMetricData&";
+
+    if (Namespace)
+    {
+        bodyStream << "Namespace=" << *Namespace << "&";
+    }
+
+    size_t metricCount = 1;
+    Vector<Metric> metricsCpy;
+    {
+        std::lock_guard<std::mutex> locker(m_publishDataLock);
+        metricsCpy = std::move(m_publishData);
+        m_publishData = Vector<Metric>();
+    }
+
+    for (const auto &metric : metricsCpy) {
+        bodyStream << "MetricData.member." << metricCount << ".MetricName=" << metric.MetricName << "&";
+        uint8_t dateBuffer[AWS_DATE_TIME_STR_MAX_LEN];
+        AWS_ZERO_ARRAY(dateBuffer);
+        auto dateBuf = ByteBufFromEmptyArray(dateBuffer, AWS_ARRAY_SIZE(dateBuffer));
+        metric.Timestamp.ToGmtString(DateFormat::ISO_8601, dateBuf);
+        String dateStr((char *) dateBuf.buffer, dateBuf.len);
+        bodyStream << "MetricData.member." << metricCount << ".Timestamp=" << dateStr << "&";
+        bodyStream << "MetricData.member." << metricCount << ".Value=" << metric.Value << "&";
+        bodyStream << "MetricData.member." << metricCount << ".Unit=" << s_UnitToStr(metric.Unit) << "&";
+
+        metricCount++;
+    }
+
+    bodyStream << "Version=2010-08-01";
+}
+
+void MetricsPublisher::AddDataPoint(const Metric& metricData) {
+    std::lock_guard<std::mutex> locker(m_publishDataLock);
+    m_publishData.push_back(metricData);
+}
+
+void MetricsPublisher::s_OnPublishTask(aws_task *task, void *arg, aws_task_status status) {
+    (void)task;
+
+    if (status == AWS_TASK_STATUS_RUN_READY) {
+        auto publisher = static_cast<MetricsPublisher *>(arg);
+
+        {
+            std::lock_guard<std::mutex> locker(publisher->m_publishDataLock);
+            if (publisher->m_publishData.empty()) {
+                uint64_t now = 0;
+                aws_event_loop_current_clock_time(publisher->m_schedulingLoop, &now);
+                aws_event_loop_schedule_task_future(publisher->m_schedulingLoop, &publisher->m_publishTask, now + publisher->m_publishFrequencyNs);
+                return;
+            }
+        }
+
+        auto request = MakeShared<Http::HttpRequest>(g_allocator, g_allocator);
+        request->AddHeader(publisher->m_hostHeader);
+        request->AddHeader(publisher->m_contentTypeHeader);
+        request->AddHeader(publisher->m_apiVersionHeader);
+
+        auto bodyStream = MakeShared<StringStream>(g_allocator);
+        publisher->PreparePayload(*bodyStream);
+
+        Http::HttpHeader contentLength;
+        contentLength.name = ByteCursorFromCString("content-length");
+
+        StringStream intValue;
+        intValue << bodyStream->tellp();
+        String contentLengthVal = intValue.str();
+        contentLength.value = ByteCursorFromCString(contentLengthVal.c_str());
+        request->AddHeader(contentLength);
+
+        request->SetBody(bodyStream);
+        request->SetMethod(aws_http_method_post);
+
+        ByteCursor path = ByteCursorFromCString("/");
+        request->SetPath(path);
+
+        auto signingConfig = MakeShared<Auth::AwsSigningConfig>(g_allocator, g_allocator);
+        signingConfig->SetRegion(publisher->m_region);
+        signingConfig->SetCredentialsProvider(publisher->m_credsProvider);
+        signingConfig->SetService("monitoring");
+        signingConfig->SetSignBody(true);
+        signingConfig->SetSigningTimepoint(DateTime::Now());
+        signingConfig->SetSigningAlgorithm(Auth::SigningAlgorithm::SigV4Header);
+
+        publisher->m_signer->SignRequest(request, signingConfig, [bodyStream, publisher](const std::shared_ptr<Aws::Crt::Http::HttpRequest> &signedRequest, int signingError) {
+            if (signingError == AWS_OP_SUCCESS) {
+                publisher->m_connManager->AcquireConnection([publisher, signedRequest](std::shared_ptr<Http::HttpClientConnection> conn, int connError) {
+                    if (connError == AWS_OP_SUCCESS) {
+                        Http::HttpRequestOptions requestOptions;
+                        AWS_ZERO_STRUCT(requestOptions);
+                        requestOptions.request = signedRequest.get();
+                        requestOptions.onStreamComplete = [signedRequest, conn](Http::HttpStream &, int) {
+                        };
+                        conn->NewClientStream(requestOptions);
+                    }
+
+                    uint64_t now = 0;
+                    aws_event_loop_current_clock_time(publisher->m_schedulingLoop, &now);
+                    aws_event_loop_schedule_task_future(publisher->m_schedulingLoop, &publisher->m_publishTask, now + publisher->m_publishFrequencyNs);
+                });
+            }
+        });
+    }
 }

--- a/canary/MetricsPublisher.h
+++ b/canary/MetricsPublisher.h
@@ -13,8 +13,8 @@
  * permissions and limitations under the License.
  */
 #include <aws/crt/DateTime.h>
-#include <aws/crt/http/HttpConnectionManager.h>
 #include <aws/crt/auth/Sigv4Signing.h>
+#include <aws/crt/http/HttpConnectionManager.h>
 
 #include <chrono>
 #include <mutex>
@@ -62,41 +62,43 @@ struct Metric
  */
 class MetricsPublisher
 {
-public:
-    MetricsPublisher(const Aws::Crt::String &region,
-            Aws::Crt::Io::TlsContext &tlsContext,
-            Aws::Crt::Io::ClientBootstrap &clientBootstrap,
-            Aws::Crt::Io::EventLoopGroup &elGroup,
-            const std::shared_ptr<Aws::Crt::Auth::ICredentialsProvider> &credsProvider,
-            const std::shared_ptr<Aws::Crt::Auth::Sigv4HttpRequestSigner> &signer,
-            std::chrono::seconds publishFrequency = std::chrono::seconds(1));
+  public:
+    MetricsPublisher(
+        const Aws::Crt::String &region,
+        Aws::Crt::Io::TlsContext &tlsContext,
+        Aws::Crt::Io::ClientBootstrap &clientBootstrap,
+        Aws::Crt::Io::EventLoopGroup &elGroup,
+        const std::shared_ptr<Aws::Crt::Auth::ICredentialsProvider> &credsProvider,
+        const std::shared_ptr<Aws::Crt::Auth::Sigv4HttpRequestSigner> &signer,
+        std::chrono::seconds publishFrequency = std::chrono::seconds(1));
 
     ~MetricsPublisher();
 
     /**
      * Add a data point to the outgoing metrics collection.
      */
-    void AddDataPoint(const Metric& metricData);
+    void AddDataPoint(const Metric &metricData);
 
     /**
      * namespace to use for the metrics
      */
     Aws::Crt::Optional<Aws::Crt::String> Namespace;
 
-private:
-    void PreparePayload(Aws::Crt::StringStream& bodyStream);
+  private:
+    void PreparePayload(Aws::Crt::StringStream &bodyStream, const Aws::Crt::Vector<Metric> &);
 
     static void s_OnPublishTask(aws_task *task, void *arg, aws_task_status status);
 
     std::shared_ptr<Aws::Crt::Http::HttpClientConnectionManager> m_connManager;
     std::shared_ptr<Aws::Crt::Auth::Sigv4HttpRequestSigner> m_signer;
     std::shared_ptr<Aws::Crt::Auth::ICredentialsProvider> m_credsProvider;
-    Aws::Crt::Io::EventLoopGroup& m_elGroup;
+    Aws::Crt::Io::EventLoopGroup &m_elGroup;
     Aws::Crt::Vector<Metric> m_publishData;
     const Aws::Crt::String m_region;
     Aws::Crt::Http::HttpHeader m_hostHeader;
     Aws::Crt::Http::HttpHeader m_contentTypeHeader;
     Aws::Crt::Http::HttpHeader m_apiVersionHeader;
+    Aws::Crt::String m_endpoint;
     aws_event_loop *m_schedulingLoop;
 
     std::mutex m_publishDataLock;

--- a/canary/MetricsPublisher.h
+++ b/canary/MetricsPublisher.h
@@ -12,6 +12,9 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
+#pragma once
+
 #include <aws/crt/DateTime.h>
 #include <aws/crt/auth/Sigv4Signing.h>
 #include <aws/crt/http/HttpConnectionManager.h>

--- a/canary/MetricsPublisher.h
+++ b/canary/MetricsPublisher.h
@@ -67,6 +67,8 @@ struct Metric
     Aws::Crt::String MetricName;
 };
 
+struct CanaryApp;
+
 /**
  * Publishes an aggregated metrics collection to cloud watch at 'publishFrequency'
  */
@@ -74,15 +76,8 @@ class MetricsPublisher
 {
   public:
     MetricsPublisher(
-        const Aws::Crt::String &platformName,
-        const Aws::Crt::String &toolName,
-        const Aws::Crt::String &ec2InstanceType,
-        const Aws::Crt::String &region,
-        Aws::Crt::Io::TlsContext &tlsContext,
-        Aws::Crt::Io::ClientBootstrap &clientBootstrap,
-        Aws::Crt::Io::EventLoopGroup &elGroup,
-        const std::shared_ptr<Aws::Crt::Auth::ICredentialsProvider> &credsProvider,
-        const std::shared_ptr<Aws::Crt::Auth::Sigv4HttpRequestSigner> &signer,
+        CanaryApp &canaryApp,
+        const char *metricNamespace,
         std::chrono::seconds publishFrequency = std::chrono::seconds(1));
 
     ~MetricsPublisher();
@@ -114,15 +109,9 @@ class MetricsPublisher
     static void s_OnPublishTask(aws_task *task, void *arg, aws_task_status status);
 
     MetricTransferSize m_transferSize;
+    CanaryApp &m_canaryApp;
     std::shared_ptr<Aws::Crt::Http::HttpClientConnectionManager> m_connManager;
-    std::shared_ptr<Aws::Crt::Auth::Sigv4HttpRequestSigner> m_signer;
-    std::shared_ptr<Aws::Crt::Auth::ICredentialsProvider> m_credsProvider;
-    Aws::Crt::Io::EventLoopGroup &m_elGroup;
     Aws::Crt::Vector<Metric> m_publishData;
-    Aws::Crt::String m_platformName;
-    Aws::Crt::String m_toolName;
-    Aws::Crt::String m_ec2InstanceType;
-    const Aws::Crt::String m_region;
     Aws::Crt::Http::HttpHeader m_hostHeader;
     Aws::Crt::Http::HttpHeader m_contentTypeHeader;
     Aws::Crt::Http::HttpHeader m_apiVersionHeader;

--- a/canary/MetricsPublisher.h
+++ b/canary/MetricsPublisher.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#include <aws/crt/DateTime.h>
+#include <aws/crt/http/HttpConnectionManager.h>
+#include <aws/crt/auth/Sigv4Signing.h>
+
+#include <chrono>
+#include <mutex>
+
+enum class MetricUnit
+{
+    Seconds,
+    Microseconds,
+    Milliseconds,
+    Bytes,
+    Kilobytes,
+    Megabytes,
+    Gigabytes,
+    Terabytes,
+    Bits,
+    Kilobits,
+    Gigabits,
+    Terabits,
+    Percent,
+    Count,
+    Bytes_Per_Second,
+    Kilobytes_Per_Second,
+    Megabytes_Per_Second,
+    Gigabytes_Per_Second,
+    Terabytes_Per_Second,
+    Bits_Per_Second,
+    Kilobits_Per_Second,
+    Megabits_Per_Second,
+    Gigabits_Per_Second,
+    Terabits_Per_Second,
+    Counts_Per_Second,
+    None,
+};
+
+struct Metric
+{
+    MetricUnit Unit;
+    Aws::Crt::DateTime Timestamp;
+    double Value;
+    Aws::Crt::String MetricName;
+};
+
+class MetricsPublisher
+{
+public:
+    MetricsPublisher(const Aws::Crt::String region,
+            Aws::Crt::Io::TlsContext &tlsContext,
+            Aws::Crt::Io::ClientBootstrap &clientBootstrap,
+            Aws::Crt::Io::EventLoopGroup &elGroup,
+            const std::shared_ptr<Aws::Crt::Auth::ICredentialsProvider> &credsProvider,
+            const std::shared_ptr<Aws::Crt::Auth::Sigv4HttpRequestSigner> &signer,
+            std::chrono::seconds publishFrequency = std::chrono::seconds(1));
+    void AddDataPoint(Metric&& metricData);
+
+private:
+    static void s_OnPublishTask(aws_task *task, void *arg, aws_task_status status);
+
+    std::shared_ptr<Aws::Crt::Http::HttpClientConnectionManager> m_connManager;
+    std::shared_ptr<Aws::Crt::Auth::Sigv4HttpRequestSigner> m_signer;
+    std::shared_ptr<Aws::Crt::Auth::ICredentialsProvider> m_credsProvider;
+    Aws::Crt::Io::EventLoopGroup& m_elGroup;
+    Aws::Crt::Vector<Metric> m_publishData;
+    std::mutex m_publishDataLock;
+    aws_task m_publishTask;
+    uint64_t m_publishFrequencyNs;
+};

--- a/canary/MetricsPublisher.h
+++ b/canary/MetricsPublisher.h
@@ -57,19 +57,35 @@ struct Metric
     Aws::Crt::String MetricName;
 };
 
+/**
+ * Publishes an aggregated metrics collection to cloud watch at 'publishFrequency'
+ */
 class MetricsPublisher
 {
 public:
-    MetricsPublisher(const Aws::Crt::String region,
+    MetricsPublisher(const Aws::Crt::String &region,
             Aws::Crt::Io::TlsContext &tlsContext,
             Aws::Crt::Io::ClientBootstrap &clientBootstrap,
             Aws::Crt::Io::EventLoopGroup &elGroup,
             const std::shared_ptr<Aws::Crt::Auth::ICredentialsProvider> &credsProvider,
             const std::shared_ptr<Aws::Crt::Auth::Sigv4HttpRequestSigner> &signer,
             std::chrono::seconds publishFrequency = std::chrono::seconds(1));
-    void AddDataPoint(Metric&& metricData);
+
+    ~MetricsPublisher();
+
+    /**
+     * Add a data point to the outgoing metrics collection.
+     */
+    void AddDataPoint(const Metric& metricData);
+
+    /**
+     * namespace to use for the metrics
+     */
+    Aws::Crt::Optional<Aws::Crt::String> Namespace;
 
 private:
+    void PreparePayload(Aws::Crt::StringStream& bodyStream);
+
     static void s_OnPublishTask(aws_task *task, void *arg, aws_task_status status);
 
     std::shared_ptr<Aws::Crt::Http::HttpClientConnectionManager> m_connManager;
@@ -77,6 +93,12 @@ private:
     std::shared_ptr<Aws::Crt::Auth::ICredentialsProvider> m_credsProvider;
     Aws::Crt::Io::EventLoopGroup& m_elGroup;
     Aws::Crt::Vector<Metric> m_publishData;
+    const Aws::Crt::String m_region;
+    Aws::Crt::Http::HttpHeader m_hostHeader;
+    Aws::Crt::Http::HttpHeader m_contentTypeHeader;
+    Aws::Crt::Http::HttpHeader m_apiVersionHeader;
+    aws_event_loop *m_schedulingLoop;
+
     std::mutex m_publishDataLock;
     aws_task m_publishTask;
     uint64_t m_publishFrequencyNs;

--- a/canary/MultipartTransferProcessor.cpp
+++ b/canary/MultipartTransferProcessor.cpp
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "MultipartTransferProcessor.h"
+#include "S3ObjectTransport.h"
+#include <aws/crt/Types.h>
+#include <aws/crt/io/Stream.h>
+#include <aws/io/stream.h>
+
+#if defined(_WIN32)
+#    undef min
+#endif
+
+using namespace Aws::Crt;
+
+MultipartTransferProcessor::MultipartTransferProcessor(std::uint32_t streamsAvailable)
+{
+    m_streamsAvailable = streamsAvailable;
+
+    aws_mutex_init(&m_queueMutex);
+}
+
+MultipartTransferProcessor::~MultipartTransferProcessor()
+{
+    aws_mutex_clean_up(&m_queueMutex);
+}
+
+void MultipartTransferProcessor::ProcessNextParts(uint32_t streamsReturning)
+{
+    ProcessNextPartsForNextObject(streamsReturning);
+
+    while (ProcessNextPartsForNextObject(0))
+    {
+    }
+}
+
+bool MultipartTransferProcessor::ProcessNextPartsForNextObject(uint32_t streamsReturning)
+{
+    uint32_t startPartIndex = 0;
+    uint32_t numPartsToProcess = 0;
+    std::shared_ptr<MultipartTransferState> state;
+
+    // Grab all of the streams currently available.
+    uint32_t numStreamsToConsume = m_streamsAvailable.exchange(0);
+
+    // Add the number of streams that we just got back to our local count.  If
+    // we don't use it, then it'll get put it back into m_streamsAvailable.
+    // This way, we guarantee that those streams get to be used locally, and do not
+    // get stolen by another thread.
+    numStreamsToConsume += streamsReturning;
+
+    // If we have streams to consume, try to find something to use them.  We're not intending
+    // to use all of them all of the time--we're just trying to find the next valid range of
+    // parts to process.  Any remaining streams we grabbed will get thrown back into the pool
+    // and will be handled with a different call to this method.
+    if (numStreamsToConsume > 0)
+    {
+        bool processingQueue = true;
+
+        // Find the next thing in the queue that needs parts processed, cleaning up the queue along the way.
+        while (processingQueue)
+        {
+            state = PeekQueue();
+
+            // If we have no state returned, the queue is empty, so stop processing.
+            if (state == nullptr)
+            {
+                processingQueue = false;
+            }
+            // Try getting a range of parts to process.
+            else if (state->GetPartRangeForTransfer(numStreamsToConsume, startPartIndex, numPartsToProcess))
+            {
+                numStreamsToConsume -= numPartsToProcess;
+                AWS_FATAL_ASSERT(numStreamsToConsume >= 0);
+                processingQueue = false;
+            }
+            // If GetPartRangeForTransfer returned false, then there's nothing left to process on that object,
+            // so remove it from the queue.
+            else
+            {
+                PopQueue(state);
+            }
+        }
+    }
+
+    // Put back the count of streams that we didn't use.
+    m_streamsAvailable += numStreamsToConsume;
+
+    // If we didn't get a state back, then numPartsToProcess should be zero.
+    AWS_FATAL_ASSERT(state != nullptr || numPartsToProcess == 0);
+
+    for (uint32_t i = 0; i < numPartsToProcess; ++i)
+    {
+        uint32_t partIndex = startPartIndex + i;
+        uint32_t partNumber = partIndex + 1;
+
+        uint64_t partByteStart = partIndex * S3ObjectTransport::MaxPartSizeBytes;
+        uint64_t partByteRemainder = state->GetObjectSize() - (partIndex * S3ObjectTransport::MaxPartSizeBytes);
+        uint64_t partByteSize = std::min(partByteRemainder, S3ObjectTransport::MaxPartSizeBytes);
+
+        MultipartTransferState::PartInfo partInfo(partIndex, partNumber, partByteStart, partByteSize);
+
+        state->ProcessPart(state, partInfo, [this]() { ProcessNextParts(1); });
+    }
+
+    return numPartsToProcess > 0;
+}
+
+void MultipartTransferProcessor::PushQueue(const std::shared_ptr<MultipartTransferState> &state)
+{
+    aws_mutex_lock(&m_queueMutex);
+    m_stateQueue.push(state);
+    aws_mutex_unlock(&m_queueMutex);
+
+    ProcessNextParts(0);
+}
+
+std::shared_ptr<MultipartTransferState> MultipartTransferProcessor::PeekQueue()
+{
+    std::shared_ptr<MultipartTransferState> state;
+
+    aws_mutex_lock(&m_queueMutex);
+
+    if (m_stateQueue.size() > 0)
+    {
+        state = m_stateQueue.front();
+    }
+
+    aws_mutex_unlock(&m_queueMutex);
+
+    return state;
+}
+
+void MultipartTransferProcessor::PopQueue(const std::shared_ptr<MultipartTransferState> &state)
+{
+    aws_mutex_lock(&m_queueMutex);
+    if (m_stateQueue.size() > 0)
+    {
+        std::shared_ptr<MultipartTransferState> front = m_stateQueue.front();
+
+        if (state == front)
+        {
+            m_stateQueue.pop();
+        }
+    }
+    aws_mutex_unlock(&m_queueMutex);
+}

--- a/canary/MultipartTransferProcessor.h
+++ b/canary/MultipartTransferProcessor.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <queue>
+
+#include <aws/common/mutex.h>
+
+#include "MultipartTransferState.h"
+
+class S3ObjectTransport;
+
+class MultipartTransferProcessor
+{
+  public:
+    MultipartTransferProcessor(std::uint32_t streamsAvailable);
+    virtual ~MultipartTransferProcessor();
+
+    void PushQueue(const std::shared_ptr<MultipartTransferState> &uploadState);
+
+  private:
+    std::atomic<uint32_t> m_streamsAvailable;
+    aws_mutex m_queueMutex;
+
+    std::queue<std::shared_ptr<MultipartTransferState>> m_stateQueue;
+
+    void ProcessNextParts(uint32_t streamsReturning);
+    bool ProcessNextPartsForNextObject(uint32_t streamsReturning);
+    std::shared_ptr<MultipartTransferState> PeekQueue();
+    void PopQueue(const std::shared_ptr<MultipartTransferState> &state);
+};

--- a/canary/MultipartTransferState.cpp
+++ b/canary/MultipartTransferState.cpp
@@ -1,0 +1,143 @@
+#include "MultipartTransferState.h"
+#include "S3ObjectTransport.h"
+
+#include <aws/crt/http/HttpConnectionManager.h>
+#include <aws/crt/http/HttpRequestResponse.h>
+#include <aws/crt/io/stream.h>
+#include <aws/io/stream.h>
+
+using namespace Aws::Crt;
+
+MultipartTransferState::MultipartTransferState(
+    const Aws::Crt::String &key,
+    const Aws::Crt::String &uploadId,
+    uint64_t objectSize,
+    uint32_t numParts,
+    GetObjectPartCallback getObjectPartCallback,
+    OnCompletedCallback onCompletedCallback)
+{
+    m_isCompleted = false;
+    m_errorCode = AWS_OP_SUCCESS;
+    m_numParts = numParts;
+    m_numPartsRequested = 0;
+    m_numPartsCompleted = 0;
+    m_objectSize = objectSize;
+    m_key = key;
+    m_uploadId = uploadId;
+    m_getObjectPartCallback = getObjectPartCallback;
+    m_onCompletedCallback = onCompletedCallback;
+
+    for (size_t i = 0; i < m_numParts; ++i)
+    {
+        m_etags.push_back("");
+    }
+
+    aws_mutex_init(&m_completionMutex);
+    aws_mutex_init(&m_etagsMutex);
+}
+
+MultipartTransferState::~MultipartTransferState()
+{
+    aws_mutex_clean_up(&m_completionMutex);
+    aws_mutex_clean_up(&m_etagsMutex);
+}
+
+void MultipartTransferState::SetCompleted(int32_t errorCode)
+{
+    aws_mutex_lock(&m_completionMutex);
+
+    if (m_isCompleted)
+    {
+        AWS_LOGF_INFO(
+            AWS_LS_COMMON_GENERAL,
+            "MultipartTransferState::SetCompleted being called multiple times--not recording error code %d.",
+            errorCode);
+    }
+    else
+    {
+        m_isCompleted = true;
+        m_errorCode = errorCode;
+        m_onCompletedCallback(m_errorCode);
+    }
+
+    aws_mutex_unlock(&m_completionMutex);
+}
+
+bool MultipartTransferState::IsCompleted() const
+{
+    return m_isCompleted;
+}
+
+void MultipartTransferState::SetETag(uint32_t partIndex, const Aws::Crt::String &etag)
+{
+    aws_mutex_lock(&m_etagsMutex);
+    m_etags[partIndex] = etag;
+    aws_mutex_unlock(&m_etagsMutex);
+}
+
+bool MultipartTransferState::GetPartsForUpload(
+    uint32_t desiredNumParts,
+    uint32_t &outStartPartIndex,
+    uint32_t &outNumParts)
+{
+    uint32_t startPartIndex = m_numPartsRequested.fetch_add(desiredNumParts);
+    uint32_t numPartsToUpload = 0;
+
+    if (startPartIndex >= m_numParts)
+    {
+        m_numPartsRequested = m_numParts;
+        return false;
+    }
+
+    if ((startPartIndex + desiredNumParts) >= m_numParts)
+    {
+        numPartsToUpload = m_numParts - startPartIndex;
+    }
+
+    outStartPartIndex = startPartIndex;
+    outNumParts = numPartsToUpload;
+    return true;
+}
+
+bool MultipartTransferState::IncNumPartsCompleted()
+{
+    uint32_t originalValue = m_numPartsCompleted.fetch_add(1);
+    return (originalValue + 1) == GetNumParts();
+}
+
+const Aws::Crt::String &MultipartTransferState::GetKey() const
+{
+    return m_key;
+}
+
+const Aws::Crt::String &MultipartTransferState::GetUploadId() const
+{
+    return m_uploadId;
+}
+
+void MultipartTransferState::GetETags(Aws::Crt::Vector<Aws::Crt::String> & outETags)
+{
+    aws_mutex_lock(&m_etagsMutex);
+    outETags = m_etags;
+    aws_mutex_unlock(&m_etagsMutex);
+}
+
+uint32_t MultipartTransferState::GetNumParts() const
+{
+    return m_numParts;
+}
+
+uint32_t MultipartTransferState::GetNumPartsRequested() const
+{
+    return m_numPartsRequested;
+}
+
+uint32_t MultipartTransferState::GetNumPartsCompleted() const
+{
+    return m_numPartsCompleted;
+}
+
+uint64_t MultipartTransferState::GetObjectSize() const
+{
+    return m_objectSize;
+}

--- a/canary/MultipartTransferState.cpp
+++ b/canary/MultipartTransferState.cpp
@@ -3,7 +3,7 @@
 
 #include <aws/crt/http/HttpConnectionManager.h>
 #include <aws/crt/http/HttpRequestResponse.h>
-#include <aws/crt/io/stream.h>
+#include <aws/crt/io/Stream.h>
 #include <aws/io/stream.h>
 
 using namespace Aws::Crt;
@@ -115,7 +115,7 @@ const Aws::Crt::String &MultipartTransferState::GetUploadId() const
     return m_uploadId;
 }
 
-void MultipartTransferState::GetETags(Aws::Crt::Vector<Aws::Crt::String> & outETags)
+void MultipartTransferState::GetETags(Aws::Crt::Vector<Aws::Crt::String> &outETags)
 {
     aws_mutex_lock(&m_etagsMutex);
     outETags = m_etags;

--- a/canary/MultipartTransferState.h
+++ b/canary/MultipartTransferState.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#pragma once
+
+#include <atomic>
+#include <aws/common/mutex.h>
+#include <aws/common/string.h>
+#include <aws/crt/types.h>
+#include <mutex>
+
+class S3ObjectTransport;
+
+class MultipartTransferState
+{
+  public:
+    using GetObjectPartCallback =
+        std::function<struct aws_input_stream *(uint64_t partStartBytes, uint64_t partSizeBytes)>;
+    using OnCompletedCallback = std::function<void(int32_t errorCode)>;
+
+    MultipartTransferState(
+        const Aws::Crt::String &key,
+        const Aws::Crt::String &uploadId,
+        uint64_t objectSize,
+        uint32_t numParts,
+        GetObjectPartCallback getObjectPartCallback,
+        OnCompletedCallback onCompletedCallback);
+
+    ~MultipartTransferState();
+
+    void SetCompleted(int32_t errorCode = AWS_OP_SUCCESS);
+    void SetETag(uint32_t partIndex, const Aws::Crt::String &etag);
+
+    bool GetPartsForUpload(uint32_t desiredNumParts, uint32_t &outStartPartIndex, uint32_t &outNumParts);
+    bool IncNumPartsCompleted();
+
+    bool IsCompleted() const;
+    const Aws::Crt::String &GetKey() const;
+    const Aws::Crt::String &GetUploadId() const;
+    void GetETags(Aws::Crt::Vector<Aws::Crt::String> &outETags);
+    uint32_t GetNumParts() const;
+    uint32_t GetNumPartsRequested() const;
+    uint32_t GetNumPartsCompleted() const;
+    uint64_t GetObjectSize() const;
+
+
+    template <typename... TArgs> aws_input_stream *GetObjectPart(TArgs &&... Args) const
+    {
+        return m_getObjectPartCallback(std::forward<TArgs>(Args)...);
+    }
+
+  private:
+    uint32_t m_isCompleted : 1;
+    int32_t m_errorCode;
+    uint32_t m_numParts;
+    std::atomic<uint32_t> m_numPartsRequested;
+    std::atomic<uint32_t> m_numPartsCompleted;
+    uint64_t m_objectSize;
+    Aws::Crt::String m_key;
+    Aws::Crt::String m_uploadId;
+    Aws::Crt::Vector<Aws::Crt::String> m_etags;
+    aws_mutex m_completionMutex;
+    aws_mutex m_etagsMutex;
+    GetObjectPartCallback m_getObjectPartCallback;
+    OnCompletedCallback m_onCompletedCallback;
+};

--- a/canary/MultipartTransferState.h
+++ b/canary/MultipartTransferState.h
@@ -17,7 +17,7 @@
 #include <atomic>
 #include <aws/common/mutex.h>
 #include <aws/common/string.h>
-#include <aws/crt/types.h>
+#include <aws/crt/Types.h>
 #include <mutex>
 
 class S3ObjectTransport;
@@ -53,7 +53,6 @@ class MultipartTransferState
     uint32_t GetNumPartsRequested() const;
     uint32_t GetNumPartsCompleted() const;
     uint64_t GetObjectSize() const;
-
 
     template <typename... TArgs> aws_input_stream *GetObjectPart(TArgs &&... Args) const
     {

--- a/canary/MultipartTransferState.h
+++ b/canary/MultipartTransferState.h
@@ -25,16 +25,27 @@ class S3ObjectTransport;
 class MultipartTransferState
 {
   public:
-    using GetObjectPartCallback =
-        std::function<struct aws_input_stream *(uint64_t partStartBytes, uint64_t partSizeBytes)>;
+    struct PartInfo
+    {
+        uint32_t index;
+        uint32_t number;
+        uint64_t byteOffset;
+        uint64_t byteSize;
+
+        PartInfo();
+        PartInfo(uint32_t partIndex, uint32_t partNumber, uint64_t partByteOffset, uint64_t partByteSize);
+    };
+
+    using PartFinishedCallback = std::function<void()>;
+    using ProcessPartCallback = std::function<
+        void(std::shared_ptr<MultipartTransferState> state, const PartInfo &partInfo, PartFinishedCallback callback)>;
     using OnCompletedCallback = std::function<void(int32_t errorCode)>;
 
     MultipartTransferState(
         const Aws::Crt::String &key,
-        const Aws::Crt::String &uploadId,
         uint64_t objectSize,
         uint32_t numParts,
-        GetObjectPartCallback getObjectPartCallback,
+        ProcessPartCallback processPartCallback,
         OnCompletedCallback onCompletedCallback);
 
     ~MultipartTransferState();
@@ -42,35 +53,32 @@ class MultipartTransferState
     void SetCompleted(int32_t errorCode = AWS_OP_SUCCESS);
     void SetETag(uint32_t partIndex, const Aws::Crt::String &etag);
 
-    bool GetPartsForUpload(uint32_t desiredNumParts, uint32_t &outStartPartIndex, uint32_t &outNumParts);
+    bool GetPartRangeForTransfer(uint32_t desiredNumParts, uint32_t &outStartPartIndex, uint32_t &outNumParts);
     bool IncNumPartsCompleted();
 
     bool IsCompleted() const;
     const Aws::Crt::String &GetKey() const;
-    const Aws::Crt::String &GetUploadId() const;
     void GetETags(Aws::Crt::Vector<Aws::Crt::String> &outETags);
     uint32_t GetNumParts() const;
     uint32_t GetNumPartsRequested() const;
     uint32_t GetNumPartsCompleted() const;
     uint64_t GetObjectSize() const;
 
-    template <typename... TArgs> aws_input_stream *GetObjectPart(TArgs &&... Args) const
+    template <typename... TArgs> void ProcessPart(TArgs &&... Args) const
     {
-        return m_getObjectPartCallback(std::forward<TArgs>(Args)...);
+        m_processPartCallback(std::forward<TArgs>(Args)...);
     }
 
   private:
-    uint32_t m_isCompleted : 1;
     int32_t m_errorCode;
     uint32_t m_numParts;
+    std::atomic<bool> m_isCompleted;
     std::atomic<uint32_t> m_numPartsRequested;
     std::atomic<uint32_t> m_numPartsCompleted;
     uint64_t m_objectSize;
     Aws::Crt::String m_key;
-    Aws::Crt::String m_uploadId;
     Aws::Crt::Vector<Aws::Crt::String> m_etags;
-    aws_mutex m_completionMutex;
     aws_mutex m_etagsMutex;
-    GetObjectPartCallback m_getObjectPartCallback;
+    ProcessPartCallback m_processPartCallback;
     OnCompletedCallback m_onCompletedCallback;
 };

--- a/canary/S3ObjectTransport.cpp
+++ b/canary/S3ObjectTransport.cpp
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#include "S3ObjectTransport.h"
+
+#include <aws/crt/http/HttpConnectionManager.h>
+#include <aws/crt/http/HttpRequestResponse.h>
+#include <aws/io/stream.h>
+
+using namespace Aws::Crt;
+
+S3ObjectTransport::S3ObjectTransport(
+    const Aws::Crt::String &region,
+    const Aws::Crt::String &bucket,
+    Aws::Crt::Io::TlsContext &tlsContext,
+    Aws::Crt::Io::ClientBootstrap &clientBootstrap,
+    const std::shared_ptr<Aws::Crt::Auth::ICredentialsProvider> &credsProvider,
+    const std::shared_ptr<Aws::Crt::Auth::Sigv4HttpRequestSigner> &signer,
+    size_t maxCons)
+    : m_signer(signer), m_credsProvider(credsProvider), m_region(region), m_bucketName(bucket)
+{
+    Http::HttpClientConnectionManagerOptions connectionManagerOptions;
+    m_endpoint = m_bucketName + ".s3." + m_region + ".amazonaws.com";
+    connectionManagerOptions.ConnectionOptions.HostName = m_endpoint;
+    connectionManagerOptions.ConnectionOptions.Port = 443;
+    connectionManagerOptions.ConnectionOptions.SocketOptions.SetConnectTimeoutMs(3000);
+    connectionManagerOptions.ConnectionOptions.SocketOptions.SetSocketType(AWS_SOCKET_STREAM);
+    connectionManagerOptions.ConnectionOptions.InitialWindowSize = SIZE_MAX;
+
+    aws_byte_cursor serverName = ByteCursorFromCString(m_endpoint.c_str());
+
+    auto connOptions = tlsContext.NewConnectionOptions();
+    connOptions.SetServerName(serverName);
+    connectionManagerOptions.ConnectionOptions.TlsOptions = connOptions;
+    connectionManagerOptions.ConnectionOptions.Bootstrap = &clientBootstrap;
+    connectionManagerOptions.MaxConnections = maxCons;
+
+    m_connManager =
+        Http::HttpClientConnectionManager::NewClientConnectionManager(connectionManagerOptions, g_allocator);
+
+    m_hostHeader.name = ByteCursorFromCString("host");
+    m_hostHeader.value = ByteCursorFromCString(m_endpoint.c_str());
+
+    m_contentTypeHeader.name = ByteCursorFromCString("content-type");
+    m_contentTypeHeader.value = ByteCursorFromCString("text/plain");
+}
+
+void S3ObjectTransport::PutObject(
+    const Aws::Crt::String &key,
+    struct aws_input_stream *inputStream,
+    TransportOpCompleted transportOpCompleted)
+{
+    auto request = MakeShared<Http::HttpRequest>(g_allocator, g_allocator);
+    request->AddHeader(m_hostHeader);
+    request->AddHeader(m_contentTypeHeader);
+
+    Http::HttpHeader contentLength;
+    contentLength.name = ByteCursorFromCString("content-length");
+
+    int64_t streamLen = 0;
+
+    aws_input_stream_get_length(inputStream, &streamLen);
+    StringStream intValue;
+    intValue << streamLen;
+    String contentLengthVal = intValue.str();
+    contentLength.value = ByteCursorFromCString(contentLengthVal.c_str());
+    request->AddHeader(contentLength);
+
+    aws_http_message_set_body_stream(request->GetUnderlyingMessage(), inputStream);
+    request->SetMethod(aws_http_method_put);
+
+    String keyPath = "/" + key;
+    ByteCursor path = ByteCursorFromCString(keyPath.c_str());
+    request->SetPath(path);
+
+    auto signingConfig = MakeShared<Auth::AwsSigningConfig>(g_allocator, g_allocator);
+    signingConfig->SetRegion(m_region);
+    signingConfig->SetCredentialsProvider(m_credsProvider);
+    signingConfig->SetService("s3");
+    signingConfig->SetSignBody(false);
+    signingConfig->SetUseUnsignedPayloadHash(true);
+    signingConfig->SetSigningTimepoint(DateTime::Now());
+    signingConfig->SetSigningAlgorithm(Auth::SigningAlgorithm::SigV4Header);
+
+    m_signer->SignRequest(
+        request,
+        signingConfig,
+        [this,
+         transportOpCompleted](const std::shared_ptr<Aws::Crt::Http::HttpRequest> &signedRequest, int signingError) {
+            if (signingError == AWS_OP_SUCCESS)
+            {
+                m_connManager->AcquireConnection([signedRequest, transportOpCompleted](
+                                                     std::shared_ptr<Http::HttpClientConnection> conn, int connError) {
+                    if (connError == AWS_OP_SUCCESS)
+                    {
+                        Http::HttpRequestOptions requestOptions;
+                        AWS_ZERO_STRUCT(requestOptions);
+                        requestOptions.request = signedRequest.get();
+                        requestOptions.onStreamComplete =
+                            [signedRequest, conn, transportOpCompleted](Http::HttpStream &stream, int error) {
+                                int errorCode = error;
+
+                                if (!errorCode)
+                                {
+                                    errorCode = stream.GetResponseStatusCode() == 200 ? AWS_OP_SUCCESS : AWS_OP_ERR;
+                                }
+
+                                transportOpCompleted(errorCode);
+                            };
+                        conn->NewClientStream(requestOptions);
+                    }
+                    else
+                    {
+                        transportOpCompleted(connError);
+                    }
+                });
+            }
+            else
+            {
+                transportOpCompleted(signingError);
+            }
+        });
+}
+
+void S3ObjectTransport::GetObject(
+    const Aws::Crt::String &key,
+    Aws::Crt::Http::OnIncomingBody onIncomingBody,
+    TransportOpCompleted transportOpCompleted)
+{
+    auto request = MakeShared<Http::HttpRequest>(g_allocator, g_allocator);
+    request->AddHeader(m_hostHeader);
+
+    request->SetMethod(aws_http_method_get);
+
+    String keyPath = "/" + key;
+    ByteCursor path = ByteCursorFromCString(keyPath.c_str());
+    request->SetPath(path);
+
+    auto signingConfig = MakeShared<Auth::AwsSigningConfig>(g_allocator, g_allocator);
+    signingConfig->SetRegion(m_region);
+    signingConfig->SetCredentialsProvider(m_credsProvider);
+    signingConfig->SetService("s3");
+    signingConfig->SetSignBody(false);
+    signingConfig->SetUseUnsignedPayloadHash(true);
+    signingConfig->SetSigningTimepoint(DateTime::Now());
+    signingConfig->SetSigningAlgorithm(Auth::SigningAlgorithm::SigV4Header);
+
+    m_signer->SignRequest(
+        request,
+        signingConfig,
+        [this, onIncomingBody, transportOpCompleted](
+            const std::shared_ptr<Aws::Crt::Http::HttpRequest> &signedRequest, int signingError) {
+            if (signingError == AWS_OP_SUCCESS)
+            {
+                m_connManager->AcquireConnection([signedRequest, onIncomingBody, transportOpCompleted](
+                                                     std::shared_ptr<Http::HttpClientConnection> conn, int connError) {
+                    if (connError == AWS_OP_SUCCESS)
+                    {
+                        Http::HttpRequestOptions requestOptions;
+                        AWS_ZERO_STRUCT(requestOptions);
+                        requestOptions.request = signedRequest.get();
+                        requestOptions.onIncomingBody = onIncomingBody;
+                        requestOptions.onStreamComplete =
+                            [signedRequest, conn, transportOpCompleted](Http::HttpStream &stream, int error) {
+                                int errorCode = error;
+
+                                if (!errorCode)
+                                {
+                                    errorCode = stream.GetResponseStatusCode() == 200 ? AWS_OP_SUCCESS : AWS_OP_ERR;
+                                }
+
+                                transportOpCompleted(errorCode);
+                            };
+                        conn->NewClientStream(requestOptions);
+                    }
+                    else
+                    {
+                        transportOpCompleted(connError);
+                    }
+                });
+            }
+            else
+            {
+                transportOpCompleted(signingError);
+            }
+        });
+}

--- a/canary/S3ObjectTransport.cpp
+++ b/canary/S3ObjectTransport.cpp
@@ -14,9 +14,15 @@
  */
 #include "S3ObjectTransport.h"
 
+#include <aws/cal/hash.h>
+#include <aws/common/encoding.h>
+#include <aws/crt/external/tinyxml2.h>
 #include <aws/crt/http/HttpConnectionManager.h>
 #include <aws/crt/http/HttpRequestResponse.h>
+#include <aws/crt/io/stream.h>
 #include <aws/io/stream.h>
+
+#include <iostream>
 
 using namespace Aws::Crt;
 
@@ -54,33 +60,51 @@ S3ObjectTransport::S3ObjectTransport(
 
     m_contentTypeHeader.name = ByteCursorFromCString("content-type");
     m_contentTypeHeader.value = ByteCursorFromCString("text/plain");
+
+    m_upStreamsAvailable = MaxStreams;
+
+    aws_mutex_init(&m_upStreamsAvailableMutex);
+    aws_mutex_init(&m_multipartUploadQueueMutex);
+}
+
+S3ObjectTransport::~S3ObjectTransport()
+{
+    aws_mutex_clean_up(&m_upStreamsAvailableMutex);
+    aws_mutex_clean_up(&m_multipartUploadQueueMutex);
 }
 
 void S3ObjectTransport::PutObject(
     const Aws::Crt::String &key,
-    struct aws_input_stream *inputStream,
-    TransportOpCompleted transportOpCompleted)
+    aws_input_stream *inputStream,
+    uint32_t flags,
+    PutObjectCompleted completedCallback)
 {
     auto request = MakeShared<Http::HttpRequest>(g_allocator, g_allocator);
+
+    {
+        Http::HttpHeader contentLength;
+        contentLength.name = ByteCursorFromCString("content-length");
+
+        int64_t streamLen = 0;
+
+        aws_input_stream_get_length(inputStream, &streamLen);
+        StringStream intValue;
+        intValue << streamLen;
+        String contentLengthVal = intValue.str();
+        contentLength.value = ByteCursorFromCString(contentLengthVal.c_str());
+        request->AddHeader(contentLength);
+    }
+
     request->AddHeader(m_hostHeader);
     request->AddHeader(m_contentTypeHeader);
-
-    Http::HttpHeader contentLength;
-    contentLength.name = ByteCursorFromCString("content-length");
-
-    int64_t streamLen = 0;
-
-    aws_input_stream_get_length(inputStream, &streamLen);
-    StringStream intValue;
-    intValue << streamLen;
-    String contentLengthVal = intValue.str();
-    contentLength.value = ByteCursorFromCString(contentLengthVal.c_str());
-    request->AddHeader(contentLength);
 
     aws_http_message_set_body_stream(request->GetUnderlyingMessage(), inputStream);
     request->SetMethod(aws_http_method_put);
 
-    String keyPath = "/" + key;
+    StringStream keyPathStream;
+    keyPathStream << "/" << key;
+
+    String keyPath = keyPathStream.str();
     ByteCursor path = ByteCursorFromCString(keyPath.c_str());
     request->SetPath(path);
 
@@ -92,43 +116,118 @@ void S3ObjectTransport::PutObject(
     signingConfig.SetSigningTimepoint(DateTime::Now());
     signingConfig.SetSigningAlgorithm(Auth::SigningAlgorithm::SigV4Header);
 
+    AWS_LOGF_INFO(AWS_LS_COMMON_GENERAL, "PutObject initiated for path %s...", keyPath.c_str());
+
+    std::shared_ptr<Aws::Crt::String> etag = nullptr;
+
+    if ((flags & (uint32_t)EPutObjectFlags::RetrieveETag) != 0)
+    {
+        etag = std::make_shared<Aws::Crt::String>();
+    }
+
     m_signer->SignRequest(
         request,
         signingConfig,
-        [this,
-         transportOpCompleted](const std::shared_ptr<Aws::Crt::Http::HttpRequest> &signedRequest, int signingError) {
-            if (signingError == AWS_OP_SUCCESS)
+        [this, keyPath, inputStream, etag, completedCallback](
+            const std::shared_ptr<Aws::Crt::Http::HttpRequest> &signedRequest, int signingError) {
+            if (signingError != AWS_OP_SUCCESS)
             {
-                m_connManager->AcquireConnection([signedRequest, transportOpCompleted](
-                                                     std::shared_ptr<Http::HttpClientConnection> conn, int connError) {
-                    if (connError == AWS_OP_SUCCESS)
+                completedCallback(signingError, nullptr);
+                return;
+            }
+
+            m_connManager->AcquireConnection([signedRequest, keyPath, inputStream, etag, completedCallback](
+                                                 std::shared_ptr<Http::HttpClientConnection> conn, int connError) {
+                if (connError != AWS_OP_SUCCESS)
+                {
+                    completedCallback(connError, nullptr);
+                    return;
+                }
+
+                Http::HttpRequestOptions requestOptions;
+                AWS_ZERO_STRUCT(requestOptions);
+                requestOptions.request = signedRequest.get();
+                requestOptions.onIncomingHeaders = [etag](
+                                                       Http::HttpStream &stream,
+                                                       enum aws_http_header_block headerBlock,
+                                                       const Http::HttpHeader *headersArray,
+                                                       std::size_t headersCount) {
+                    (void)stream;
+                    (void)headerBlock;
+
+                    if (etag == nullptr)
                     {
-                        Http::HttpRequestOptions requestOptions;
-                        AWS_ZERO_STRUCT(requestOptions);
-                        requestOptions.request = signedRequest.get();
-                        requestOptions.onStreamComplete =
-                            [signedRequest, conn, transportOpCompleted](Http::HttpStream &stream, int error) {
-                                int errorCode = error;
+                        return;
+                    }
 
-                                if (!errorCode)
-                                {
-                                    errorCode = stream.GetResponseStatusCode() == 200 ? AWS_OP_SUCCESS : AWS_OP_ERR;
-                                }
+                    for (size_t i = 0; i < headersCount; ++i)
+                    {
+                        const aws_byte_cursor &name = headersArray[i].name;
 
-                                transportOpCompleted(errorCode);
-                            };
-                        conn->NewClientStream(requestOptions);
+                        if (aws_byte_cursor_eq_c_str(&name, "ETag"))
+                        {
+                            const aws_byte_cursor &value = headersArray[i].value;
+                            *etag = Aws::Crt::String((const char *)value.ptr, value.len);
+                        }
+                    }
+                };
+                requestOptions.onStreamComplete = [signedRequest, keyPath, inputStream, etag, conn, completedCallback](
+                                                      Http::HttpStream &stream, int error) {
+                    int errorCode = error;
+
+                    if (!errorCode)
+                    {
+                        errorCode = stream.GetResponseStatusCode() == 200 ? AWS_OP_SUCCESS : AWS_OP_ERR;
+
+                        AWS_LOGF_INFO(
+                            AWS_LS_COMMON_GENERAL,
+                            "PutObjectInternal completed for path %s with response status %d.",
+                            keyPath.c_str(),
+                            stream.GetResponseStatusCode());
                     }
                     else
                     {
-                        transportOpCompleted(connError);
+                        AWS_LOGF_INFO(
+                            AWS_LS_COMMON_GENERAL,
+                            "PutObjectInternal completed for path %s with error '%s'",
+                            keyPath.c_str(),
+                            aws_error_debug_str(errorCode));
                     }
-                });
-            }
-            else
+
+                    completedCallback(errorCode, etag);
+                };
+
+                conn->NewClientStream(requestOptions);
+            });
+        });
+}
+
+void S3ObjectTransport::PutObjectMultipart(
+    const Aws::Crt::String &key,
+    std::uint64_t objectSize,
+    MultipartTransferState::GetObjectPartCallback getObjectPart,
+    MultipartTransferState::OnCompletedCallback onCompleted)
+{
+    CreateMultipartUpload(
+        key,
+        [this, key, objectSize, getObjectPart, onCompleted](int errorCode, std::shared_ptr<Aws::Crt::String> uploadId) {
+            if (uploadId == nullptr || uploadId->empty())
             {
-                transportOpCompleted(signingError);
+                errorCode = AWS_OP_ERR;
             }
+
+            if (errorCode != AWS_OP_SUCCESS)
+            {
+                onCompleted(errorCode);
+                return;
+            }
+
+            std::shared_ptr<MultipartTransferState> uploadState = std::make_shared<MultipartTransferState>(
+                key, *uploadId, objectSize, GetNumParts(objectSize), getObjectPart, onCompleted);
+
+            PushMultipartUpload(uploadState);
+
+            UploadNextParts(0);
         });
 }
 
@@ -159,38 +258,484 @@ void S3ObjectTransport::GetObject(
         signingConfig,
         [this, onIncomingBody, transportOpCompleted](
             const std::shared_ptr<Aws::Crt::Http::HttpRequest> &signedRequest, int signingError) {
-            if (signingError == AWS_OP_SUCCESS)
+            if (signingError != AWS_OP_SUCCESS)
             {
-                m_connManager->AcquireConnection([signedRequest, onIncomingBody, transportOpCompleted](
-                                                     std::shared_ptr<Http::HttpClientConnection> conn, int connError) {
-                    if (connError == AWS_OP_SUCCESS)
+                transportOpCompleted(signingError);
+                return;
+            }
+
+            m_connManager->AcquireConnection([signedRequest, onIncomingBody, transportOpCompleted](
+                                                 std::shared_ptr<Http::HttpClientConnection> conn, int connError) {
+                if (connError != AWS_OP_SUCCESS)
+                {
+                    transportOpCompleted(connError);
+                    return;
+                }
+
+                Http::HttpRequestOptions requestOptions;
+                AWS_ZERO_STRUCT(requestOptions);
+                requestOptions.request = signedRequest.get();
+                requestOptions.onIncomingBody = onIncomingBody;
+                requestOptions.onStreamComplete =
+                    [signedRequest, conn, transportOpCompleted](Http::HttpStream &stream, int error) {
+                        int errorCode = error;
+
+                        if (!errorCode)
+                        {
+                            errorCode = stream.GetResponseStatusCode() == 200 ? AWS_OP_SUCCESS : AWS_OP_ERR;
+                        }
+
+                        transportOpCompleted(errorCode);
+                    };
+
+                conn->NewClientStream(requestOptions);
+            });
+        });
+}
+
+uint32_t S3ObjectTransport::GetNumParts(uint64_t objectSize) const
+{
+    uint64_t numParts = objectSize / MaxPartSizeBytes;
+
+    if ((objectSize % MaxPartSizeBytes) > 0)
+    {
+        ++numParts;
+    }
+
+    AWS_FATAL_ASSERT(numParts <= static_cast<uint64_t>(UINT32_MAX));
+
+    return static_cast<uint32_t>(numParts);
+}
+
+void S3ObjectTransport::CreateMultipartUpload(
+    const Aws::Crt::String &key,
+    CreateMultipartUploadCompleted completedCallback)
+{
+    auto createMultipartUploadRequest = MakeShared<Http::HttpRequest>(g_allocator, g_allocator);
+    createMultipartUploadRequest->AddHeader(m_hostHeader);
+    createMultipartUploadRequest->AddHeader(m_contentTypeHeader);
+    createMultipartUploadRequest->SetMethod(aws_http_method_post);
+
+    String keyPath = "/" + key + "?uploads";
+    ByteCursor path = ByteCursorFromCString(keyPath.c_str());
+    createMultipartUploadRequest->SetPath(path);
+
+    Auth::AwsSigningConfig signingConfig(g_allocator);
+    signingConfig.SetRegion(m_region);
+    signingConfig.SetCredentialsProvider(m_credsProvider);
+    signingConfig.SetService("s3");
+    signingConfig.SetBodySigningType(Auth::BodySigningType::UnsignedPayload);
+    signingConfig.SetSigningTimepoint(DateTime::Now());
+    signingConfig.SetSigningAlgorithm(Auth::SigningAlgorithm::SigV4Header);
+
+    AWS_LOGF_INFO(AWS_LS_COMMON_GENERAL, "Creating multipart upload for %s...", keyPath.c_str());
+
+    std::shared_ptr<Aws::Crt::String> uploadId = std::make_shared<Aws::Crt::String>();
+
+    m_signer->SignRequest(
+        createMultipartUploadRequest,
+        signingConfig,
+        [this, uploadId, keyPath, completedCallback](
+            const std::shared_ptr<Aws::Crt::Http::HttpRequest> &signedRequest, int signingError) {
+            if (signingError != AWS_OP_SUCCESS)
+            {
+                completedCallback(signingError, nullptr);
+                return;
+            }
+
+            m_connManager->AcquireConnection([uploadId, keyPath, signedRequest, completedCallback](
+                                                 std::shared_ptr<Http::HttpClientConnection> conn, int connError) {
+                if (connError != AWS_OP_SUCCESS)
+                {
+                    completedCallback(connError, nullptr);
+                    return;
+                }
+
+                Http::HttpRequestOptions requestOptions;
+                AWS_ZERO_STRUCT(requestOptions);
+                requestOptions.request = signedRequest.get();
+                requestOptions.onIncomingBody = [uploadId, keyPath](Http::HttpStream &stream, const ByteCursor &data) {
+                    (void)stream;
+
+                    tinyxml2::XMLDocument xmlDocument;
+                    tinyxml2::XMLError parseError = xmlDocument.Parse((const char *)data.ptr, data.len);
+
+                    if (parseError != tinyxml2::XML_SUCCESS)
                     {
-                        Http::HttpRequestOptions requestOptions;
-                        AWS_ZERO_STRUCT(requestOptions);
-                        requestOptions.request = signedRequest.get();
-                        requestOptions.onIncomingBody = onIncomingBody;
-                        requestOptions.onStreamComplete =
-                            [signedRequest, conn, transportOpCompleted](Http::HttpStream &stream, int error) {
-                                int errorCode = error;
+                        return;
+                    }
 
-                                if (!errorCode)
-                                {
-                                    errorCode = stream.GetResponseStatusCode() == 200 ? AWS_OP_SUCCESS : AWS_OP_ERR;
-                                }
+                    tinyxml2::XMLElement *rootElement = xmlDocument.RootElement();
 
-                                transportOpCompleted(errorCode);
-                            };
-                        conn->NewClientStream(requestOptions);
+                    if (rootElement == nullptr)
+                    {
+                        return;
+                    }
+
+                    tinyxml2::XMLElement *uploadIdElement = rootElement->FirstChildElement("UploadId");
+
+                    if (uploadIdElement == nullptr)
+                    {
+                        return;
                     }
                     else
                     {
-                        transportOpCompleted(connError);
+                        *uploadId = uploadIdElement->GetText();
                     }
-                });
+                };
+                requestOptions.onStreamComplete =
+                    [uploadId, keyPath, signedRequest, conn, completedCallback](Http::HttpStream &stream, int error) {
+                        int errorCode = error;
+
+                        if (!errorCode)
+                        {
+                            errorCode = stream.GetResponseStatusCode() == 200 ? AWS_OP_SUCCESS : AWS_OP_ERR;
+
+                            AWS_LOGF_INFO(
+                                AWS_LS_COMMON_GENERAL,
+                                "Created multipart upload for path %s with response status %d.",
+                                keyPath.c_str(),
+                                stream.GetResponseStatusCode());
+                        }
+                        else
+                        {
+                            AWS_LOGF_INFO(
+                                AWS_LS_COMMON_GENERAL,
+                                "Completed multipart upload for path %s with error '%s'",
+                                keyPath.c_str(),
+                                aws_error_debug_str(errorCode));
+                        }
+
+                        if (uploadId->empty())
+                        {
+                            errorCode = AWS_OP_ERR;
+                        }
+
+                        completedCallback(errorCode, uploadId);
+                    };
+
+                conn->NewClientStream(requestOptions);
+            });
+        });
+}
+
+void S3ObjectTransport::CompleteMultipartUpload(
+    const Aws::Crt::String &key,
+    const Aws::Crt::String &uploadId,
+    const Aws::Crt::Vector<Aws::Crt::String> &etags,
+    CompleteMultipartUploadCompleted completedCallback)
+{
+    AWS_LOGF_INFO(AWS_LS_COMMON_GENERAL, "Completing multipart upload for %s...", key.c_str());
+
+    auto completeMultipartUploadRequest = MakeShared<Http::HttpRequest>(g_allocator, g_allocator);
+    completeMultipartUploadRequest->AddHeader(m_hostHeader);
+    completeMultipartUploadRequest->SetMethod(aws_http_method_post);
+
+    std::shared_ptr<StringStream> xmlContents = std::make_shared<StringStream>();
+    *xmlContents << "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n";
+    *xmlContents << "<CompleteMultipartUpload xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\n";
+
+    for (int i = 0; i < etags.size(); ++i)
+    {
+        const Aws::Crt::String &etag = etags[i];
+        int partNumber = i + 1;
+
+        *xmlContents << "   <Part>\n";
+        *xmlContents << "       <ETag>" << etag << "</ETag>\n";
+        *xmlContents << "       <PartNumber>" << partNumber << "</PartNumber>\n";
+        *xmlContents << "   </Part>\n";
+    }
+
+    *xmlContents << "</CompleteMultipartUpload>";
+
+    aws_input_stream *inputStream = Aws::Crt::Io::AwsInputStreamNewCpp(xmlContents, aws_default_allocator());
+
+    {
+        int64_t streamLen = 0;
+        aws_input_stream_get_length(inputStream, &streamLen);
+        StringStream intValue;
+        intValue << streamLen;
+        String contentLengthVal = intValue.str();
+
+        Http::HttpHeader contentLength;
+        contentLength.name = ByteCursorFromCString("content-length");
+        contentLength.value = ByteCursorFromCString(contentLengthVal.c_str());
+
+        completeMultipartUploadRequest->AddHeader(contentLength);
+    }
+
+    aws_http_message_set_body_stream(completeMultipartUploadRequest->GetUnderlyingMessage(), inputStream);
+
+    StringStream keyPathStream;
+    keyPathStream << "/" << key << "?uploadId=" << uploadId;
+    String keyPath = keyPathStream.str();
+    ByteCursor path = ByteCursorFromCString(keyPath.c_str());
+    completeMultipartUploadRequest->SetPath(path);
+
+    Auth::AwsSigningConfig signingConfig(g_allocator);
+    signingConfig.SetRegion(m_region);
+    signingConfig.SetCredentialsProvider(m_credsProvider);
+    signingConfig.SetService("s3");
+    signingConfig.SetBodySigningType(Auth::BodySigningType::UnsignedPayload);
+    signingConfig.SetSigningTimepoint(DateTime::Now());
+    signingConfig.SetSigningAlgorithm(Auth::SigningAlgorithm::SigV4Header);
+
+    m_signer->SignRequest(
+        completeMultipartUploadRequest,
+        signingConfig,
+        [this, keyPath, completedCallback](
+            const std::shared_ptr<Aws::Crt::Http::HttpRequest> &signedRequest, int signingError) {
+            if (signingError != AWS_OP_SUCCESS)
+            {
+                completedCallback(signingError);
+                return;
+            }
+
+            m_connManager->AcquireConnection([keyPath, signedRequest, completedCallback](
+                                                 std::shared_ptr<Http::HttpClientConnection> conn, int connError) {
+                if (connError != AWS_OP_SUCCESS)
+                {
+                    completedCallback(connError);
+                    return;
+                }
+
+                Http::HttpRequestOptions requestOptions;
+                AWS_ZERO_STRUCT(requestOptions);
+                requestOptions.request = signedRequest.get();
+                requestOptions.onStreamComplete =
+                    [keyPath, signedRequest, conn, completedCallback](Http::HttpStream &stream, int error) {
+                        int errorCode = error;
+
+                        if (!errorCode)
+                        {
+                            errorCode = stream.GetResponseStatusCode() == 200 ? AWS_OP_SUCCESS : AWS_OP_ERR;
+
+                            AWS_LOGF_INFO(
+                                AWS_LS_COMMON_GENERAL,
+                                "Completed multipart upload for path %s with response status %d.",
+                                keyPath.c_str(),
+                                stream.GetResponseStatusCode());
+                        }
+                        else
+                        {
+                            AWS_LOGF_INFO(
+                                AWS_LS_COMMON_GENERAL,
+                                "Completed multipart upload for path %s with error '%s'",
+                                keyPath.c_str(),
+                                aws_error_debug_str(errorCode));
+                        }
+
+                        completedCallback(errorCode);
+                    };
+
+                conn->NewClientStream(requestOptions);
+            });
+        });
+}
+
+void S3ObjectTransport::AbortMultipartUpload(
+    const Aws::Crt::String &key,
+    const Aws::Crt::String &uploadId,
+    AbortMultipartUploadCompleted completedCallback)
+{
+    (void)uploadId;
+    (void)completedCallback;
+
+    AWS_LOGF_INFO(AWS_LS_COMMON_GENERAL, "Aborting multipart upload for %s...", key.c_str());
+
+    auto abortMultipartUploadRequest = MakeShared<Http::HttpRequest>(g_allocator, g_allocator);
+    abortMultipartUploadRequest->AddHeader(m_hostHeader);
+    abortMultipartUploadRequest->SetMethod(aws_http_method_delete);
+
+    String keyPath = "/" + key + "?uploadId=" + uploadId;
+    ByteCursor keyPathByteCursor = ByteCursorFromCString(keyPath.c_str());
+    abortMultipartUploadRequest->SetPath(keyPathByteCursor);
+
+    Auth::AwsSigningConfig signingConfig(g_allocator);
+    signingConfig.SetRegion(m_region);
+    signingConfig.SetCredentialsProvider(m_credsProvider);
+    signingConfig.SetService("s3");
+    signingConfig.SetBodySigningType(Auth::BodySigningType::UnsignedPayload);
+    signingConfig.SetSigningTimepoint(DateTime::Now());
+    signingConfig.SetSigningAlgorithm(Auth::SigningAlgorithm::SigV4Header);
+
+    m_signer->SignRequest(
+        abortMultipartUploadRequest,
+        signingConfig,
+        [this, uploadId, keyPath, completedCallback](
+            const std::shared_ptr<Aws::Crt::Http::HttpRequest> &signedRequest, int signingError) {
+            if (signingError != AWS_OP_SUCCESS)
+            {
+                completedCallback(signingError);
+                return;
+            }
+
+            m_connManager->AcquireConnection([uploadId, keyPath, signedRequest, completedCallback](
+                                                 std::shared_ptr<Http::HttpClientConnection> conn, int connError) {
+                if (connError != AWS_OP_SUCCESS)
+                {
+                    completedCallback(connError);
+                    return;
+                }
+
+                Http::HttpRequestOptions requestOptions;
+                AWS_ZERO_STRUCT(requestOptions);
+                requestOptions.request = signedRequest.get();
+                requestOptions.onStreamComplete =
+                    [uploadId, keyPath, signedRequest, conn, completedCallback](Http::HttpStream &stream, int error) {
+                        int errorCode = error;
+
+                        if (!errorCode)
+                        {
+                            errorCode = stream.GetResponseStatusCode() == 204 ? AWS_OP_SUCCESS : AWS_OP_ERR;
+
+                            AWS_LOGF_INFO(
+                                AWS_LS_COMMON_GENERAL,
+                                "Abort multipart upload for path %s with response status %d.",
+                                keyPath.c_str(),
+                                stream.GetResponseStatusCode());
+                        }
+                        else
+                        {
+                            AWS_LOGF_INFO(
+                                AWS_LS_COMMON_GENERAL,
+                                "Abort multipart upload for path %s with error '%s'",
+                                keyPath.c_str(),
+                                aws_error_debug_str(errorCode));
+                        }
+
+                        completedCallback(errorCode);
+                    };
+
+                conn->NewClientStream(requestOptions);
+            });
+        });
+}
+
+void S3ObjectTransport::UploadNextParts(uint32_t upStreamsReturning)
+{
+    UploadNextPartsForNextObject(upStreamsReturning);
+
+    while (UploadNextPartsForNextObject(0))
+    {
+    }
+}
+
+bool S3ObjectTransport::UploadNextPartsForNextObject(uint32_t upStreamsReturning)
+{
+    uint32_t startPartIndex = 0;
+    uint32_t numPartsToUpload = 0;
+    std::shared_ptr<MultipartTransferState> uploadState;
+
+    aws_mutex_lock(&m_upStreamsAvailableMutex);
+
+    m_upStreamsAvailable += upStreamsReturning;
+
+    if (m_upStreamsAvailable > 0)
+    {
+        bool searchingQueue = true;
+
+        // Find the next thing in the queue that needs parts uploaded, cleaning up the queue along the way.
+        while (searchingQueue)
+        {
+            uploadState = PeekMultipartUploadQueue();
+
+            if (uploadState == nullptr)
+            {
+                searchingQueue = false;
+            }
+            else if (uploadState->GetPartsForUpload(m_upStreamsAvailable, startPartIndex, numPartsToUpload))
+            {
+                m_upStreamsAvailable -= numPartsToUpload;
+                searchingQueue = false;
             }
             else
             {
-                transportOpCompleted(signingError);
+                PopMultipartUploadQueue();
             }
-        });
+        }
+    }
+
+    aws_mutex_unlock(&m_upStreamsAvailableMutex);
+
+    for (uint32_t i = 0; i < numPartsToUpload; ++i)
+    {
+        uint32_t partIndex = startPartIndex + i;
+        uint32_t partNumber = partIndex + 1;
+
+        uint64_t partByteStart = partIndex * S3ObjectTransport::MaxPartSizeBytes;
+        uint64_t partByteRemainder = uploadState->GetObjectSize() - (partIndex * S3ObjectTransport::MaxPartSizeBytes);
+        uint64_t partByteSize = min(partByteRemainder, S3ObjectTransport::MaxPartSizeBytes);
+
+        aws_input_stream *inputStream = uploadState->GetObjectPart(partByteStart, partByteSize);
+
+        StringStream keyPathStream;
+        keyPathStream << uploadState->GetKey() << "?partNumber=" << partNumber
+                      << "&uploadId=" << uploadState->GetUploadId();
+
+        // Do the actual uploading of the part
+        PutObject(
+            keyPathStream.str(),
+            inputStream,
+            (uint32_t)EPutObjectFlags::RetrieveETag,
+            [this, uploadState, partIndex](int errorCode, std::shared_ptr<Aws::Crt::String> etag) {
+                if (errorCode == AWS_OP_SUCCESS && etag != nullptr)
+                {
+                    uploadState->SetETag(partIndex, *etag);
+
+                    if (uploadState->IncNumPartsCompleted())
+                    {
+                        Aws::Crt::Vector<Aws::Crt::String> etags;
+                        uploadState->GetETags(etags);
+
+                        CompleteMultipartUpload(
+                            uploadState->GetKey(),
+                            uploadState->GetUploadId(),
+                            etags,
+                            [uploadState](int errorCode) { uploadState->SetCompleted(errorCode); });
+                    }
+                }
+                else
+                {
+                    AbortMultipartUpload(
+                        uploadState->GetKey(), uploadState->GetUploadId(), [](int errorCode) { (void)errorCode; });
+
+                    uploadState->SetCompleted(errorCode);
+                }
+
+                UploadNextParts(1);
+            });
+    }
+
+    return numPartsToUpload > 0;
+}
+
+void S3ObjectTransport::PushMultipartUpload(std::shared_ptr<MultipartTransferState> uploadState)
+{
+    aws_mutex_lock(&m_multipartUploadQueueMutex);
+    m_multipartUploadQueue.push(uploadState);
+    aws_mutex_unlock(&m_multipartUploadQueueMutex);
+}
+
+std::shared_ptr<MultipartTransferState> S3ObjectTransport::PeekMultipartUploadQueue()
+{
+    std::shared_ptr<MultipartTransferState> uploadState;
+
+    aws_mutex_lock(&m_multipartUploadQueueMutex);
+
+    if (m_multipartUploadQueue.size() > 0)
+    {
+        uploadState = m_multipartUploadQueue.front();
+    }
+
+    aws_mutex_unlock(&m_multipartUploadQueueMutex);
+
+    return uploadState;
+}
+
+void S3ObjectTransport::PopMultipartUploadQueue()
+{
+    aws_mutex_lock(&m_multipartUploadQueueMutex);
+    m_multipartUploadQueue.pop();
+    aws_mutex_unlock(&m_multipartUploadQueueMutex);
 }

--- a/canary/S3ObjectTransport.cpp
+++ b/canary/S3ObjectTransport.cpp
@@ -14,12 +14,14 @@
  */
 #include "S3ObjectTransport.h"
 
+#include <aws/common/thread.h>
+#include <aws/crt/Api.h>
 #include <aws/crt/external/tinyxml2.h>
 #include <aws/crt/http/HttpConnectionManager.h>
 #include <aws/crt/http/HttpRequestResponse.h>
 #include <aws/crt/io/Stream.h>
 #include <aws/io/stream.h>
-
+#include <inttypes.h>
 #include <iostream>
 
 #if defined(_WIN32)
@@ -29,7 +31,8 @@
 using namespace Aws::Crt;
 
 const uint64_t S3ObjectTransport::MaxPartSizeBytes = 10 * 1000 * 1000;
-const uint32_t S3ObjectTransport::MaxStreams = 10000;
+const uint32_t S3ObjectTransport::MaxStreams = 10;
+const int32_t S3ObjectTransport::S3GetObjectResponseStatus_PartialContent = 206;
 
 S3ObjectTransport::S3ObjectTransport(
     const Aws::Crt::String &region,
@@ -39,7 +42,8 @@ S3ObjectTransport::S3ObjectTransport(
     const std::shared_ptr<Aws::Crt::Auth::ICredentialsProvider> &credsProvider,
     const std::shared_ptr<Aws::Crt::Auth::Sigv4HttpRequestSigner> &signer,
     size_t maxCons)
-    : m_signer(signer), m_credsProvider(credsProvider), m_region(region), m_bucketName(bucket)
+    : m_signer(signer), m_credsProvider(credsProvider), m_region(region), m_bucketName(bucket),
+      m_uploadProcessor(S3ObjectTransport::MaxStreams), m_downloadProcessor(S3ObjectTransport::MaxStreams)
 {
     Http::HttpClientConnectionManagerOptions connectionManagerOptions;
     m_endpoint = m_bucketName + ".s3." + m_region + ".amazonaws.com";
@@ -65,17 +69,6 @@ S3ObjectTransport::S3ObjectTransport(
 
     m_contentTypeHeader.name = ByteCursorFromCString("content-type");
     m_contentTypeHeader.value = ByteCursorFromCString("text/plain");
-
-    m_upStreamsAvailable = MaxStreams;
-
-    aws_mutex_init(&m_upStreamsAvailableMutex);
-    aws_mutex_init(&m_multipartUploadQueueMutex);
-}
-
-S3ObjectTransport::~S3ObjectTransport()
-{
-    aws_mutex_clean_up(&m_upStreamsAvailableMutex);
-    aws_mutex_clean_up(&m_multipartUploadQueueMutex);
 }
 
 void S3ObjectTransport::PutObject(
@@ -121,7 +114,7 @@ void S3ObjectTransport::PutObject(
     signingConfig.SetSigningTimepoint(DateTime::Now());
     signingConfig.SetSigningAlgorithm(Auth::SigningAlgorithm::SigV4Header);
 
-    AWS_LOGF_INFO(AWS_LS_COMMON_GENERAL, "PutObject initiated for path %s...", keyPath.c_str());
+    AWS_LOGF_INFO(AWS_LS_CRT_CPP_CANARY, "PutObject initiated for path %s...", keyPath.c_str());
 
     std::shared_ptr<Aws::Crt::String> etag = nullptr;
 
@@ -182,21 +175,26 @@ void S3ObjectTransport::PutObject(
 
                         if (!errorCode)
                         {
-                            errorCode = stream.GetResponseStatusCode() == 200 ? AWS_OP_SUCCESS : AWS_OP_ERR;
+                            errorCode = (stream.GetResponseStatusCode() == 200) ? AWS_OP_SUCCESS : AWS_OP_ERR;
 
-                            AWS_LOGF_INFO(
-                                AWS_LS_COMMON_GENERAL,
-                                "PutObjectInternal completed for path %s with response status %d.",
+                            aws_log_level logLevel = (errorCode == AWS_OP_ERR) ? AWS_LL_ERROR : AWS_LL_INFO;
+
+                            AWS_LOGF(
+                                logLevel,
+                                AWS_LS_CRT_CPP_CANARY,
+                                "PutObject completed for path %s with response status %d on thread %" PRId64,
                                 keyPath.c_str(),
-                                stream.GetResponseStatusCode());
+                                stream.GetResponseStatusCode(),
+                                aws_thread_current_thread_id());
                         }
                         else
                         {
-                            AWS_LOGF_INFO(
-                                AWS_LS_COMMON_GENERAL,
-                                "PutObjectInternal completed for path %s with error '%s'",
+                            AWS_LOGF_ERROR(
+                                AWS_LS_CRT_CPP_CANARY,
+                                "PutObject completed for path %s with error '%s' on thread %" PRId64,
                                 keyPath.c_str(),
-                                aws_error_debug_str(errorCode));
+                                aws_error_debug_str(errorCode),
+                                aws_thread_current_thread_id());
                         }
 
                         completedCallback(errorCode, etag);
@@ -207,15 +205,18 @@ void S3ObjectTransport::PutObject(
         });
 }
 
-void S3ObjectTransport::PutObjectMultipart(
+uint32_t S3ObjectTransport::PutObjectMultipart(
     const Aws::Crt::String &key,
     std::uint64_t objectSize,
-    MultipartTransferState::GetObjectPartCallback getObjectPart,
-    MultipartTransferState::OnCompletedCallback onCompleted)
+    GetObjectPartCallback getObjectPart,
+    PutObjectMultipartCompleted onCompleted)
 {
+    uint32_t numParts = GetNumParts(objectSize);
+
     CreateMultipartUpload(
         key,
-        [this, key, objectSize, getObjectPart, onCompleted](int errorCode, std::shared_ptr<Aws::Crt::String> uploadId) {
+        [this, key, objectSize, numParts, getObjectPart, onCompleted](
+            int errorCode, std::shared_ptr<Aws::Crt::String> uploadId) {
             if (uploadId == nullptr || uploadId->empty())
             {
                 errorCode = AWS_OP_ERR;
@@ -223,30 +224,104 @@ void S3ObjectTransport::PutObjectMultipart(
 
             if (errorCode != AWS_OP_SUCCESS)
             {
-                onCompleted(errorCode);
+                onCompleted(errorCode, numParts);
                 return;
             }
 
             std::shared_ptr<MultipartTransferState> uploadState = std::make_shared<MultipartTransferState>(
-                key, *uploadId, objectSize, GetNumParts(objectSize), getObjectPart, onCompleted);
+                key,
+                objectSize,
+                numParts,
+                [this, uploadId, getObjectPart, onCompleted](
+                    std::shared_ptr<MultipartTransferState> state,
+                    const MultipartTransferState::PartInfo &partInfo,
+                    MultipartTransferState::PartFinishedCallback partFinished) {
+                    aws_input_stream *partInputStream = getObjectPart(partInfo);
+                    UploadPart(state, uploadId, partInfo, partInputStream, partFinished);
+                },
+                [numParts, onCompleted](int32_t errorCode) { onCompleted(errorCode, numParts); });
 
-            PushMultipartUpload(uploadState);
+            m_uploadProcessor.PushQueue(uploadState);
+        });
 
-            UploadNextParts(0);
+    return numParts;
+}
+
+void S3ObjectTransport::UploadPart(
+    const std::shared_ptr<MultipartTransferState> &state,
+    const std::shared_ptr<Aws::Crt::String> &uploadId,
+    const MultipartTransferState::PartInfo &partInfo,
+    aws_input_stream *partInputStream,
+    const MultipartTransferState::PartFinishedCallback &partFinished)
+{
+    StringStream keyPathStream;
+    keyPathStream << state->GetKey() << "?partNumber=" << partInfo.number << "&uploadId=" << *uploadId;
+
+    PutObject(
+        keyPathStream.str(),
+        partInputStream,
+        (uint32_t)EPutObjectFlags::RetrieveETag,
+        [this, uploadId, state, partInfo, partFinished](int errorCode, std::shared_ptr<Aws::Crt::String> etag) {
+            if (errorCode == AWS_OP_SUCCESS && etag != nullptr)
+            {
+                state->SetETag(partInfo.index, *etag);
+
+                if (state->IncNumPartsCompleted())
+                {
+                    Aws::Crt::Vector<Aws::Crt::String> etags;
+                    state->GetETags(etags);
+
+                    CompleteMultipartUpload(
+                        state->GetKey(), *uploadId, etags, [this, state, uploadId](int32_t errorCode) {
+                            if (errorCode != AWS_OP_SUCCESS)
+                            {
+                                AbortMultipartUpload(
+                                    state->GetKey(), *uploadId, [](int32_t errorCode) { (void)errorCode; });
+                            }
+                            state->SetCompleted(errorCode);
+                        });
+                }
+            }
+            else
+            {
+                AbortMultipartUpload(state->GetKey(), *uploadId, [](int32_t errorCode) { (void)errorCode; });
+
+                state->SetCompleted(errorCode);
+            }
+
+            AWS_LOGF_INFO(
+                AWS_LS_CRT_CPP_CANARY,
+                "UploadPart for path %s and part #%d (%d/%d) just returned code %d",
+                state->GetKey().c_str(),
+                partInfo.number,
+                state->GetNumPartsCompleted(),
+                state->GetNumParts(),
+                errorCode);
+
+            partFinished();
         });
 }
 
 void S3ObjectTransport::GetObject(
     const Aws::Crt::String &key,
+    uint32_t partNumber,
     Aws::Crt::Http::OnIncomingBody onIncomingBody,
-    TransportOpCompleted transportOpCompleted)
+    GetObjectCompleted getObjectCompleted)
 {
     auto request = MakeShared<Http::HttpRequest>(g_allocator, g_allocator);
     request->AddHeader(m_hostHeader);
 
     request->SetMethod(aws_http_method_get);
 
-    String keyPath = "/" + key;
+    StringStream keyPathStream;
+    keyPathStream << "/" << key;
+
+    if (partNumber > 0)
+    {
+        keyPathStream << "?partNumber=" << partNumber;
+    }
+
+    String keyPath = keyPathStream.str();
     ByteCursor path = ByteCursorFromCString(keyPath.c_str());
     request->SetPath(path);
 
@@ -261,19 +336,19 @@ void S3ObjectTransport::GetObject(
     m_signer->SignRequest(
         request,
         signingConfig,
-        [this, onIncomingBody, transportOpCompleted](
+        [this, keyPath, partNumber, onIncomingBody, getObjectCompleted](
             const std::shared_ptr<Aws::Crt::Http::HttpRequest> &signedRequest, int signingError) {
             if (signingError != AWS_OP_SUCCESS)
             {
-                transportOpCompleted(signingError);
+                getObjectCompleted(signingError);
                 return;
             }
 
-            m_connManager->AcquireConnection([signedRequest, onIncomingBody, transportOpCompleted](
+            m_connManager->AcquireConnection([signedRequest, keyPath, partNumber, onIncomingBody, getObjectCompleted](
                                                  std::shared_ptr<Http::HttpClientConnection> conn, int connError) {
                 if (connError != AWS_OP_SUCCESS)
                 {
-                    transportOpCompleted(connError);
+                    getObjectCompleted(connError);
                     return;
                 }
 
@@ -281,21 +356,91 @@ void S3ObjectTransport::GetObject(
                 AWS_ZERO_STRUCT(requestOptions);
                 requestOptions.request = signedRequest.get();
                 requestOptions.onIncomingBody = onIncomingBody;
-                requestOptions.onStreamComplete =
-                    [signedRequest, conn, transportOpCompleted](Http::HttpStream &stream, int error) {
-                        int errorCode = error;
+                requestOptions.onStreamComplete = [conn, signedRequest, keyPath, partNumber, getObjectCompleted](
+                                                      Http::HttpStream &stream, int error) {
+                    int errorCode = error;
 
-                        if (!errorCode)
-                        {
-                            errorCode = stream.GetResponseStatusCode() == 200 ? AWS_OP_SUCCESS : AWS_OP_ERR;
-                        }
+                    if (!errorCode)
+                    {
+                        int32_t successStatus = partNumber > 0 ? S3GetObjectResponseStatus_PartialContent : 200;
 
-                        transportOpCompleted(errorCode);
-                    };
+                        errorCode = (stream.GetResponseStatusCode() == successStatus) ? AWS_OP_SUCCESS : AWS_OP_ERR;
+
+                        aws_log_level logLevel = (errorCode == AWS_OP_ERR) ? AWS_LL_ERROR : AWS_LL_INFO;
+
+                        AWS_LOGF(
+                            logLevel,
+                            AWS_LS_CRT_CPP_CANARY,
+                            "GetObject completed for path %s with response status %d on thread %" PRId64,
+                            keyPath.c_str(),
+                            stream.GetResponseStatusCode(),
+                            aws_thread_current_thread_id());
+                    }
+                    else
+                    {
+                        AWS_LOGF_ERROR(
+                            AWS_LS_CRT_CPP_CANARY,
+                            "GetObject completed for path %s with error '%s' on thread %" PRId64,
+                            keyPath.c_str(),
+                            aws_error_debug_str(errorCode),
+                            aws_thread_current_thread_id());
+                    }
+
+                    getObjectCompleted(errorCode);
+                };
 
                 conn->NewClientStream(requestOptions);
             });
         });
+}
+
+void S3ObjectTransport::GetObjectMultipart(
+    const Aws::Crt::String &key,
+    std::uint32_t numParts,
+    ReceiveObjectPartDataCallback receiveObjectPartData,
+    GetObjectMultipartCompleted onCompleted)
+{
+    std::shared_ptr<MultipartTransferState> downloadState = std::make_shared<MultipartTransferState>(
+        key,
+        0L,
+        numParts,
+        [this, key, receiveObjectPartData](
+            std::shared_ptr<MultipartTransferState> state,
+            const MultipartTransferState::PartInfo &partInfo,
+            MultipartTransferState::PartFinishedCallback partFinished) {
+            GetObject(
+                key,
+                partInfo.number,
+                [state, partInfo, receiveObjectPartData](Http::HttpStream &stream, const ByteCursor &data) {
+                    (void)stream;
+
+                    receiveObjectPartData(partInfo, data);
+                },
+                [key, state, partInfo, partFinished](int32_t errorCode) {
+                    if (errorCode != AWS_OP_SUCCESS)
+                    {
+                        AWS_LOGF_ERROR(
+                            AWS_LS_CRT_CPP_CANARY, "Did not receive part #%d for %s", partInfo.number, key.c_str());
+
+                        state->SetCompleted(errorCode);
+                    }
+                    else
+                    {
+                        AWS_LOGF_INFO(AWS_LS_CRT_CPP_CANARY, "Received part #%d for %s", partInfo.number, key.c_str());
+
+                        if (state->IncNumPartsCompleted())
+                        {
+                            AWS_LOGF_INFO(AWS_LS_CRT_CPP_CANARY, "All parts received for %s", key.c_str());
+                            state->SetCompleted(AWS_OP_SUCCESS);
+                        }
+                    }
+
+                    partFinished();
+                });
+        },
+        [onCompleted](int32_t errorCode) { onCompleted(errorCode); });
+
+    m_downloadProcessor.PushQueue(downloadState);
 }
 
 uint32_t S3ObjectTransport::GetNumParts(uint64_t objectSize) const
@@ -333,7 +478,7 @@ void S3ObjectTransport::CreateMultipartUpload(
     signingConfig.SetSigningTimepoint(DateTime::Now());
     signingConfig.SetSigningAlgorithm(Auth::SigningAlgorithm::SigV4Header);
 
-    AWS_LOGF_INFO(AWS_LS_COMMON_GENERAL, "Creating multipart upload for %s...", keyPath.c_str());
+    AWS_LOGF_INFO(AWS_LS_CRT_CPP_CANARY, "Creating multipart upload for %s...", keyPath.c_str());
 
     std::shared_ptr<Aws::Crt::String> uploadId = std::make_shared<Aws::Crt::String>();
 
@@ -394,18 +539,21 @@ void S3ObjectTransport::CreateMultipartUpload(
 
                         if (!errorCode)
                         {
-                            errorCode = stream.GetResponseStatusCode() == 200 ? AWS_OP_SUCCESS : AWS_OP_ERR;
+                            errorCode = (stream.GetResponseStatusCode() == 200) ? AWS_OP_SUCCESS : AWS_OP_ERR;
 
-                            AWS_LOGF_INFO(
-                                AWS_LS_COMMON_GENERAL,
+                            aws_log_level logLevel = (errorCode == AWS_OP_ERR) ? AWS_LL_ERROR : AWS_LL_INFO;
+
+                            AWS_LOGF(
+                                logLevel,
+                                AWS_LS_CRT_CPP_CANARY,
                                 "Created multipart upload for path %s with response status %d.",
                                 keyPath.c_str(),
                                 stream.GetResponseStatusCode());
                         }
                         else
                         {
-                            AWS_LOGF_INFO(
-                                AWS_LS_COMMON_GENERAL,
+                            AWS_LOGF_ERROR(
+                                AWS_LS_CRT_CPP_CANARY,
                                 "Completed multipart upload for path %s with error '%s'",
                                 keyPath.c_str(),
                                 aws_error_debug_str(errorCode));
@@ -430,7 +578,7 @@ void S3ObjectTransport::CompleteMultipartUpload(
     const Aws::Crt::Vector<Aws::Crt::String> &etags,
     CompleteMultipartUploadCompleted completedCallback)
 {
-    AWS_LOGF_INFO(AWS_LS_COMMON_GENERAL, "Completing multipart upload for %s...", key.c_str());
+    AWS_LOGF_INFO(AWS_LS_CRT_CPP_CANARY, "Completing multipart upload for %s...", key.c_str());
 
     auto completeMultipartUploadRequest = MakeShared<Http::HttpRequest>(g_allocator, g_allocator);
     completeMultipartUploadRequest->AddHeader(m_hostHeader);
@@ -513,18 +661,21 @@ void S3ObjectTransport::CompleteMultipartUpload(
 
                         if (!errorCode)
                         {
-                            errorCode = stream.GetResponseStatusCode() == 200 ? AWS_OP_SUCCESS : AWS_OP_ERR;
+                            errorCode = (stream.GetResponseStatusCode() == 200) ? AWS_OP_SUCCESS : AWS_OP_ERR;
 
-                            AWS_LOGF_INFO(
-                                AWS_LS_COMMON_GENERAL,
+                            aws_log_level logLevel = (errorCode == AWS_OP_ERR) ? AWS_LL_ERROR : AWS_LL_INFO;
+
+                            AWS_LOGF(
+                                logLevel,
+                                AWS_LS_CRT_CPP_CANARY,
                                 "Completed multipart upload for path %s with response status %d.",
                                 keyPath.c_str(),
                                 stream.GetResponseStatusCode());
                         }
                         else
                         {
-                            AWS_LOGF_INFO(
-                                AWS_LS_COMMON_GENERAL,
+                            AWS_LOGF_ERROR(
+                                AWS_LS_CRT_CPP_CANARY,
                                 "Completed multipart upload for path %s with error '%s'",
                                 keyPath.c_str(),
                                 aws_error_debug_str(errorCode));
@@ -543,10 +694,7 @@ void S3ObjectTransport::AbortMultipartUpload(
     const Aws::Crt::String &uploadId,
     AbortMultipartUploadCompleted completedCallback)
 {
-    (void)uploadId;
-    (void)completedCallback;
-
-    AWS_LOGF_INFO(AWS_LS_COMMON_GENERAL, "Aborting multipart upload for %s...", key.c_str());
+    AWS_LOGF_INFO(AWS_LS_CRT_CPP_CANARY, "Aborting multipart upload for %s...", key.c_str());
 
     auto abortMultipartUploadRequest = MakeShared<Http::HttpRequest>(g_allocator, g_allocator);
     abortMultipartUploadRequest->AddHeader(m_hostHeader);
@@ -592,18 +740,21 @@ void S3ObjectTransport::AbortMultipartUpload(
 
                         if (!errorCode)
                         {
-                            errorCode = stream.GetResponseStatusCode() == 204 ? AWS_OP_SUCCESS : AWS_OP_ERR;
+                            errorCode = (stream.GetResponseStatusCode() == 204) ? AWS_OP_SUCCESS : AWS_OP_ERR;
 
-                            AWS_LOGF_INFO(
-                                AWS_LS_COMMON_GENERAL,
+                            aws_log_level logLevel = (errorCode == AWS_OP_ERR) ? AWS_LL_ERROR : AWS_LL_INFO;
+
+                            AWS_LOGF(
+                                logLevel,
+                                AWS_LS_CRT_CPP_CANARY,
                                 "Abort multipart upload for path %s with response status %d.",
                                 keyPath.c_str(),
                                 stream.GetResponseStatusCode());
                         }
                         else
                         {
-                            AWS_LOGF_INFO(
-                                AWS_LS_COMMON_GENERAL,
+                            AWS_LOGF_ERROR(
+                                AWS_LS_CRT_CPP_CANARY,
                                 "Abort multipart upload for path %s with error '%s'",
                                 keyPath.c_str(),
                                 aws_error_debug_str(errorCode));
@@ -615,131 +766,4 @@ void S3ObjectTransport::AbortMultipartUpload(
                 conn->NewClientStream(requestOptions);
             });
         });
-}
-
-void S3ObjectTransport::UploadNextParts(uint32_t upStreamsReturning)
-{
-    UploadNextPartsForNextObject(upStreamsReturning);
-
-    while (UploadNextPartsForNextObject(0))
-    {
-    }
-}
-
-bool S3ObjectTransport::UploadNextPartsForNextObject(uint32_t upStreamsReturning)
-{
-    uint32_t startPartIndex = 0;
-    uint32_t numPartsToUpload = 0;
-    std::shared_ptr<MultipartTransferState> uploadState;
-
-    aws_mutex_lock(&m_upStreamsAvailableMutex);
-
-    m_upStreamsAvailable += upStreamsReturning;
-
-    if (m_upStreamsAvailable > 0)
-    {
-        bool searchingQueue = true;
-
-        // Find the next thing in the queue that needs parts uploaded, cleaning up the queue along the way.
-        while (searchingQueue)
-        {
-            uploadState = PeekMultipartUploadQueue();
-
-            if (uploadState == nullptr)
-            {
-                searchingQueue = false;
-            }
-            else if (uploadState->GetPartsForUpload(m_upStreamsAvailable, startPartIndex, numPartsToUpload))
-            {
-                m_upStreamsAvailable -= numPartsToUpload;
-                searchingQueue = false;
-            }
-            else
-            {
-                PopMultipartUploadQueue();
-            }
-        }
-    }
-
-    aws_mutex_unlock(&m_upStreamsAvailableMutex);
-
-    for (uint32_t i = 0; i < numPartsToUpload; ++i)
-    {
-        uint32_t partIndex = startPartIndex + i;
-        uint32_t partNumber = partIndex + 1;
-
-        uint64_t partByteStart = partIndex * S3ObjectTransport::MaxPartSizeBytes;
-        uint64_t partByteRemainder = uploadState->GetObjectSize() - (partIndex * S3ObjectTransport::MaxPartSizeBytes);
-        uint64_t partByteSize = std::min(partByteRemainder, S3ObjectTransport::MaxPartSizeBytes);
-
-        aws_input_stream *inputStream = uploadState->GetObjectPart(partByteStart, partByteSize);
-
-        StringStream keyPathStream;
-        keyPathStream << uploadState->GetKey() << "?partNumber=" << partNumber
-                      << "&uploadId=" << uploadState->GetUploadId();
-
-        // Do the actual uploading of the part
-        PutObject(
-            keyPathStream.str(),
-            inputStream,
-            (uint32_t)EPutObjectFlags::RetrieveETag,
-            [this, uploadState, partIndex](int errorCode, std::shared_ptr<Aws::Crt::String> etag) {
-                if (errorCode == AWS_OP_SUCCESS && etag != nullptr)
-                {
-                    uploadState->SetETag(partIndex, *etag);
-
-                    if (uploadState->IncNumPartsCompleted())
-                    {
-                        Aws::Crt::Vector<Aws::Crt::String> etags;
-                        uploadState->GetETags(etags);
-
-                        CompleteMultipartUpload(
-                            uploadState->GetKey(), uploadState->GetUploadId(), etags, [uploadState](int errorCode) {
-                                uploadState->SetCompleted(errorCode);
-                            });
-                    }
-                }
-                else
-                {
-                    AbortMultipartUpload(
-                        uploadState->GetKey(), uploadState->GetUploadId(), [](int errorCode) { (void)errorCode; });
-
-                    uploadState->SetCompleted(errorCode);
-                }
-
-                UploadNextParts(1);
-            });
-    }
-
-    return numPartsToUpload > 0;
-}
-
-void S3ObjectTransport::PushMultipartUpload(std::shared_ptr<MultipartTransferState> uploadState)
-{
-    aws_mutex_lock(&m_multipartUploadQueueMutex);
-    m_multipartUploadQueue.push(uploadState);
-    aws_mutex_unlock(&m_multipartUploadQueueMutex);
-}
-
-std::shared_ptr<MultipartTransferState> S3ObjectTransport::PeekMultipartUploadQueue()
-{
-    std::shared_ptr<MultipartTransferState> uploadState;
-
-    aws_mutex_lock(&m_multipartUploadQueueMutex);
-
-    if (m_multipartUploadQueue.size() > 0)
-    {
-        uploadState = m_multipartUploadQueue.front();
-    }
-
-    aws_mutex_unlock(&m_multipartUploadQueueMutex);
-
-    return uploadState;
-}
-
-void S3ObjectTransport::PopMultipartUploadQueue()
-{
-    aws_mutex_lock(&m_multipartUploadQueueMutex);
-    m_multipartUploadQueue.pop();
-    aws_mutex_unlock(&m_multipartUploadQueueMutex);
 }

--- a/canary/S3ObjectTransport.cpp
+++ b/canary/S3ObjectTransport.cpp
@@ -84,14 +84,13 @@ void S3ObjectTransport::PutObject(
     ByteCursor path = ByteCursorFromCString(keyPath.c_str());
     request->SetPath(path);
 
-    auto signingConfig = MakeShared<Auth::AwsSigningConfig>(g_allocator, g_allocator);
-    signingConfig->SetRegion(m_region);
-    signingConfig->SetCredentialsProvider(m_credsProvider);
-    signingConfig->SetService("s3");
-    signingConfig->SetSignBody(false);
-    signingConfig->SetUseUnsignedPayloadHash(true);
-    signingConfig->SetSigningTimepoint(DateTime::Now());
-    signingConfig->SetSigningAlgorithm(Auth::SigningAlgorithm::SigV4Header);
+    Auth::AwsSigningConfig signingConfig(g_allocator);
+    signingConfig.SetRegion(m_region);
+    signingConfig.SetCredentialsProvider(m_credsProvider);
+    signingConfig.SetService("s3");
+    signingConfig.SetBodySigningType(Auth::BodySigningType::UnsignedPayload);
+    signingConfig.SetSigningTimepoint(DateTime::Now());
+    signingConfig.SetSigningAlgorithm(Auth::SigningAlgorithm::SigV4Header);
 
     m_signer->SignRequest(
         request,
@@ -147,14 +146,13 @@ void S3ObjectTransport::GetObject(
     ByteCursor path = ByteCursorFromCString(keyPath.c_str());
     request->SetPath(path);
 
-    auto signingConfig = MakeShared<Auth::AwsSigningConfig>(g_allocator, g_allocator);
-    signingConfig->SetRegion(m_region);
-    signingConfig->SetCredentialsProvider(m_credsProvider);
-    signingConfig->SetService("s3");
-    signingConfig->SetSignBody(false);
-    signingConfig->SetUseUnsignedPayloadHash(true);
-    signingConfig->SetSigningTimepoint(DateTime::Now());
-    signingConfig->SetSigningAlgorithm(Auth::SigningAlgorithm::SigV4Header);
+    Auth::AwsSigningConfig signingConfig(g_allocator);
+    signingConfig.SetRegion(m_region);
+    signingConfig.SetCredentialsProvider(m_credsProvider);
+    signingConfig.SetService("s3");
+    signingConfig.SetBodySigningType(Auth::BodySigningType::UnsignedPayload);
+    signingConfig.SetSigningTimepoint(DateTime::Now());
+    signingConfig.SetSigningAlgorithm(Auth::SigningAlgorithm::SigV4Header);
 
     m_signer->SignRequest(
         request,

--- a/canary/S3ObjectTransport.h
+++ b/canary/S3ObjectTransport.h
@@ -14,8 +14,8 @@
  */
 #pragma once
 
-#include <aws/common/mutex.h>
 #include <aws/common/condition_variable.h>
+#include <aws/common/mutex.h>
 #include <aws/crt/DateTime.h>
 #include <aws/crt/auth/Sigv4Signing.h>
 #include <aws/crt/http/HttpConnectionManager.h>
@@ -38,8 +38,8 @@ enum class EPutObjectFlags : uint32_t
 class S3ObjectTransport
 {
   public:
-    static const uint64_t MaxPartSizeBytes = 10 * 1000 * 1000;
-    static const uint32_t MaxStreams = 10000;
+    static const uint64_t MaxPartSizeBytes;
+    static const uint32_t MaxStreams;
 
     S3ObjectTransport(
         const Aws::Crt::String &region,
@@ -100,13 +100,15 @@ class S3ObjectTransport
         const Aws::Crt::Vector<Aws::Crt::String> &etags,
         CompleteMultipartUploadCompleted completedCallback);
 
-    void AbortMultipartUpload(const Aws::Crt::String & key, const Aws::Crt::String &uploadId, AbortMultipartUploadCompleted completedCallback);
+    void AbortMultipartUpload(
+        const Aws::Crt::String &key,
+        const Aws::Crt::String &uploadId,
+        AbortMultipartUploadCompleted completedCallback);
 
     void UploadNextParts(uint32_t upStreamsReturning);
     bool UploadNextPartsForNextObject(uint32_t upStreamsReturning);
-    
+
     void PushMultipartUpload(std::shared_ptr<MultipartTransferState> uploadState);
     std::shared_ptr<MultipartTransferState> PeekMultipartUploadQueue();
     void PopMultipartUploadQueue();
-
 };

--- a/canary/S3ObjectTransport.h
+++ b/canary/S3ObjectTransport.h
@@ -25,15 +25,15 @@
 #include "MultipartTransferProcessor.h"
 #include "MultipartTransferState.h"
 
-using GetObjectCompleted = std::function<void(int32_t errorCode)>;
-using PutObjectCompleted = std::function<void(int32_t errorCode, std::shared_ptr<Aws::Crt::String> etag)>;
+using GetObjectFinished = std::function<void(int32_t errorCode)>;
+using PutObjectFinished = std::function<void(int32_t errorCode, std::shared_ptr<Aws::Crt::String> etag)>;
 
-using PutObjectMultipartCompleted = std::function<void(int32_t errorCode, uint32_t numParts)>;
-using GetObjectMultipartCompleted = std::function<void(int32_t errorCode)>;
+using PutObjectMultipartFinished = std::function<void(int32_t errorCode, uint32_t numParts)>;
+using GetObjectMultipartFinished = std::function<void(int32_t errorCode)>;
 
-using GetObjectPartCallback =
-    std::function<struct aws_input_stream *(const MultipartTransferState::PartInfo &partInfo)>;
-using ReceiveObjectPartDataCallback =
+// Note: Any stream returned here will be cleaned up by the caller.
+using SendPartCallback = std::function<struct aws_input_stream *(const MultipartTransferState::PartInfo &partInfo)>;
+using ReceivePartCallback =
     std::function<void(const MultipartTransferState::PartInfo &partInfo, const Aws::Crt::ByteCursor &data)>;
 
 struct aws_allocator;
@@ -50,45 +50,46 @@ class S3ObjectTransport
     static const uint64_t MaxPartSizeBytes;
     static const uint32_t MaxStreams;
     static const int32_t S3GetObjectResponseStatus_PartialContent;
+    static const bool SingleConnectionPerMultipartUpload;
 
     S3ObjectTransport(
+        Aws::Crt::Io::EventLoopGroup &elGroup,
         const Aws::Crt::String &region,
         const Aws::Crt::String &bucket,
         Aws::Crt::Io::TlsContext &tlsContext,
         Aws::Crt::Io::ClientBootstrap &clientBootstrap,
         const std::shared_ptr<Aws::Crt::Auth::ICredentialsProvider> &credsProvider,
-        const std::shared_ptr<Aws::Crt::Auth::Sigv4HttpRequestSigner> &signer,
-        size_t maxCons = 1000);
+        const std::shared_ptr<Aws::Crt::Auth::Sigv4HttpRequestSigner> &signer);
 
+    // Note: PutObject is responsible for making sure that inputStream will be cleaned up.
     void PutObject(
         const Aws::Crt::String &key,
         struct aws_input_stream *inputStream,
-        uint32_t flags,
-        PutObjectCompleted onCompleted);
+        const PutObjectFinished &finishedCallback);
 
-    uint32_t PutObjectMultipart(
+    void PutObjectMultipart(
         const Aws::Crt::String &key,
         std::uint64_t objectSize,
-        GetObjectPartCallback getObjectPart,
-        PutObjectMultipartCompleted onCompleted);
+        SendPartCallback sendPart,
+        const PutObjectMultipartFinished &finishedCallback);
 
     void GetObject(
         const Aws::Crt::String &key,
-        std::uint32_t partNumber,
         Aws::Crt::Http::OnIncomingBody onIncomingBody,
-        GetObjectCompleted getObjectCompleted);
+        const GetObjectFinished &getObjectFinished);
 
     void GetObjectMultipart(
         const Aws::Crt::String &key,
         std::uint32_t numParts,
-        ReceiveObjectPartDataCallback receiveObjectPart,
-        GetObjectMultipartCompleted onCompleted);
+        const ReceivePartCallback &receivePart,
+        const GetObjectMultipartFinished &finishedCallback);
 
   private:
-    using CreateMultipartUploadCompleted =
-        std::function<void(int32_t error, std::shared_ptr<Aws::Crt::String> uploadId)>;
-    using CompleteMultipartUploadCompleted = std::function<void(int32_t error)>;
-    using AbortMultipartUploadCompleted = std::function<void(int32_t error)>;
+    using CreateMultipartUploadFinished = std::function<void(int32_t error, const Aws::Crt::String &uploadId)>;
+    using CompleteMultipartUploadFinished = std::function<void(int32_t error)>;
+    using AbortMultipartUploadFinished = std::function<void(int32_t error)>;
+
+    using ErrorCallback = std::function<void(int32_t errorCode)>;
 
     std::shared_ptr<Aws::Crt::Http::HttpClientConnectionManager> m_connManager;
     std::shared_ptr<Aws::Crt::Auth::Sigv4HttpRequestSigner> m_signer;
@@ -102,25 +103,60 @@ class S3ObjectTransport
     MultipartTransferProcessor m_uploadProcessor;
     MultipartTransferProcessor m_downloadProcessor;
 
-    uint32_t GetNumParts(uint64_t objectSize) const;
-
-    void CreateMultipartUpload(const Aws::Crt::String &key, CreateMultipartUploadCompleted completedCallback);
-
-    void CompleteMultipartUpload(
+    void PutObject(
+        const std::shared_ptr<Aws::Crt::Http::HttpClientConnection> &conn,
         const Aws::Crt::String &key,
-        const Aws::Crt::String &uploadId,
-        const Aws::Crt::Vector<Aws::Crt::String> &etags,
-        CompleteMultipartUploadCompleted completedCallback);
-
-    void AbortMultipartUpload(
-        const Aws::Crt::String &key,
-        const Aws::Crt::String &uploadId,
-        AbortMultipartUploadCompleted completedCallback);
+        struct aws_input_stream *inputStream,
+        uint32_t flags,
+        const PutObjectFinished &onFinished);
 
     void UploadPart(
-        const std::shared_ptr<MultipartTransferState> &state,
-        const std::shared_ptr<Aws::Crt::String> &uploadId,
+        const std::shared_ptr<MultipartUploadState> &state,
         const MultipartTransferState::PartInfo &partInfo,
         aws_input_stream *partInputStream,
         const MultipartTransferState::PartFinishedCallback &partFinished);
+
+    void GetObject(
+        const std::shared_ptr<Aws::Crt::Http::HttpClientConnection> &conn,
+        const Aws::Crt::String &key,
+        std::uint32_t partNumber,
+        Aws::Crt::Http::OnIncomingBody onIncomingBody,
+        const GetObjectFinished &getObjectFinished);
+
+    void GetPart(
+        std::shared_ptr<MultipartDownloadState> downloadState,
+        const MultipartTransferState::PartInfo &partInfo,
+        const ReceivePartCallback &receiveObjectPartData,
+        const MultipartTransferState::PartFinishedCallback &partFinished);
+
+    uint32_t GetNumParts(uint64_t objectSize) const;
+
+    void MakeSignedRequest(
+        const std::shared_ptr<Aws::Crt::Http::HttpClientConnection> &existingConn,
+        const std::shared_ptr<Aws::Crt::Http::HttpRequest> &request,
+        const Aws::Crt::Http::HttpRequestOptions &requestOptions,
+        ErrorCallback errorCallback);
+
+    void MakeSignedRequest_SendRequest(
+        const std::shared_ptr<Aws::Crt::Http::HttpClientConnection> &conn,
+        const Aws::Crt::Http::HttpRequestOptions &requestOptions,
+        const std::shared_ptr<Aws::Crt::Http::HttpRequest> &signedRequest);
+
+    void CreateMultipartUpload(
+        const std::shared_ptr<Aws::Crt::Http::HttpClientConnection> &conn,
+        const Aws::Crt::String &key,
+        const CreateMultipartUploadFinished &finishedCallback);
+
+    void CompleteMultipartUpload(
+        const std::shared_ptr<Aws::Crt::Http::HttpClientConnection> &conn,
+        const Aws::Crt::String &key,
+        const Aws::Crt::String &uploadId,
+        const Aws::Crt::Vector<Aws::Crt::String> &etags,
+        const CompleteMultipartUploadFinished &finishedCallback);
+
+    void AbortMultipartUpload(
+        const std::shared_ptr<Aws::Crt::Http::HttpClientConnection> &conn,
+        const Aws::Crt::String &key,
+        const Aws::Crt::String &uploadId,
+        const AbortMultipartUploadFinished &finishedCallback);
 };

--- a/canary/S3ObjectTransport.h
+++ b/canary/S3ObjectTransport.h
@@ -12,15 +12,35 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+#pragma once
+
+#include <aws/common/mutex.h>
+#include <aws/common/condition_variable.h>
 #include <aws/crt/DateTime.h>
 #include <aws/crt/auth/Sigv4Signing.h>
 #include <aws/crt/http/HttpConnectionManager.h>
 
+#include <queue>
+
+#include "MultipartTransferState.h"
+
 using TransportOpCompleted = std::function<void(int errorCode)>;
+using PutObjectCompleted = std::function<void(int errorCode, std::shared_ptr<Aws::Crt::String> etag)>;
+
+struct aws_allocator;
+struct aws_event_loop;
+
+enum class EPutObjectFlags : uint32_t
+{
+    RetrieveETag = 0x00000001
+};
 
 class S3ObjectTransport
 {
   public:
+    static const uint64_t MaxPartSizeBytes = 10 * 1000 * 1000;
+    static const uint32_t MaxStreams = 10000;
+
     S3ObjectTransport(
         const Aws::Crt::String &region,
         const Aws::Crt::String &bucket,
@@ -30,16 +50,31 @@ class S3ObjectTransport
         const std::shared_ptr<Aws::Crt::Auth::Sigv4HttpRequestSigner> &signer,
         size_t maxCons = 1000);
 
+    ~S3ObjectTransport();
+
     void PutObject(
         const Aws::Crt::String &key,
         struct aws_input_stream *inputStream,
-        TransportOpCompleted transportOpCompleted);
+        uint32_t flags,
+        PutObjectCompleted completedCallback);
+
+    void PutObjectMultipart(
+        const Aws::Crt::String &key,
+        std::uint64_t objectSize,
+        MultipartTransferState::GetObjectPartCallback getObjectPart,
+        MultipartTransferState::OnCompletedCallback onCompleted);
+
     void GetObject(
         const Aws::Crt::String &key,
         Aws::Crt::Http::OnIncomingBody onIncomingBody,
         TransportOpCompleted transportOpCompleted);
 
   private:
+    using CreateMultipartUploadCompleted =
+        std::function<void(int32_t error, std::shared_ptr<Aws::Crt::String> uploadId)>;
+    using CompleteMultipartUploadCompleted = std::function<void(int32_t error)>;
+    using AbortMultipartUploadCompleted = std::function<void(int32_t error)>;
+
     std::shared_ptr<Aws::Crt::Http::HttpClientConnectionManager> m_connManager;
     std::shared_ptr<Aws::Crt::Auth::Sigv4HttpRequestSigner> m_signer;
     std::shared_ptr<Aws::Crt::Auth::ICredentialsProvider> m_credsProvider;
@@ -48,4 +83,30 @@ class S3ObjectTransport
     Aws::Crt::Http::HttpHeader m_hostHeader;
     Aws::Crt::Http::HttpHeader m_contentTypeHeader;
     Aws::Crt::String m_endpoint;
+
+    uint32_t m_upStreamsAvailable;
+    aws_mutex m_upStreamsAvailableMutex;
+    aws_mutex m_multipartUploadQueueMutex;
+
+    std::queue<std::shared_ptr<MultipartTransferState>> m_multipartUploadQueue;
+
+    uint32_t GetNumParts(uint64_t objectSize) const;
+
+    void CreateMultipartUpload(const Aws::Crt::String &key, CreateMultipartUploadCompleted completedCallback);
+
+    void CompleteMultipartUpload(
+        const Aws::Crt::String &key,
+        const Aws::Crt::String &uploadId,
+        const Aws::Crt::Vector<Aws::Crt::String> &etags,
+        CompleteMultipartUploadCompleted completedCallback);
+
+    void AbortMultipartUpload(const Aws::Crt::String & key, const Aws::Crt::String &uploadId, AbortMultipartUploadCompleted completedCallback);
+
+    void UploadNextParts(uint32_t upStreamsReturning);
+    bool UploadNextPartsForNextObject(uint32_t upStreamsReturning);
+    
+    void PushMultipartUpload(std::shared_ptr<MultipartTransferState> uploadState);
+    std::shared_ptr<MultipartTransferState> PeekMultipartUploadQueue();
+    void PopMultipartUploadQueue();
+
 };

--- a/canary/S3ObjectTransport.h
+++ b/canary/S3ObjectTransport.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#include <aws/crt/DateTime.h>
+#include <aws/crt/auth/Sigv4Signing.h>
+#include <aws/crt/http/HttpConnectionManager.h>
+
+using TransportOpCompleted = std::function<void(int errorCode)>;
+
+class S3ObjectTransport
+{
+  public:
+    S3ObjectTransport(
+        const Aws::Crt::String &region,
+        const Aws::Crt::String &bucket,
+        Aws::Crt::Io::TlsContext &tlsContext,
+        Aws::Crt::Io::ClientBootstrap &clientBootstrap,
+        const std::shared_ptr<Aws::Crt::Auth::ICredentialsProvider> &credsProvider,
+        const std::shared_ptr<Aws::Crt::Auth::Sigv4HttpRequestSigner> &signer,
+        size_t maxCons = 1000);
+
+    void PutObject(
+        const Aws::Crt::String &key,
+        struct aws_input_stream *inputStream,
+        TransportOpCompleted transportOpCompleted);
+    void GetObject(
+        const Aws::Crt::String &key,
+        Aws::Crt::Http::OnIncomingBody onIncomingBody,
+        TransportOpCompleted transportOpCompleted);
+
+  private:
+    std::shared_ptr<Aws::Crt::Http::HttpClientConnectionManager> m_connManager;
+    std::shared_ptr<Aws::Crt::Auth::Sigv4HttpRequestSigner> m_signer;
+    std::shared_ptr<Aws::Crt::Auth::ICredentialsProvider> m_credsProvider;
+    const Aws::Crt::String m_region;
+    const Aws::Crt::String m_bucketName;
+    Aws::Crt::Http::HttpHeader m_hostHeader;
+    Aws::Crt::Http::HttpHeader m_contentTypeHeader;
+    Aws::Crt::String m_endpoint;
+};

--- a/canary/main.cpp
+++ b/canary/main.cpp
@@ -13,19 +13,122 @@
  * permissions and limitations under the License.
  */
 
+#include "MetricsPublisher.h"
+#include "S3ObjectTransport.h"
+#include <aws/common/system_info.h>
 #include <aws/crt/Api.h>
 #include <aws/crt/auth/Credentials.h>
-#include "MetricsPublisher.h"
+#include <aws/io/stream.h>
 
 using namespace Aws::Crt;
 
-int main() {
+static const char s_BodyTemplate[] =
+    "This is a test string for use with canary testing against Amazon Simple Storage Service";
+static size_t s_defaultObjSize = 16 * 1024 * 1024;
+
+struct TemplateStream
+{
+    aws_input_stream inputStream;
+    MetricsPublisher *publisher;
+    size_t length;
+    size_t written;
+};
+
+static int s_templateStreamRead(struct aws_input_stream *stream, struct aws_byte_buf *dest)
+{
+    auto templateStream = static_cast<TemplateStream *>(stream->impl);
+
+    size_t totalBufferSpace = dest->capacity - dest->len;
+    size_t unwritten = templateStream->length - templateStream->written;
+    size_t totalToWrite = totalBufferSpace > unwritten ? unwritten : totalBufferSpace;
+    size_t writtenOut = 0;
+
+    while (totalToWrite)
+    {
+        size_t toWrite =
+            AWS_ARRAY_SIZE(s_BodyTemplate) - 1 > totalToWrite ? totalToWrite : AWS_ARRAY_SIZE(s_BodyTemplate) - 1;
+        ByteCursor outCur = ByteCursorFromArray((const uint8_t *)s_BodyTemplate, toWrite);
+        aws_byte_buf_append(dest, &outCur);
+        writtenOut += toWrite;
+        totalToWrite = totalToWrite - toWrite;
+    }
+
+    templateStream->written += writtenOut;
+
+    if (templateStream->length == templateStream->written)
+    {
+        Metric uploadMetric;
+        uploadMetric.MetricName = "BytesUp";
+        uploadMetric.Timestamp = DateTime::Now();
+        uploadMetric.Value = (double)templateStream->length;
+        uploadMetric.Unit = MetricUnit::Bytes;
+
+        templateStream->publisher->AddDataPoint(uploadMetric);
+    }
+
+    return AWS_OP_SUCCESS;
+}
+
+static int s_templateStreamGetStatus(struct aws_input_stream *stream, struct aws_stream_status *status)
+{
+    auto templateStream = static_cast<TemplateStream *>(stream->impl);
+
+    status->is_end_of_stream = templateStream->written == templateStream->length;
+    status->is_valid = !status->is_end_of_stream;
+
+    return AWS_OP_SUCCESS;
+}
+
+static int s_templateStreamSeek(struct aws_input_stream *stream, aws_off_t offset, enum aws_stream_seek_basis basis)
+{
+    (void)offset;
+    (void)basis;
+
+    auto templateStream = static_cast<TemplateStream *>(stream->impl);
+    templateStream->written = 0;
+    return AWS_OP_SUCCESS;
+}
+
+static int s_templateStreamGetLength(struct aws_input_stream *stream, int64_t *length)
+{
+    auto templateStream = static_cast<TemplateStream *>(stream->impl);
+    *length = templateStream->length;
+    return AWS_OP_SUCCESS;
+}
+
+static void s_templateStreamDestroy(struct aws_input_stream *stream)
+{
+    auto templateStream = static_cast<TemplateStream *>(stream->impl);
+    Delete(templateStream, stream->allocator);
+}
+
+static struct aws_input_stream_vtable s_templateStreamVTable = {s_templateStreamSeek,
+                                                                s_templateStreamRead,
+                                                                s_templateStreamGetStatus,
+                                                                s_templateStreamGetLength,
+                                                                s_templateStreamDestroy};
+
+static aws_input_stream *s_createTemplateStream(Allocator *alloc, MetricsPublisher *publisher, size_t length)
+{
+    auto templateStream = New<TemplateStream>(alloc);
+    templateStream->publisher = publisher;
+    templateStream->length = length;
+    templateStream->written = 0;
+    templateStream->inputStream.allocator = alloc;
+    templateStream->inputStream.impl = templateStream;
+    templateStream->inputStream.vtable = &s_templateStreamVTable;
+
+    return &templateStream->inputStream;
+}
+
+int main()
+{
     Allocator *traceAllocator = aws_mem_tracer_new(DefaultAllocator(), NULL, AWS_MEMTRACE_BYTES, 0);
     ApiHandle apiHandle(traceAllocator);
-    apiHandle.InitializeLogging(LogLevel::Trace, stderr);
+    // apiHandle.InitializeLogging(LogLevel::Trace, stderr);
 
     Io::EventLoopGroup eventLoopGroup(traceAllocator);
-    Io::DefaultHostResolver defaultHostResolver(eventLoopGroup, 2, 1000, traceAllocator);
+    Io::DefaultHostResolver defaultHostResolver(eventLoopGroup, 60, 1000, traceAllocator);
     Io::ClientBootstrap bootstrap(eventLoopGroup, defaultHostResolver, traceAllocator);
 
     auto contextOptions = Io::TlsContextOptions::InitDefaultClient(traceAllocator);
@@ -40,13 +143,92 @@ int main() {
     MetricsPublisher publisher("us-west-2", tlsContext, bootstrap, eventLoopGroup, credsProvider, signer);
     publisher.Namespace = "CRT-CPP-Canary";
 
-    while (true) {
-        Metric metric;
-        metric.Unit = MetricUnit::Count;
-        metric.Value = 1;
-        metric.Timestamp = DateTime::Now();
-        metric.MetricName = "LoopIteration";
-        publisher.AddDataPoint(metric);
+    size_t threadCount = aws_system_info_processor_count();
+    size_t maxInFlight = threadCount * 10;
+    S3ObjectTransport transport(
+        "us-west-2", "aws-crt-canary-bucket", tlsContext, bootstrap, credsProvider, signer, maxInFlight);
+
+    bool shouldContinue = true;
+    uint64_t counter = INT64_MAX;
+    std::atomic<size_t> inFlight(0);
+
+    while (shouldContinue)
+    {
+
+        if (counter == 0)
+        {
+            counter = INT64_MAX;
+        }
+
+        while (inFlight < maxInFlight)
+        {
+            StringStream keyStream;
+            keyStream << "crt-canary-obj-" << counter--;
+            inFlight += 1;
+            auto key = keyStream.str();
+            transport.PutObject(
+                key, s_createTemplateStream(traceAllocator, &publisher, s_defaultObjSize), [&, key](int errorCode) {
+                    if (errorCode == AWS_OP_SUCCESS)
+                    {
+                        Metric successMetric;
+                        successMetric.MetricName = "SuccessfulTransfer";
+                        successMetric.Unit = MetricUnit::Count;
+                        successMetric.Value = 1;
+                        successMetric.Timestamp = DateTime::Now();
+
+                        publisher.AddDataPoint(successMetric);
+
+                        auto downMetric = New<Metric>(g_allocator);
+                        downMetric->MetricName = "BytesDown";
+                        downMetric->Unit = MetricUnit::Bytes;
+
+                        transport.GetObject(
+                            key,
+                            [&, downMetric](Http::HttpStream &, const ByteCursor &cur) {
+                                downMetric->Value += (double)cur.len;
+                            },
+                            [&, downMetric](int errorCode) {
+                                if (errorCode == AWS_OP_SUCCESS)
+                                {
+                                    Metric successMetric;
+                                    successMetric.MetricName = "SuccessfulTransfer";
+                                    successMetric.Unit = MetricUnit::Count;
+                                    successMetric.Value = 1;
+                                    successMetric.Timestamp = DateTime::Now();
+
+                                    publisher.AddDataPoint(successMetric);
+                                }
+                                else
+                                {
+                                    Metric failureMetric;
+                                    failureMetric.MetricName = "FailedTransfer";
+                                    failureMetric.Unit = MetricUnit::Count;
+                                    failureMetric.Value = 1;
+                                    failureMetric.Timestamp = DateTime::Now();
+
+                                    publisher.AddDataPoint(failureMetric);
+                                }
+
+                                downMetric->Timestamp = DateTime::Now();
+                                publisher.AddDataPoint(*downMetric);
+                                Delete(downMetric, g_allocator);
+
+                                inFlight -= 1;
+                            });
+                    }
+                    else
+                    {
+                        Metric failureMetric;
+                        failureMetric.MetricName = "FailedTransfer";
+                        failureMetric.Unit = MetricUnit::Count;
+                        failureMetric.Value = 1;
+                        failureMetric.Timestamp = DateTime::Now();
+
+                        publisher.AddDataPoint(failureMetric);
+                        inFlight -= 1;
+                    }
+                });
+        }
 
         Metric memMetric;
         memMetric.Unit = MetricUnit::Bytes;
@@ -54,8 +236,7 @@ int main() {
         memMetric.Timestamp = DateTime::Now();
         memMetric.MetricName = "BytesAllocated";
         publisher.AddDataPoint(memMetric);
-
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        std::this_thread::sleep_for(std::chrono::seconds(1));
     }
 
     return 0;

--- a/canary/main.cpp
+++ b/canary/main.cpp
@@ -13,117 +13,21 @@
  * permissions and limitations under the License.
  */
 
+#include "CanaryUtil.h"
+#include "MeasureTransferRate.h"
 #include "MetricsPublisher.h"
 #include "S3ObjectTransport.h"
-#include <aws/common/system_info.h>
+#include <aws/common/log_channel.h>
+#include <aws/common/log_formatter.h>
+#include <aws/common/logging.h>
 #include <aws/crt/Api.h>
 #include <aws/crt/auth/Credentials.h>
 #include <aws/io/stream.h>
+#include <time.h>
 
 using namespace Aws::Crt;
 
-static const char s_BodyTemplate[] =
-    "This is a test string for use with canary testing against Amazon Simple Storage Service";
-static size_t s_defaultObjSize = 16 * 1024 * 1024;
-
-struct TemplateStream
-{
-    aws_input_stream inputStream;
-    MetricsPublisher *publisher;
-    size_t length;
-    size_t written;
-};
-
-static int s_templateStreamRead(struct aws_input_stream *stream, struct aws_byte_buf *dest)
-{
-    auto templateStream = static_cast<TemplateStream *>(stream->impl);
-
-    size_t totalBufferSpace = dest->capacity - dest->len;
-    size_t unwritten = templateStream->length - templateStream->written;
-    size_t totalToWrite = totalBufferSpace > unwritten ? unwritten : totalBufferSpace;
-    size_t writtenOut = 0;
-
-    while (totalToWrite)
-    {
-        size_t toWrite =
-            AWS_ARRAY_SIZE(s_BodyTemplate) - 1 > totalToWrite ? totalToWrite : AWS_ARRAY_SIZE(s_BodyTemplate) - 1;
-        ByteCursor outCur = ByteCursorFromArray((const uint8_t *)s_BodyTemplate, toWrite);
-
-        aws_byte_buf_append(dest, &outCur);
-
-        writtenOut += toWrite;
-        totalToWrite = totalToWrite - toWrite;
-    }
-
-    templateStream->written += writtenOut;
-
-    if (templateStream->length == templateStream->written)
-    {
-        Metric uploadMetric;
-        uploadMetric.MetricName = "BytesUp";
-        uploadMetric.Timestamp = DateTime::Now();
-        uploadMetric.Value = (double)templateStream->length;
-        uploadMetric.Unit = MetricUnit::Bytes;
-
-        templateStream->publisher->AddDataPoint(uploadMetric);
-    }
-
-    return AWS_OP_SUCCESS;
-}
-
-static int s_templateStreamGetStatus(struct aws_input_stream *stream, struct aws_stream_status *status)
-{
-    auto templateStream = static_cast<TemplateStream *>(stream->impl);
-
-    status->is_end_of_stream = templateStream->written == templateStream->length;
-    status->is_valid = !status->is_end_of_stream;
-
-    return AWS_OP_SUCCESS;
-}
-
-static int s_templateStreamSeek(struct aws_input_stream *stream, aws_off_t offset, enum aws_stream_seek_basis basis)
-{
-    (void)offset;
-    (void)basis;
-
-    auto templateStream = static_cast<TemplateStream *>(stream->impl);
-    templateStream->written = 0;
-    return AWS_OP_SUCCESS;
-}
-
-static int s_templateStreamGetLength(struct aws_input_stream *stream, int64_t *length)
-{
-    auto templateStream = static_cast<TemplateStream *>(stream->impl);
-    *length = templateStream->length;
-    return AWS_OP_SUCCESS;
-}
-
-static void s_templateStreamDestroy(struct aws_input_stream *stream)
-{
-    auto templateStream = static_cast<TemplateStream *>(stream->impl);
-    Delete(templateStream, stream->allocator);
-}
-
-static struct aws_input_stream_vtable s_templateStreamVTable = {s_templateStreamSeek,
-                                                                s_templateStreamRead,
-                                                                s_templateStreamGetStatus,
-                                                                s_templateStreamGetLength,
-                                                                s_templateStreamDestroy};
-
-static aws_input_stream *s_createTemplateStream(Allocator *alloc, MetricsPublisher *publisher, size_t length)
-{
-    auto templateStream = New<TemplateStream>(alloc);
-    templateStream->publisher = publisher;
-    templateStream->length = length;
-    templateStream->written = 0;
-    templateStream->inputStream.allocator = alloc;
-    templateStream->inputStream.impl = templateStream;
-    templateStream->inputStream.vtable = &s_templateStreamVTable;
-
-    return &templateStream->inputStream;
-}
-
-int main()
+int main(int argc, char *argv[])
 {
     Allocator *traceAllocator = aws_mem_tracer_new(DefaultAllocator(), NULL, AWS_MEMTRACE_BYTES, 0);
     ApiHandle apiHandle(traceAllocator);
@@ -142,107 +46,68 @@ int main()
     auto credsProvider = Auth::CredentialsProvider::CreateCredentialsProviderChainDefault(chainConfig, traceAllocator);
     auto signer = MakeShared<Auth::Sigv4HttpRequestSigner>(traceAllocator, traceAllocator);
 
-    MetricsPublisher publisher("us-west-2", tlsContext, bootstrap, eventLoopGroup, credsProvider, signer);
+    String platformName = CanaryUtil::GetPlatformName();
+
+    String toolName = argc >= 1 ? argv[0] : "NA";
+    size_t dirStart = toolName.rfind('\\');
+
+    if (dirStart != String::npos)
+    {
+        toolName = toolName.substr(dirStart + 1);
+    }
+
+    CanaryUtil::GetSwitchVariable(argc, argv, "-toolName", toolName);
+
+    String ec2InstanceType = "NA";
+    CanaryUtil::GetSwitchVariable(argc, argv, "-ec2InstanceType", ec2InstanceType);
+
+    double cutOffTimeSmallObjects = 10.0;
+    double cutOffTimeLargeObjects = 10.0;
+
+    String cutOffTimeString;
+    if (CanaryUtil::GetSwitchVariable(argc, argv, "-cutOffTimeSmallObjects", cutOffTimeString))
+    {
+        cutOffTimeSmallObjects = atof(cutOffTimeString.c_str());
+    }
+
+    if (CanaryUtil::GetSwitchVariable(argc, argv, "-cutOffTimeLargeObjects", cutOffTimeString))
+    {
+        cutOffTimeLargeObjects = atof(cutOffTimeString.c_str());
+    }
+
+    MetricsPublisher publisher(
+        platformName,
+        toolName,
+        ec2InstanceType,
+        "us-west-2",
+        tlsContext,
+        bootstrap,
+        eventLoopGroup,
+        credsProvider,
+        signer);
     publisher.Namespace = "CRT-CPP-Canary";
 
-    size_t threadCount = aws_system_info_processor_count();
-    size_t maxInFlight = threadCount * 10;
     S3ObjectTransport transport(
-        "us-west-2", "aws-crt-canary-bucket", tlsContext, bootstrap, credsProvider, signer, maxInFlight);
+        eventLoopGroup, "us-west-2", "aws-crt-canary-bucket", tlsContext, bootstrap, credsProvider, signer);
 
-    bool shouldContinue = true;
-    uint64_t counter = INT64_MAX;
-    std::atomic<size_t> inFlight(0);
+    MeasureTransferRate measureTransferRate;
 
-    while (shouldContinue)
+    if (CanaryUtil::HasSwitch(argc, argv, "-smallObjectTransfer"))
     {
+        publisher.SetMetricTransferSize(MetricTransferSize::Small);
 
-        if (counter == 0)
-        {
-            counter = INT64_MAX;
-        }
+        measureTransferRate.MeasureSmallObjectTransfer(traceAllocator, transport, publisher, cutOffTimeSmallObjects);
 
-        while (inFlight < maxInFlight)
-        {
-            StringStream keyStream;
-            keyStream << "crt-canary-obj-" << counter--;
-            inFlight += 1;
-            auto key = keyStream.str();
-            transport.PutObject(
-                key,
-                s_createTemplateStream(traceAllocator, &publisher, s_defaultObjSize),
-                0,
-                [&, key](int32_t errorCode, std::shared_ptr<Aws::Crt::String> etag) {
-                    if (errorCode == AWS_OP_SUCCESS)
-                    {
-                        Metric successMetric;
-                        successMetric.MetricName = "SuccessfulTransfer";
-                        successMetric.Unit = MetricUnit::Count;
-                        successMetric.Value = 1;
-                        successMetric.Timestamp = DateTime::Now();
+        publisher.WaitForLastPublish();
+    }
 
-                        publisher.AddDataPoint(successMetric);
+    if (CanaryUtil::HasSwitch(argc, argv, "-largeObjectTransfer"))
+    {
+        publisher.SetMetricTransferSize(MetricTransferSize::Large);
 
-                        auto downMetric = New<Metric>(g_allocator);
-                        downMetric->MetricName = "BytesDown";
-                        downMetric->Unit = MetricUnit::Bytes;
+        measureTransferRate.MeasureLargeObjectTransfer(traceAllocator, transport, publisher, cutOffTimeLargeObjects);
 
-                        transport.GetObject(
-                            key,
-                            0,
-                            [&, downMetric](Http::HttpStream &, const ByteCursor &cur) {
-                                downMetric->Value += (double)cur.len;
-                            },
-                            [&, downMetric](int32_t errorCode) {
-                                if (errorCode == AWS_OP_SUCCESS)
-                                {
-                                    Metric successMetric;
-                                    successMetric.MetricName = "SuccessfulTransfer";
-                                    successMetric.Unit = MetricUnit::Count;
-                                    successMetric.Value = 1;
-                                    successMetric.Timestamp = DateTime::Now();
-
-                                    publisher.AddDataPoint(successMetric);
-                                }
-                                else
-                                {
-                                    Metric failureMetric;
-                                    failureMetric.MetricName = "FailedTransfer";
-                                    failureMetric.Unit = MetricUnit::Count;
-                                    failureMetric.Value = 1;
-                                    failureMetric.Timestamp = DateTime::Now();
-
-                                    publisher.AddDataPoint(failureMetric);
-                                }
-
-                                downMetric->Timestamp = DateTime::Now();
-                                publisher.AddDataPoint(*downMetric);
-                                Delete(downMetric, g_allocator);
-
-                                inFlight -= 1;
-                            });
-                    }
-                    else
-                    {
-                        Metric failureMetric;
-                        failureMetric.MetricName = "FailedTransfer";
-                        failureMetric.Unit = MetricUnit::Count;
-                        failureMetric.Value = 1;
-                        failureMetric.Timestamp = DateTime::Now();
-
-                        publisher.AddDataPoint(failureMetric);
-                        inFlight -= 1;
-                    }
-                });
-        }
-
-        Metric memMetric;
-        memMetric.Unit = MetricUnit::Bytes;
-        memMetric.Value = (double)aws_mem_tracer_bytes(traceAllocator);
-        memMetric.Timestamp = DateTime::Now();
-        memMetric.MetricName = "BytesAllocated";
-        publisher.AddDataPoint(memMetric);
-        std::this_thread::sleep_for(std::chrono::seconds(1));
+        publisher.WaitForLastPublish();
     }
 
     return 0;

--- a/canary/main.cpp
+++ b/canary/main.cpp
@@ -172,7 +172,7 @@ int main()
                 key,
                 s_createTemplateStream(traceAllocator, &publisher, s_defaultObjSize),
                 0,
-                [&, key](int errorCode, std::shared_ptr<Aws::Crt::String> etag) {
+                [&, key](int32_t errorCode, std::shared_ptr<Aws::Crt::String> etag) {
                     if (errorCode == AWS_OP_SUCCESS)
                     {
                         Metric successMetric;
@@ -189,10 +189,11 @@ int main()
 
                         transport.GetObject(
                             key,
+                            0,
                             [&, downMetric](Http::HttpStream &, const ByteCursor &cur) {
                                 downMetric->Value += (double)cur.len;
                             },
-                            [&, downMetric](int errorCode) {
+                            [&, downMetric](int32_t errorCode) {
                                 if (errorCode == AWS_OP_SUCCESS)
                                 {
                                     Metric successMetric;

--- a/canary/main.cpp
+++ b/canary/main.cpp
@@ -150,42 +150,6 @@ int main()
     S3ObjectTransport transport(
         "us-west-2", "aws-crt-canary-bucket", tlsContext, bootstrap, credsProvider, signer, maxInFlight);
 
-/*
-    StringStream keyStream1;
-    keyStream1 << "test_large_1_" << GetTickCount();
-    auto key1 = keyStream1.str();
-    uint64_t objectSize1 = S3ObjectTransport::MaxPartSizeBytes * 10;
-
-    transport.PutObjectMultipart(
-        key1,
-        objectSize1,
-        [&traceAllocator, &publisher](uint64_t byteStart, uint64_t byteSize) {
-            (void)byteStart;
-
-            aws_input_stream *inputStream = s_createTemplateStream(traceAllocator, &publisher, byteSize);
-            return inputStream;
-        },
-        [](int errorCode) {
-            (void)errorCode;
-        });
-
-    StringStream keyStream2;
-    keyStream2 << "test_large_2_" << GetTickCount();
-    auto key2 = keyStream2.str();
-    uint64_t objectSize2 = S3ObjectTransport::MaxPartSizeBytes * 5;
-
-    transport.PutObjectMultipart(
-        key2,
-        objectSize2,
-        [&traceAllocator, &publisher](uint64_t byteStart, uint64_t byteSize) {
-            (void)byteStart;
-
-            aws_input_stream *inputStream = s_createTemplateStream(traceAllocator, &publisher, byteSize);
-            return inputStream;
-        },
-        [](int errorCode) { (void)errorCode; });
-*/   
-
     bool shouldContinue = true;
     uint64_t counter = INT64_MAX;
     std::atomic<size_t> inFlight(0);
@@ -205,8 +169,11 @@ int main()
             inFlight += 1;
             auto key = keyStream.str();
             transport.PutObject(
-                key, s_createTemplateStream(traceAllocator, &publisher, s_defaultObjSize), 0, [&, key](int errorCode,
-    std::shared_ptr<Aws::Crt::String> etag) { if (errorCode == AWS_OP_SUCCESS)
+                key,
+                s_createTemplateStream(traceAllocator, &publisher, s_defaultObjSize),
+                0,
+                [&, key](int errorCode, std::shared_ptr<Aws::Crt::String> etag) {
+                    if (errorCode == AWS_OP_SUCCESS)
                     {
                         Metric successMetric;
                         successMetric.MetricName = "SuccessfulTransfer";

--- a/canary/main.cpp
+++ b/canary/main.cpp
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+int main() {
+    return 0;
+}

--- a/canary/main.cpp
+++ b/canary/main.cpp
@@ -13,6 +13,50 @@
  * permissions and limitations under the License.
  */
 
+#include <aws/crt/Api.h>
+#include <aws/crt/auth/Credentials.h>
+#include "MetricsPublisher.h"
+
+using namespace Aws::Crt;
+
 int main() {
+    Allocator *traceAllocator = aws_mem_tracer_new(DefaultAllocator(), NULL, AWS_MEMTRACE_BYTES, 0);
+    ApiHandle apiHandle(traceAllocator);
+    apiHandle.InitializeLogging(LogLevel::Trace, stderr);
+
+    Io::EventLoopGroup eventLoopGroup(traceAllocator);
+    Io::DefaultHostResolver defaultHostResolver(eventLoopGroup, 2, 1000, traceAllocator);
+    Io::ClientBootstrap bootstrap(eventLoopGroup, defaultHostResolver, traceAllocator);
+
+    auto contextOptions = Io::TlsContextOptions::InitDefaultClient(traceAllocator);
+    Io::TlsContext tlsContext(contextOptions, Io::TlsMode::CLIENT, traceAllocator);
+
+    Auth::CredentialsProviderChainDefaultConfig chainConfig;
+    chainConfig.Bootstrap = &bootstrap;
+
+    auto credsProvider = Auth::CredentialsProvider::CreateCredentialsProviderChainDefault(chainConfig, traceAllocator);
+    auto signer = MakeShared<Auth::Sigv4HttpRequestSigner>(traceAllocator, traceAllocator);
+
+    MetricsPublisher publisher("us-west-2", tlsContext, bootstrap, eventLoopGroup, credsProvider, signer);
+    publisher.Namespace = "CRT-CPP-Canary";
+
+    while (true) {
+        Metric metric;
+        metric.Unit = MetricUnit::Count;
+        metric.Value = 1;
+        metric.Timestamp = DateTime::Now();
+        metric.MetricName = "LoopIteration";
+        publisher.AddDataPoint(metric);
+
+        Metric memMetric;
+        memMetric.Unit = MetricUnit::Bytes;
+        memMetric.Value = (double)aws_mem_tracer_bytes(traceAllocator);
+        memMetric.Timestamp = DateTime::Now();
+        memMetric.MetricName = "BytesAllocated";
+        publisher.AddDataPoint(memMetric);
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
     return 0;
 }

--- a/canary/main.cpp
+++ b/canary/main.cpp
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 
+#include "CanaryApp.h"
 #include "CanaryUtil.h"
 #include "MeasureTransferRate.h"
 #include "MetricsPublisher.h"
@@ -20,8 +21,6 @@
 #include <aws/common/log_channel.h>
 #include <aws/common/log_formatter.h>
 #include <aws/common/logging.h>
-#include <aws/crt/Api.h>
-#include <aws/crt/auth/Credentials.h>
 #include <aws/io/stream.h>
 #include <time.h>
 
@@ -29,85 +28,18 @@ using namespace Aws::Crt;
 
 int main(int argc, char *argv[])
 {
-    Allocator *traceAllocator = aws_mem_tracer_new(DefaultAllocator(), NULL, AWS_MEMTRACE_BYTES, 0);
-    ApiHandle apiHandle(traceAllocator);
-    apiHandle.InitializeLogging(LogLevel::Info, stderr);
+    CanaryApp canaryApp(argc, argv);
 
-    Io::EventLoopGroup eventLoopGroup(traceAllocator);
-    Io::DefaultHostResolver defaultHostResolver(eventLoopGroup, 60, 1000, traceAllocator);
-    Io::ClientBootstrap bootstrap(eventLoopGroup, defaultHostResolver, traceAllocator);
-
-    auto contextOptions = Io::TlsContextOptions::InitDefaultClient(traceAllocator);
-    Io::TlsContext tlsContext(contextOptions, Io::TlsMode::CLIENT, traceAllocator);
-
-    Auth::CredentialsProviderChainDefaultConfig chainConfig;
-    chainConfig.Bootstrap = &bootstrap;
-
-    auto credsProvider = Auth::CredentialsProvider::CreateCredentialsProviderChainDefault(chainConfig, traceAllocator);
-    auto signer = MakeShared<Auth::Sigv4HttpRequestSigner>(traceAllocator, traceAllocator);
-
-    String platformName = CanaryUtil::GetPlatformName();
-
-    String toolName = argc >= 1 ? argv[0] : "NA";
-    size_t dirStart = toolName.rfind('\\');
-
-    if (dirStart != String::npos)
+    if (canaryApp.measureSmallTransfer)
     {
-        toolName = toolName.substr(dirStart + 1);
+        canaryApp.publisher->SetMetricTransferSize(MetricTransferSize::Small);
+        canaryApp.measureTransferRate->MeasureSmallObjectTransfer();
     }
 
-    CanaryUtil::GetSwitchVariable(argc, argv, "-toolName", toolName);
-
-    String ec2InstanceType = "NA";
-    CanaryUtil::GetSwitchVariable(argc, argv, "-ec2InstanceType", ec2InstanceType);
-
-    double cutOffTimeSmallObjects = 10.0;
-    double cutOffTimeLargeObjects = 10.0;
-
-    String cutOffTimeString;
-    if (CanaryUtil::GetSwitchVariable(argc, argv, "-cutOffTimeSmallObjects", cutOffTimeString))
+    if (canaryApp.measureLargeTransfer)
     {
-        cutOffTimeSmallObjects = atof(cutOffTimeString.c_str());
-    }
-
-    if (CanaryUtil::GetSwitchVariable(argc, argv, "-cutOffTimeLargeObjects", cutOffTimeString))
-    {
-        cutOffTimeLargeObjects = atof(cutOffTimeString.c_str());
-    }
-
-    MetricsPublisher publisher(
-        platformName,
-        toolName,
-        ec2InstanceType,
-        "us-west-2",
-        tlsContext,
-        bootstrap,
-        eventLoopGroup,
-        credsProvider,
-        signer);
-    publisher.Namespace = "CRT-CPP-Canary";
-
-    S3ObjectTransport transport(
-        eventLoopGroup, "us-west-2", "aws-crt-canary-bucket", tlsContext, bootstrap, credsProvider, signer);
-
-    MeasureTransferRate measureTransferRate;
-
-    if (CanaryUtil::HasSwitch(argc, argv, "-smallObjectTransfer"))
-    {
-        publisher.SetMetricTransferSize(MetricTransferSize::Small);
-
-        measureTransferRate.MeasureSmallObjectTransfer(traceAllocator, transport, publisher, cutOffTimeSmallObjects);
-
-        publisher.WaitForLastPublish();
-    }
-
-    if (CanaryUtil::HasSwitch(argc, argv, "-largeObjectTransfer"))
-    {
-        publisher.SetMetricTransferSize(MetricTransferSize::Large);
-
-        measureTransferRate.MeasureLargeObjectTransfer(traceAllocator, transport, publisher, cutOffTimeLargeObjects);
-
-        publisher.WaitForLastPublish();
+        canaryApp.publisher->SetMetricTransferSize(MetricTransferSize::Large);
+        canaryApp.measureTransferRate->MeasureLargeObjectTransfer();
     }
 
     return 0;

--- a/format-check.sh
+++ b/format-check.sh
@@ -10,7 +10,7 @@ if NOT type $CLANG_FORMAT 2> /dev/null ; then
 fi
 
 FAIL=0
-SOURCE_FILES=`find source include tests -type f \( -name '*.h' -o -name '*.cpp' \) -not -name "cJSON.h" -not -name "cJSON.cpp"`
+SOURCE_FILES=`find source include tests samples canary -type f \( -name '*.h' -o -name '*.cpp' \) -not -name "cJSON.h" -not -name "cJSON.cpp"`
 for i in $SOURCE_FILES
 do
     $CLANG_FORMAT -output-replacements-xml $i | grep -c "<replacement " > /dev/null

--- a/include/aws/crt/Api.h
+++ b/include/aws/crt/Api.h
@@ -38,6 +38,14 @@ namespace Aws
             Count
         };
 
+        enum LogSubject
+        {
+            AWS_LS_CRT_CPP_GENERAL = 0x1C00,
+            AWS_LS_CRT_CPP_CANARY,
+
+            AWS_LS_CRT_CPP_LAST = (AWS_LS_CRT_CPP_GENERAL + AWS_LOG_SUBJECT_SPACE_SIZE - 1)
+        };
+
         class AWS_CRT_CPP_API ApiHandle
         {
           public:

--- a/include/aws/crt/auth/Sigv4Signing.h
+++ b/include/aws/crt/auth/Sigv4Signing.h
@@ -153,18 +153,6 @@ namespace Aws
                 void SetBodySigningType(BodySigningType bodysigningType) noexcept;
 
                 /**
-                 * Gets whether or not the signer should use 'UNSIGNED_PAYLOAD' for the payload hash. This is only ever
-                 * used for S3.
-                 */
-                bool GetUseUnsignedPayloadHash() const noexcept;
-
-                /**
-                 * Sets whether or not the signer should use 'UNSIGNED_PAYLOAD' for the payload hash. This is only ever
-                 * used for S3.
-                 */
-                void SetUseUnsignedPayloadHash(bool useUnsignedPayload) noexcept;
-
-                /**
                  *  Get the credentials provider to use for signing.
                  */
                 const std::shared_ptr<ICredentialsProvider> &GetCredentialsProvider() const noexcept;

--- a/include/aws/crt/auth/Sigv4Signing.h
+++ b/include/aws/crt/auth/Sigv4Signing.h
@@ -153,6 +153,18 @@ namespace Aws
                 void SetBodySigningType(BodySigningType bodysigningType) noexcept;
 
                 /**
+                 * Gets whether or not the signer should use 'UNSIGNED_PAYLOAD' for the payload hash. This is only ever
+                 * used for S3.
+                 */
+                bool GetUseUnsignedPayloadHash() const noexcept;
+
+                /**
+                 * Sets whether or not the signer should use 'UNSIGNED_PAYLOAD' for the payload hash. This is only ever
+                 * used for S3.
+                 */
+                void SetUseUnsignedPayloadHash(bool useUnsignedPayload) noexcept;
+
+                /**
                  *  Get the credentials provider to use for signing.
                  */
                 const std::shared_ptr<ICredentialsProvider> &GetCredentialsProvider() const noexcept;

--- a/include/aws/crt/external/tinyxml2.h
+++ b/include/aws/crt/external/tinyxml2.h
@@ -1,0 +1,2350 @@
+/*
+Original code by Lee Thomason (www.grinninglizard.com)
+
+This software is provided 'as-is', without any express or implied
+warranty. In no event will the authors be held liable for any
+damages arising from the use of this software.
+
+Permission is granted to anyone to use this software for any
+purpose, including commercial applications, and to alter it and
+redistribute it freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must
+not claim that you wrote the original software. If you use this
+software in a product, an acknowledgment in the product documentation
+would be appreciated but is not required.
+
+2. Altered source versions must be plainly marked as such, and
+must not be misrepresented as being the original software.
+
+3. This notice may not be removed or altered from any source
+distribution.
+*/
+
+#ifndef TINYXML2_INCLUDED
+#define TINYXML2_INCLUDED
+
+#if defined(ANDROID_NDK) || defined(__BORLANDC__) || defined(__QNXNTO__)
+#   include <ctype.h>
+#   include <limits.h>
+#   include <stdio.h>
+#   include <stdlib.h>
+#   include <string.h>
+#	if defined(__PS3__)
+#		include <stddef.h>
+#	endif
+#else
+#   include <cctype>
+#   include <climits>
+#   include <cstdio>
+#   include <cstdlib>
+#   include <cstring>
+#endif
+#include <stdint.h>
+
+/*
+   TODO: intern strings instead of allocation.
+*/
+/*
+	gcc:
+        g++ -Wall -DTINYXML2_DEBUG tinyxml2.cpp xmltest.cpp -o gccxmltest.exe
+
+    Formatting, Artistic Style:
+        AStyle.exe --style=1tbs --indent-switches --break-closing-brackets --indent-preprocessor tinyxml2.cpp tinyxml2.h
+*/
+
+#if defined( _DEBUG ) || defined (__DEBUG__)
+#   ifndef TINYXML2_DEBUG
+#       define TINYXML2_DEBUG
+#   endif
+#endif
+
+#ifdef _MSC_VER
+#   pragma warning(push)
+#   pragma warning(disable: 4251)
+#endif
+
+#ifdef _WIN32
+#   ifdef TINYXML2_EXPORT
+#       define TINYXML2_LIB __declspec(dllexport)
+#   elif defined(TINYXML2_IMPORT)
+#       define TINYXML2_LIB __declspec(dllimport)
+#   else
+#       define TINYXML2_LIB
+#   endif
+#elif __GNUC__ >= 4
+#   define TINYXML2_LIB __attribute__((visibility("default")))
+#else
+#   define TINYXML2_LIB
+#endif
+
+
+#if defined(TINYXML2_DEBUG)
+#   if defined(_MSC_VER)
+#       // "(void)0," is for suppressing C4127 warning in "assert(false)", "assert(true)" and the like
+#       define TIXMLASSERT( x )           if ( !((void)0,(x))) { __debugbreak(); }
+#   elif defined (ANDROID_NDK)
+#       include <android/log.h>
+#       define TIXMLASSERT( x )           if ( !(x)) { __android_log_assert( "assert", "grinliz", "ASSERT in '%s' at %d.", __FILE__, __LINE__ ); }
+#   else
+#       include <assert.h>
+#       define TIXMLASSERT                assert
+#   endif
+#else
+#   define TIXMLASSERT( x )               {}
+#endif
+
+
+/* Versioning, past 1.0.14:
+	http://semver.org/
+*/
+static const int TIXML2_MAJOR_VERSION = 7;
+static const int TIXML2_MINOR_VERSION = 1;
+static const int TIXML2_PATCH_VERSION = 0;
+
+#define TINYXML2_MAJOR_VERSION 7
+#define TINYXML2_MINOR_VERSION 1
+#define TINYXML2_PATCH_VERSION 0
+
+// A fixed element depth limit is problematic. There needs to be a
+// limit to avoid a stack overflow. However, that limit varies per
+// system, and the capacity of the stack. On the other hand, it's a trivial
+// attack that can result from ill, malicious, or even correctly formed XML,
+// so there needs to be a limit in place.
+static const int TINYXML2_MAX_ELEMENT_DEPTH = 100;
+
+namespace tinyxml2
+{
+class XMLDocument;
+class XMLElement;
+class XMLAttribute;
+class XMLComment;
+class XMLText;
+class XMLDeclaration;
+class XMLUnknown;
+class XMLPrinter;
+
+/*
+	A class that wraps strings. Normally stores the start and end
+	pointers into the XML file itself, and will apply normalization
+	and entity translation if actually read. Can also store (and memory
+	manage) a traditional char[]
+
+    Isn't clear why TINYXML2_LIB is needed; but seems to fix #719
+*/
+class TINYXML2_LIB StrPair
+{
+public:
+    enum {
+        NEEDS_ENTITY_PROCESSING			= 0x01,
+        NEEDS_NEWLINE_NORMALIZATION		= 0x02,
+        NEEDS_WHITESPACE_COLLAPSING     = 0x04,
+
+        TEXT_ELEMENT		            = NEEDS_ENTITY_PROCESSING | NEEDS_NEWLINE_NORMALIZATION,
+        TEXT_ELEMENT_LEAVE_ENTITIES		= NEEDS_NEWLINE_NORMALIZATION,
+        ATTRIBUTE_NAME		            = 0,
+        ATTRIBUTE_VALUE		            = NEEDS_ENTITY_PROCESSING | NEEDS_NEWLINE_NORMALIZATION,
+        ATTRIBUTE_VALUE_LEAVE_ENTITIES  = NEEDS_NEWLINE_NORMALIZATION,
+        COMMENT							= NEEDS_NEWLINE_NORMALIZATION
+    };
+
+    StrPair() : _flags( 0 ), _start( 0 ), _end( 0 ) {}
+    ~StrPair();
+
+    void Set( char* start, char* end, int flags ) {
+        TIXMLASSERT( start );
+        TIXMLASSERT( end );
+        Reset();
+        _start  = start;
+        _end    = end;
+        _flags  = flags | NEEDS_FLUSH;
+    }
+
+    const char* GetStr();
+
+    bool Empty() const {
+        return _start == _end;
+    }
+
+    void SetInternedStr( const char* str ) {
+        Reset();
+        _start = const_cast<char*>(str);
+    }
+
+    void SetStr( const char* str, int flags=0 );
+
+    char* ParseText( char* in, const char* endTag, int strFlags, int* curLineNumPtr );
+    char* ParseName( char* in );
+
+    void TransferTo( StrPair* other );
+	void Reset();
+
+private:
+    void CollapseWhitespace();
+
+    enum {
+        NEEDS_FLUSH = 0x100,
+        NEEDS_DELETE = 0x200
+    };
+
+    int     _flags;
+    char*   _start;
+    char*   _end;
+
+    StrPair( const StrPair& other );	// not supported
+    void operator=( const StrPair& other );	// not supported, use TransferTo()
+};
+
+
+/*
+	A dynamic array of Plain Old Data. Doesn't support constructors, etc.
+	Has a small initial memory pool, so that low or no usage will not
+	cause a call to new/delete
+*/
+template <class T, int INITIAL_SIZE>
+class DynArray
+{
+public:
+    DynArray() :
+        _mem( _pool ),
+        _allocated( INITIAL_SIZE ),
+        _size( 0 )
+    {
+    }
+
+    ~DynArray() {
+        if ( _mem != _pool ) {
+            delete [] _mem;
+        }
+    }
+
+    void Clear() {
+        _size = 0;
+    }
+
+    void Push( T t ) {
+        TIXMLASSERT( _size < INT_MAX );
+        EnsureCapacity( _size+1 );
+        _mem[_size] = t;
+        ++_size;
+    }
+
+    T* PushArr( int count ) {
+        TIXMLASSERT( count >= 0 );
+        TIXMLASSERT( _size <= INT_MAX - count );
+        EnsureCapacity( _size+count );
+        T* ret = &_mem[_size];
+        _size += count;
+        return ret;
+    }
+
+    T Pop() {
+        TIXMLASSERT( _size > 0 );
+        --_size;
+        return _mem[_size];
+    }
+
+    void PopArr( int count ) {
+        TIXMLASSERT( _size >= count );
+        _size -= count;
+    }
+
+    bool Empty() const					{
+        return _size == 0;
+    }
+
+    T& operator[](int i)				{
+        TIXMLASSERT( i>= 0 && i < _size );
+        return _mem[i];
+    }
+
+    const T& operator[](int i) const	{
+        TIXMLASSERT( i>= 0 && i < _size );
+        return _mem[i];
+    }
+
+    const T& PeekTop() const            {
+        TIXMLASSERT( _size > 0 );
+        return _mem[ _size - 1];
+    }
+
+    int Size() const					{
+        TIXMLASSERT( _size >= 0 );
+        return _size;
+    }
+
+    int Capacity() const				{
+        TIXMLASSERT( _allocated >= INITIAL_SIZE );
+        return _allocated;
+    }
+
+	void SwapRemove(int i) {
+		TIXMLASSERT(i >= 0 && i < _size);
+		TIXMLASSERT(_size > 0);
+		_mem[i] = _mem[_size - 1];
+		--_size;
+	}
+
+    const T* Mem() const				{
+        TIXMLASSERT( _mem );
+        return _mem;
+    }
+
+    T* Mem() {
+        TIXMLASSERT( _mem );
+        return _mem;
+    }
+
+private:
+    DynArray( const DynArray& ); // not supported
+    void operator=( const DynArray& ); // not supported
+
+    void EnsureCapacity( int cap ) {
+        TIXMLASSERT( cap > 0 );
+        if ( cap > _allocated ) {
+            TIXMLASSERT( cap <= INT_MAX / 2 );
+            const int newAllocated = cap * 2;
+            T* newMem = new T[newAllocated];
+            TIXMLASSERT( newAllocated >= _size );
+            memcpy( newMem, _mem, sizeof(T)*_size );	// warning: not using constructors, only works for PODs
+            if ( _mem != _pool ) {
+                delete [] _mem;
+            }
+            _mem = newMem;
+            _allocated = newAllocated;
+        }
+    }
+
+    T*  _mem;
+    T   _pool[INITIAL_SIZE];
+    int _allocated;		// objects allocated
+    int _size;			// number objects in use
+};
+
+
+/*
+	Parent virtual class of a pool for fast allocation
+	and deallocation of objects.
+*/
+class MemPool
+{
+public:
+    MemPool() {}
+    virtual ~MemPool() {}
+
+    virtual int ItemSize() const = 0;
+    virtual void* Alloc() = 0;
+    virtual void Free( void* ) = 0;
+    virtual void SetTracked() = 0;
+};
+
+
+/*
+	Template child class to create pools of the correct type.
+*/
+template< int ITEM_SIZE >
+class MemPoolT : public MemPool
+{
+public:
+    MemPoolT() : _blockPtrs(), _root(0), _currentAllocs(0), _nAllocs(0), _maxAllocs(0), _nUntracked(0)	{}
+    ~MemPoolT() {
+        MemPoolT< ITEM_SIZE >::Clear();
+    }
+
+    void Clear() {
+        // Delete the blocks.
+        while( !_blockPtrs.Empty()) {
+            Block* lastBlock = _blockPtrs.Pop();
+            delete lastBlock;
+        }
+        _root = 0;
+        _currentAllocs = 0;
+        _nAllocs = 0;
+        _maxAllocs = 0;
+        _nUntracked = 0;
+    }
+
+    virtual int ItemSize() const	{
+        return ITEM_SIZE;
+    }
+    int CurrentAllocs() const		{
+        return _currentAllocs;
+    }
+
+    virtual void* Alloc() {
+        if ( !_root ) {
+            // Need a new block.
+            Block* block = new Block();
+            _blockPtrs.Push( block );
+
+            Item* blockItems = block->items;
+            for( int i = 0; i < ITEMS_PER_BLOCK - 1; ++i ) {
+                blockItems[i].next = &(blockItems[i + 1]);
+            }
+            blockItems[ITEMS_PER_BLOCK - 1].next = 0;
+            _root = blockItems;
+        }
+        Item* const result = _root;
+        TIXMLASSERT( result != 0 );
+        _root = _root->next;
+
+        ++_currentAllocs;
+        if ( _currentAllocs > _maxAllocs ) {
+            _maxAllocs = _currentAllocs;
+        }
+        ++_nAllocs;
+        ++_nUntracked;
+        return result;
+    }
+
+    virtual void Free( void* mem ) {
+        if ( !mem ) {
+            return;
+        }
+        --_currentAllocs;
+        Item* item = static_cast<Item*>( mem );
+#ifdef TINYXML2_DEBUG
+        memset( item, 0xfe, sizeof( *item ) );
+#endif
+        item->next = _root;
+        _root = item;
+    }
+    void Trace( const char* name ) {
+        printf( "Mempool %s watermark=%d [%dk] current=%d size=%d nAlloc=%d blocks=%d\n",
+                name, _maxAllocs, _maxAllocs * ITEM_SIZE / 1024, _currentAllocs,
+                ITEM_SIZE, _nAllocs, _blockPtrs.Size() );
+    }
+
+    void SetTracked() {
+        --_nUntracked;
+    }
+
+    int Untracked() const {
+        return _nUntracked;
+    }
+
+	// This number is perf sensitive. 4k seems like a good tradeoff on my machine.
+	// The test file is large, 170k.
+	// Release:		VS2010 gcc(no opt)
+	//		1k:		4000
+	//		2k:		4000
+	//		4k:		3900	21000
+	//		16k:	5200
+	//		32k:	4300
+	//		64k:	4000	21000
+    // Declared public because some compilers do not accept to use ITEMS_PER_BLOCK
+    // in private part if ITEMS_PER_BLOCK is private
+    enum { ITEMS_PER_BLOCK = (4 * 1024) / ITEM_SIZE };
+
+private:
+    MemPoolT( const MemPoolT& ); // not supported
+    void operator=( const MemPoolT& ); // not supported
+
+    union Item {
+        Item*   next;
+        char    itemData[ITEM_SIZE];
+    };
+    struct Block {
+        Item items[ITEMS_PER_BLOCK];
+    };
+    DynArray< Block*, 10 > _blockPtrs;
+    Item* _root;
+
+    int _currentAllocs;
+    int _nAllocs;
+    int _maxAllocs;
+    int _nUntracked;
+};
+
+
+
+/**
+	Implements the interface to the "Visitor pattern" (see the Accept() method.)
+	If you call the Accept() method, it requires being passed a XMLVisitor
+	class to handle callbacks. For nodes that contain other nodes (Document, Element)
+	you will get called with a VisitEnter/VisitExit pair. Nodes that are always leafs
+	are simply called with Visit().
+
+	If you return 'true' from a Visit method, recursive parsing will continue. If you return
+	false, <b>no children of this node or its siblings</b> will be visited.
+
+	All flavors of Visit methods have a default implementation that returns 'true' (continue
+	visiting). You need to only override methods that are interesting to you.
+
+	Generally Accept() is called on the XMLDocument, although all nodes support visiting.
+
+	You should never change the document from a callback.
+
+	@sa XMLNode::Accept()
+*/
+class TINYXML2_LIB XMLVisitor
+{
+public:
+    virtual ~XMLVisitor() {}
+
+    /// Visit a document.
+    virtual bool VisitEnter( const XMLDocument& /*doc*/ )			{
+        return true;
+    }
+    /// Visit a document.
+    virtual bool VisitExit( const XMLDocument& /*doc*/ )			{
+        return true;
+    }
+
+    /// Visit an element.
+    virtual bool VisitEnter( const XMLElement& /*element*/, const XMLAttribute* /*firstAttribute*/ )	{
+        return true;
+    }
+    /// Visit an element.
+    virtual bool VisitExit( const XMLElement& /*element*/ )			{
+        return true;
+    }
+
+    /// Visit a declaration.
+    virtual bool Visit( const XMLDeclaration& /*declaration*/ )		{
+        return true;
+    }
+    /// Visit a text node.
+    virtual bool Visit( const XMLText& /*text*/ )					{
+        return true;
+    }
+    /// Visit a comment node.
+    virtual bool Visit( const XMLComment& /*comment*/ )				{
+        return true;
+    }
+    /// Visit an unknown node.
+    virtual bool Visit( const XMLUnknown& /*unknown*/ )				{
+        return true;
+    }
+};
+
+// WARNING: must match XMLDocument::_errorNames[]
+enum XMLError {
+    XML_SUCCESS = 0,
+    XML_NO_ATTRIBUTE,
+    XML_WRONG_ATTRIBUTE_TYPE,
+    XML_ERROR_FILE_NOT_FOUND,
+    XML_ERROR_FILE_COULD_NOT_BE_OPENED,
+    XML_ERROR_FILE_READ_ERROR,
+    XML_ERROR_PARSING_ELEMENT,
+    XML_ERROR_PARSING_ATTRIBUTE,
+    XML_ERROR_PARSING_TEXT,
+    XML_ERROR_PARSING_CDATA,
+    XML_ERROR_PARSING_COMMENT,
+    XML_ERROR_PARSING_DECLARATION,
+    XML_ERROR_PARSING_UNKNOWN,
+    XML_ERROR_EMPTY_DOCUMENT,
+    XML_ERROR_MISMATCHED_ELEMENT,
+    XML_ERROR_PARSING,
+    XML_CAN_NOT_CONVERT_TEXT,
+    XML_NO_TEXT_NODE,
+	XML_ELEMENT_DEPTH_EXCEEDED,
+
+	XML_ERROR_COUNT
+};
+
+
+/*
+	Utility functionality.
+*/
+class TINYXML2_LIB XMLUtil
+{
+public:
+    static const char* SkipWhiteSpace( const char* p, int* curLineNumPtr )	{
+        TIXMLASSERT( p );
+
+        while( IsWhiteSpace(*p) ) {
+            if (curLineNumPtr && *p == '\n') {
+                ++(*curLineNumPtr);
+            }
+            ++p;
+        }
+        TIXMLASSERT( p );
+        return p;
+    }
+    static char* SkipWhiteSpace( char* p, int* curLineNumPtr )				{
+        return const_cast<char*>( SkipWhiteSpace( const_cast<const char*>(p), curLineNumPtr ) );
+    }
+
+    // Anything in the high order range of UTF-8 is assumed to not be whitespace. This isn't
+    // correct, but simple, and usually works.
+    static bool IsWhiteSpace( char p )					{
+        return !IsUTF8Continuation(p) && isspace( static_cast<unsigned char>(p) );
+    }
+
+    inline static bool IsNameStartChar( unsigned char ch ) {
+        if ( ch >= 128 ) {
+            // This is a heuristic guess in attempt to not implement Unicode-aware isalpha()
+            return true;
+        }
+        if ( isalpha( ch ) ) {
+            return true;
+        }
+        return ch == ':' || ch == '_';
+    }
+
+    inline static bool IsNameChar( unsigned char ch ) {
+        return IsNameStartChar( ch )
+               || isdigit( ch )
+               || ch == '.'
+               || ch == '-';
+    }
+
+    inline static bool StringEqual( const char* p, const char* q, int nChar=INT_MAX )  {
+        if ( p == q ) {
+            return true;
+        }
+        TIXMLASSERT( p );
+        TIXMLASSERT( q );
+        TIXMLASSERT( nChar >= 0 );
+        return strncmp( p, q, nChar ) == 0;
+    }
+
+    inline static bool IsUTF8Continuation( char p ) {
+        return ( p & 0x80 ) != 0;
+    }
+
+    static const char* ReadBOM( const char* p, bool* hasBOM );
+    // p is the starting location,
+    // the UTF-8 value of the entity will be placed in value, and length filled in.
+    static const char* GetCharacterRef( const char* p, char* value, int* length );
+    static void ConvertUTF32ToUTF8( unsigned long input, char* output, int* length );
+
+    // converts primitive types to strings
+    static void ToStr( int v, char* buffer, int bufferSize );
+    static void ToStr( unsigned v, char* buffer, int bufferSize );
+    static void ToStr( bool v, char* buffer, int bufferSize );
+    static void ToStr( float v, char* buffer, int bufferSize );
+    static void ToStr( double v, char* buffer, int bufferSize );
+	static void ToStr(int64_t v, char* buffer, int bufferSize);
+    static void ToStr(uint64_t v, char* buffer, int bufferSize);
+
+    // converts strings to primitive types
+    static bool	ToInt( const char* str, int* value );
+    static bool ToUnsigned( const char* str, unsigned* value );
+    static bool	ToBool( const char* str, bool* value );
+    static bool	ToFloat( const char* str, float* value );
+    static bool ToDouble( const char* str, double* value );
+	static bool ToInt64(const char* str, int64_t* value);
+    static bool ToUnsigned64(const char* str, uint64_t* value);
+	// Changes what is serialized for a boolean value.
+	// Default to "true" and "false". Shouldn't be changed
+	// unless you have a special testing or compatibility need.
+	// Be careful: static, global, & not thread safe.
+	// Be sure to set static const memory as parameters.
+	static void SetBoolSerialization(const char* writeTrue, const char* writeFalse);
+
+private:
+	static const char* writeBoolTrue;
+	static const char* writeBoolFalse;
+};
+
+
+/** XMLNode is a base class for every object that is in the
+	XML Document Object Model (DOM), except XMLAttributes.
+	Nodes have siblings, a parent, and children which can
+	be navigated. A node is always in a XMLDocument.
+	The type of a XMLNode can be queried, and it can
+	be cast to its more defined type.
+
+	A XMLDocument allocates memory for all its Nodes.
+	When the XMLDocument gets deleted, all its Nodes
+	will also be deleted.
+
+	@verbatim
+	A Document can contain:	Element	(container or leaf)
+							Comment (leaf)
+							Unknown (leaf)
+							Declaration( leaf )
+
+	An Element can contain:	Element (container or leaf)
+							Text	(leaf)
+							Attributes (not on tree)
+							Comment (leaf)
+							Unknown (leaf)
+
+	@endverbatim
+*/
+class TINYXML2_LIB XMLNode
+{
+    friend class XMLDocument;
+    friend class XMLElement;
+public:
+
+    /// Get the XMLDocument that owns this XMLNode.
+    const XMLDocument* GetDocument() const	{
+        TIXMLASSERT( _document );
+        return _document;
+    }
+    /// Get the XMLDocument that owns this XMLNode.
+    XMLDocument* GetDocument()				{
+        TIXMLASSERT( _document );
+        return _document;
+    }
+
+    /// Safely cast to an Element, or null.
+    virtual XMLElement*		ToElement()		{
+        return 0;
+    }
+    /// Safely cast to Text, or null.
+    virtual XMLText*		ToText()		{
+        return 0;
+    }
+    /// Safely cast to a Comment, or null.
+    virtual XMLComment*		ToComment()		{
+        return 0;
+    }
+    /// Safely cast to a Document, or null.
+    virtual XMLDocument*	ToDocument()	{
+        return 0;
+    }
+    /// Safely cast to a Declaration, or null.
+    virtual XMLDeclaration*	ToDeclaration()	{
+        return 0;
+    }
+    /// Safely cast to an Unknown, or null.
+    virtual XMLUnknown*		ToUnknown()		{
+        return 0;
+    }
+
+    virtual const XMLElement*		ToElement() const		{
+        return 0;
+    }
+    virtual const XMLText*			ToText() const			{
+        return 0;
+    }
+    virtual const XMLComment*		ToComment() const		{
+        return 0;
+    }
+    virtual const XMLDocument*		ToDocument() const		{
+        return 0;
+    }
+    virtual const XMLDeclaration*	ToDeclaration() const	{
+        return 0;
+    }
+    virtual const XMLUnknown*		ToUnknown() const		{
+        return 0;
+    }
+
+    /** The meaning of 'value' changes for the specific type.
+    	@verbatim
+    	Document:	empty (NULL is returned, not an empty string)
+    	Element:	name of the element
+    	Comment:	the comment text
+    	Unknown:	the tag contents
+    	Text:		the text string
+    	@endverbatim
+    */
+    const char* Value() const;
+
+    /** Set the Value of an XML node.
+    	@sa Value()
+    */
+    void SetValue( const char* val, bool staticMem=false );
+
+    /// Gets the line number the node is in, if the document was parsed from a file.
+    int GetLineNum() const { return _parseLineNum; }
+
+    /// Get the parent of this node on the DOM.
+    const XMLNode*	Parent() const			{
+        return _parent;
+    }
+
+    XMLNode* Parent()						{
+        return _parent;
+    }
+
+    /// Returns true if this node has no children.
+    bool NoChildren() const					{
+        return !_firstChild;
+    }
+
+    /// Get the first child node, or null if none exists.
+    const XMLNode*  FirstChild() const		{
+        return _firstChild;
+    }
+
+    XMLNode*		FirstChild()			{
+        return _firstChild;
+    }
+
+    /** Get the first child element, or optionally the first child
+        element with the specified name.
+    */
+    const XMLElement* FirstChildElement( const char* name = 0 ) const;
+
+    XMLElement* FirstChildElement( const char* name = 0 )	{
+        return const_cast<XMLElement*>(const_cast<const XMLNode*>(this)->FirstChildElement( name ));
+    }
+
+    /// Get the last child node, or null if none exists.
+    const XMLNode*	LastChild() const						{
+        return _lastChild;
+    }
+
+    XMLNode*		LastChild()								{
+        return _lastChild;
+    }
+
+    /** Get the last child element or optionally the last child
+        element with the specified name.
+    */
+    const XMLElement* LastChildElement( const char* name = 0 ) const;
+
+    XMLElement* LastChildElement( const char* name = 0 )	{
+        return const_cast<XMLElement*>(const_cast<const XMLNode*>(this)->LastChildElement(name) );
+    }
+
+    /// Get the previous (left) sibling node of this node.
+    const XMLNode*	PreviousSibling() const					{
+        return _prev;
+    }
+
+    XMLNode*	PreviousSibling()							{
+        return _prev;
+    }
+
+    /// Get the previous (left) sibling element of this node, with an optionally supplied name.
+    const XMLElement*	PreviousSiblingElement( const char* name = 0 ) const ;
+
+    XMLElement*	PreviousSiblingElement( const char* name = 0 ) {
+        return const_cast<XMLElement*>(const_cast<const XMLNode*>(this)->PreviousSiblingElement( name ) );
+    }
+
+    /// Get the next (right) sibling node of this node.
+    const XMLNode*	NextSibling() const						{
+        return _next;
+    }
+
+    XMLNode*	NextSibling()								{
+        return _next;
+    }
+
+    /// Get the next (right) sibling element of this node, with an optionally supplied name.
+    const XMLElement*	NextSiblingElement( const char* name = 0 ) const;
+
+    XMLElement*	NextSiblingElement( const char* name = 0 )	{
+        return const_cast<XMLElement*>(const_cast<const XMLNode*>(this)->NextSiblingElement( name ) );
+    }
+
+    /**
+    	Add a child node as the last (right) child.
+		If the child node is already part of the document,
+		it is moved from its old location to the new location.
+		Returns the addThis argument or 0 if the node does not
+		belong to the same document.
+    */
+    XMLNode* InsertEndChild( XMLNode* addThis );
+
+    XMLNode* LinkEndChild( XMLNode* addThis )	{
+        return InsertEndChild( addThis );
+    }
+    /**
+    	Add a child node as the first (left) child.
+		If the child node is already part of the document,
+		it is moved from its old location to the new location.
+		Returns the addThis argument or 0 if the node does not
+		belong to the same document.
+    */
+    XMLNode* InsertFirstChild( XMLNode* addThis );
+    /**
+    	Add a node after the specified child node.
+		If the child node is already part of the document,
+		it is moved from its old location to the new location.
+		Returns the addThis argument or 0 if the afterThis node
+		is not a child of this node, or if the node does not
+		belong to the same document.
+    */
+    XMLNode* InsertAfterChild( XMLNode* afterThis, XMLNode* addThis );
+
+    /**
+    	Delete all the children of this node.
+    */
+    void DeleteChildren();
+
+    /**
+    	Delete a child of this node.
+    */
+    void DeleteChild( XMLNode* node );
+
+    /**
+    	Make a copy of this node, but not its children.
+    	You may pass in a Document pointer that will be
+    	the owner of the new Node. If the 'document' is
+    	null, then the node returned will be allocated
+    	from the current Document. (this->GetDocument())
+
+    	Note: if called on a XMLDocument, this will return null.
+    */
+    virtual XMLNode* ShallowClone( XMLDocument* document ) const = 0;
+
+	/**
+		Make a copy of this node and all its children.
+
+		If the 'target' is null, then the nodes will
+		be allocated in the current document. If 'target'
+        is specified, the memory will be allocated is the
+        specified XMLDocument.
+
+		NOTE: This is probably not the correct tool to
+		copy a document, since XMLDocuments can have multiple
+		top level XMLNodes. You probably want to use
+        XMLDocument::DeepCopy()
+	*/
+	XMLNode* DeepClone( XMLDocument* target ) const;
+
+    /**
+    	Test if 2 nodes are the same, but don't test children.
+    	The 2 nodes do not need to be in the same Document.
+
+    	Note: if called on a XMLDocument, this will return false.
+    */
+    virtual bool ShallowEqual( const XMLNode* compare ) const = 0;
+
+    /** Accept a hierarchical visit of the nodes in the TinyXML-2 DOM. Every node in the
+    	XML tree will be conditionally visited and the host will be called back
+    	via the XMLVisitor interface.
+
+    	This is essentially a SAX interface for TinyXML-2. (Note however it doesn't re-parse
+    	the XML for the callbacks, so the performance of TinyXML-2 is unchanged by using this
+    	interface versus any other.)
+
+    	The interface has been based on ideas from:
+
+    	- http://www.saxproject.org/
+    	- http://c2.com/cgi/wiki?HierarchicalVisitorPattern
+
+    	Which are both good references for "visiting".
+
+    	An example of using Accept():
+    	@verbatim
+    	XMLPrinter printer;
+    	tinyxmlDoc.Accept( &printer );
+    	const char* xmlcstr = printer.CStr();
+    	@endverbatim
+    */
+    virtual bool Accept( XMLVisitor* visitor ) const = 0;
+
+	/**
+		Set user data into the XMLNode. TinyXML-2 in
+		no way processes or interprets user data.
+		It is initially 0.
+	*/
+	void SetUserData(void* userData)	{ _userData = userData; }
+
+	/**
+		Get user data set into the XMLNode. TinyXML-2 in
+		no way processes or interprets user data.
+		It is initially 0.
+	*/
+	void* GetUserData() const			{ return _userData; }
+
+protected:
+    explicit XMLNode( XMLDocument* );
+    virtual ~XMLNode();
+
+    virtual char* ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr);
+
+    XMLDocument*	_document;
+    XMLNode*		_parent;
+    mutable StrPair	_value;
+    int             _parseLineNum;
+
+    XMLNode*		_firstChild;
+    XMLNode*		_lastChild;
+
+    XMLNode*		_prev;
+    XMLNode*		_next;
+
+	void*			_userData;
+
+private:
+    MemPool*		_memPool;
+    void Unlink( XMLNode* child );
+    static void DeleteNode( XMLNode* node );
+    void InsertChildPreamble( XMLNode* insertThis ) const;
+    const XMLElement* ToElementWithName( const char* name ) const;
+
+    XMLNode( const XMLNode& );	// not supported
+    XMLNode& operator=( const XMLNode& );	// not supported
+};
+
+
+/** XML text.
+
+	Note that a text node can have child element nodes, for example:
+	@verbatim
+	<root>This is <b>bold</b></root>
+	@endverbatim
+
+	A text node can have 2 ways to output the next. "normal" output
+	and CDATA. It will default to the mode it was parsed from the XML file and
+	you generally want to leave it alone, but you can change the output mode with
+	SetCData() and query it with CData().
+*/
+class TINYXML2_LIB XMLText : public XMLNode
+{
+    friend class XMLDocument;
+public:
+    virtual bool Accept( XMLVisitor* visitor ) const;
+
+    virtual XMLText* ToText()			{
+        return this;
+    }
+    virtual const XMLText* ToText() const	{
+        return this;
+    }
+
+    /// Declare whether this should be CDATA or standard text.
+    void SetCData( bool isCData )			{
+        _isCData = isCData;
+    }
+    /// Returns true if this is a CDATA text element.
+    bool CData() const						{
+        return _isCData;
+    }
+
+    virtual XMLNode* ShallowClone( XMLDocument* document ) const;
+    virtual bool ShallowEqual( const XMLNode* compare ) const;
+
+protected:
+    explicit XMLText( XMLDocument* doc )	: XMLNode( doc ), _isCData( false )	{}
+    virtual ~XMLText()												{}
+
+    char* ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr );
+
+private:
+    bool _isCData;
+
+    XMLText( const XMLText& );	// not supported
+    XMLText& operator=( const XMLText& );	// not supported
+};
+
+
+/** An XML Comment. */
+class TINYXML2_LIB XMLComment : public XMLNode
+{
+    friend class XMLDocument;
+public:
+    virtual XMLComment*	ToComment()					{
+        return this;
+    }
+    virtual const XMLComment* ToComment() const		{
+        return this;
+    }
+
+    virtual bool Accept( XMLVisitor* visitor ) const;
+
+    virtual XMLNode* ShallowClone( XMLDocument* document ) const;
+    virtual bool ShallowEqual( const XMLNode* compare ) const;
+
+protected:
+    explicit XMLComment( XMLDocument* doc );
+    virtual ~XMLComment();
+
+    char* ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr);
+
+private:
+    XMLComment( const XMLComment& );	// not supported
+    XMLComment& operator=( const XMLComment& );	// not supported
+};
+
+
+/** In correct XML the declaration is the first entry in the file.
+	@verbatim
+		<?xml version="1.0" standalone="yes"?>
+	@endverbatim
+
+	TinyXML-2 will happily read or write files without a declaration,
+	however.
+
+	The text of the declaration isn't interpreted. It is parsed
+	and written as a string.
+*/
+class TINYXML2_LIB XMLDeclaration : public XMLNode
+{
+    friend class XMLDocument;
+public:
+    virtual XMLDeclaration*	ToDeclaration()					{
+        return this;
+    }
+    virtual const XMLDeclaration* ToDeclaration() const		{
+        return this;
+    }
+
+    virtual bool Accept( XMLVisitor* visitor ) const;
+
+    virtual XMLNode* ShallowClone( XMLDocument* document ) const;
+    virtual bool ShallowEqual( const XMLNode* compare ) const;
+
+protected:
+    explicit XMLDeclaration( XMLDocument* doc );
+    virtual ~XMLDeclaration();
+
+    char* ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr );
+
+private:
+    XMLDeclaration( const XMLDeclaration& );	// not supported
+    XMLDeclaration& operator=( const XMLDeclaration& );	// not supported
+};
+
+
+/** Any tag that TinyXML-2 doesn't recognize is saved as an
+	unknown. It is a tag of text, but should not be modified.
+	It will be written back to the XML, unchanged, when the file
+	is saved.
+
+	DTD tags get thrown into XMLUnknowns.
+*/
+class TINYXML2_LIB XMLUnknown : public XMLNode
+{
+    friend class XMLDocument;
+public:
+    virtual XMLUnknown*	ToUnknown()					{
+        return this;
+    }
+    virtual const XMLUnknown* ToUnknown() const		{
+        return this;
+    }
+
+    virtual bool Accept( XMLVisitor* visitor ) const;
+
+    virtual XMLNode* ShallowClone( XMLDocument* document ) const;
+    virtual bool ShallowEqual( const XMLNode* compare ) const;
+
+protected:
+    explicit XMLUnknown( XMLDocument* doc );
+    virtual ~XMLUnknown();
+
+    char* ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr );
+
+private:
+    XMLUnknown( const XMLUnknown& );	// not supported
+    XMLUnknown& operator=( const XMLUnknown& );	// not supported
+};
+
+
+
+/** An attribute is a name-value pair. Elements have an arbitrary
+	number of attributes, each with a unique name.
+
+	@note The attributes are not XMLNodes. You may only query the
+	Next() attribute in a list.
+*/
+class TINYXML2_LIB XMLAttribute
+{
+    friend class XMLElement;
+public:
+    /// The name of the attribute.
+    const char* Name() const;
+
+    /// The value of the attribute.
+    const char* Value() const;
+
+    /// Gets the line number the attribute is in, if the document was parsed from a file.
+    int GetLineNum() const { return _parseLineNum; }
+
+    /// The next attribute in the list.
+    const XMLAttribute* Next() const {
+        return _next;
+    }
+
+    /** IntValue interprets the attribute as an integer, and returns the value.
+        If the value isn't an integer, 0 will be returned. There is no error checking;
+    	use QueryIntValue() if you need error checking.
+    */
+	int	IntValue() const {
+		int i = 0;
+		QueryIntValue(&i);
+		return i;
+	}
+
+	int64_t Int64Value() const {
+		int64_t i = 0;
+		QueryInt64Value(&i);
+		return i;
+	}
+
+    uint64_t Unsigned64Value() const {
+        uint64_t i = 0;
+        QueryUnsigned64Value(&i);
+        return i;
+    }
+
+    /// Query as an unsigned integer. See IntValue()
+    unsigned UnsignedValue() const			{
+        unsigned i=0;
+        QueryUnsignedValue( &i );
+        return i;
+    }
+    /// Query as a boolean. See IntValue()
+    bool	 BoolValue() const				{
+        bool b=false;
+        QueryBoolValue( &b );
+        return b;
+    }
+    /// Query as a double. See IntValue()
+    double 	 DoubleValue() const			{
+        double d=0;
+        QueryDoubleValue( &d );
+        return d;
+    }
+    /// Query as a float. See IntValue()
+    float	 FloatValue() const				{
+        float f=0;
+        QueryFloatValue( &f );
+        return f;
+    }
+
+    /** QueryIntValue interprets the attribute as an integer, and returns the value
+    	in the provided parameter. The function will return XML_SUCCESS on success,
+    	and XML_WRONG_ATTRIBUTE_TYPE if the conversion is not successful.
+    */
+    XMLError QueryIntValue( int* value ) const;
+    /// See QueryIntValue
+    XMLError QueryUnsignedValue( unsigned int* value ) const;
+	/// See QueryIntValue
+	XMLError QueryInt64Value(int64_t* value) const;
+    /// See QueryIntValue
+    XMLError QueryUnsigned64Value(uint64_t* value) const;
+	/// See QueryIntValue
+    XMLError QueryBoolValue( bool* value ) const;
+    /// See QueryIntValue
+    XMLError QueryDoubleValue( double* value ) const;
+    /// See QueryIntValue
+    XMLError QueryFloatValue( float* value ) const;
+
+    /// Set the attribute to a string value.
+    void SetAttribute( const char* value );
+    /// Set the attribute to value.
+    void SetAttribute( int value );
+    /// Set the attribute to value.
+    void SetAttribute( unsigned value );
+	/// Set the attribute to value.
+	void SetAttribute(int64_t value);
+    /// Set the attribute to value.
+    void SetAttribute(uint64_t value);
+    /// Set the attribute to value.
+    void SetAttribute( bool value );
+    /// Set the attribute to value.
+    void SetAttribute( double value );
+    /// Set the attribute to value.
+    void SetAttribute( float value );
+
+private:
+    enum { BUF_SIZE = 200 };
+
+    XMLAttribute() : _name(), _value(),_parseLineNum( 0 ), _next( 0 ), _memPool( 0 ) {}
+    virtual ~XMLAttribute()	{}
+
+    XMLAttribute( const XMLAttribute& );	// not supported
+    void operator=( const XMLAttribute& );	// not supported
+    void SetName( const char* name );
+
+    char* ParseDeep( char* p, bool processEntities, int* curLineNumPtr );
+
+    mutable StrPair _name;
+    mutable StrPair _value;
+    int             _parseLineNum;
+    XMLAttribute*   _next;
+    MemPool*        _memPool;
+};
+
+
+/** The element is a container class. It has a value, the element name,
+	and can contain other elements, text, comments, and unknowns.
+	Elements also contain an arbitrary number of attributes.
+*/
+class TINYXML2_LIB XMLElement : public XMLNode
+{
+    friend class XMLDocument;
+public:
+    /// Get the name of an element (which is the Value() of the node.)
+    const char* Name() const		{
+        return Value();
+    }
+    /// Set the name of the element.
+    void SetName( const char* str, bool staticMem=false )	{
+        SetValue( str, staticMem );
+    }
+
+    virtual XMLElement* ToElement()				{
+        return this;
+    }
+    virtual const XMLElement* ToElement() const {
+        return this;
+    }
+    virtual bool Accept( XMLVisitor* visitor ) const;
+
+    /** Given an attribute name, Attribute() returns the value
+    	for the attribute of that name, or null if none
+    	exists. For example:
+
+    	@verbatim
+    	const char* value = ele->Attribute( "foo" );
+    	@endverbatim
+
+    	The 'value' parameter is normally null. However, if specified,
+    	the attribute will only be returned if the 'name' and 'value'
+    	match. This allow you to write code:
+
+    	@verbatim
+    	if ( ele->Attribute( "foo", "bar" ) ) callFooIsBar();
+    	@endverbatim
+
+    	rather than:
+    	@verbatim
+    	if ( ele->Attribute( "foo" ) ) {
+    		if ( strcmp( ele->Attribute( "foo" ), "bar" ) == 0 ) callFooIsBar();
+    	}
+    	@endverbatim
+    */
+    const char* Attribute( const char* name, const char* value=0 ) const;
+
+    /** Given an attribute name, IntAttribute() returns the value
+    	of the attribute interpreted as an integer. The default
+        value will be returned if the attribute isn't present,
+        or if there is an error. (For a method with error
+    	checking, see QueryIntAttribute()).
+    */
+	int IntAttribute(const char* name, int defaultValue = 0) const;
+    /// See IntAttribute()
+	unsigned UnsignedAttribute(const char* name, unsigned defaultValue = 0) const;
+	/// See IntAttribute()
+	int64_t Int64Attribute(const char* name, int64_t defaultValue = 0) const;
+    /// See IntAttribute()
+    uint64_t Unsigned64Attribute(const char* name, uint64_t defaultValue = 0) const;
+	/// See IntAttribute()
+	bool BoolAttribute(const char* name, bool defaultValue = false) const;
+    /// See IntAttribute()
+	double DoubleAttribute(const char* name, double defaultValue = 0) const;
+    /// See IntAttribute()
+	float FloatAttribute(const char* name, float defaultValue = 0) const;
+
+    /** Given an attribute name, QueryIntAttribute() returns
+    	XML_SUCCESS, XML_WRONG_ATTRIBUTE_TYPE if the conversion
+    	can't be performed, or XML_NO_ATTRIBUTE if the attribute
+    	doesn't exist. If successful, the result of the conversion
+    	will be written to 'value'. If not successful, nothing will
+    	be written to 'value'. This allows you to provide default
+    	value:
+
+    	@verbatim
+    	int value = 10;
+    	QueryIntAttribute( "foo", &value );		// if "foo" isn't found, value will still be 10
+    	@endverbatim
+    */
+    XMLError QueryIntAttribute( const char* name, int* value ) const				{
+        const XMLAttribute* a = FindAttribute( name );
+        if ( !a ) {
+            return XML_NO_ATTRIBUTE;
+        }
+        return a->QueryIntValue( value );
+    }
+
+	/// See QueryIntAttribute()
+    XMLError QueryUnsignedAttribute( const char* name, unsigned int* value ) const	{
+        const XMLAttribute* a = FindAttribute( name );
+        if ( !a ) {
+            return XML_NO_ATTRIBUTE;
+        }
+        return a->QueryUnsignedValue( value );
+    }
+
+	/// See QueryIntAttribute()
+	XMLError QueryInt64Attribute(const char* name, int64_t* value) const {
+		const XMLAttribute* a = FindAttribute(name);
+		if (!a) {
+			return XML_NO_ATTRIBUTE;
+		}
+		return a->QueryInt64Value(value);
+	}
+
+    /// See QueryIntAttribute()
+    XMLError QueryUnsigned64Attribute(const char* name, uint64_t* value) const {
+        const XMLAttribute* a = FindAttribute(name);
+        if(!a) {
+            return XML_NO_ATTRIBUTE;
+        }
+        return a->QueryUnsigned64Value(value);
+    }
+
+	/// See QueryIntAttribute()
+    XMLError QueryBoolAttribute( const char* name, bool* value ) const				{
+        const XMLAttribute* a = FindAttribute( name );
+        if ( !a ) {
+            return XML_NO_ATTRIBUTE;
+        }
+        return a->QueryBoolValue( value );
+    }
+    /// See QueryIntAttribute()
+    XMLError QueryDoubleAttribute( const char* name, double* value ) const			{
+        const XMLAttribute* a = FindAttribute( name );
+        if ( !a ) {
+            return XML_NO_ATTRIBUTE;
+        }
+        return a->QueryDoubleValue( value );
+    }
+    /// See QueryIntAttribute()
+    XMLError QueryFloatAttribute( const char* name, float* value ) const			{
+        const XMLAttribute* a = FindAttribute( name );
+        if ( !a ) {
+            return XML_NO_ATTRIBUTE;
+        }
+        return a->QueryFloatValue( value );
+    }
+
+	/// See QueryIntAttribute()
+	XMLError QueryStringAttribute(const char* name, const char** value) const {
+		const XMLAttribute* a = FindAttribute(name);
+		if (!a) {
+			return XML_NO_ATTRIBUTE;
+		}
+		*value = a->Value();
+		return XML_SUCCESS;
+	}
+
+
+
+    /** Given an attribute name, QueryAttribute() returns
+    	XML_SUCCESS, XML_WRONG_ATTRIBUTE_TYPE if the conversion
+    	can't be performed, or XML_NO_ATTRIBUTE if the attribute
+    	doesn't exist. It is overloaded for the primitive types,
+		and is a generally more convenient replacement of
+		QueryIntAttribute() and related functions.
+
+		If successful, the result of the conversion
+    	will be written to 'value'. If not successful, nothing will
+    	be written to 'value'. This allows you to provide default
+    	value:
+
+    	@verbatim
+    	int value = 10;
+    	QueryAttribute( "foo", &value );		// if "foo" isn't found, value will still be 10
+    	@endverbatim
+    */
+	XMLError QueryAttribute( const char* name, int* value ) const {
+		return QueryIntAttribute( name, value );
+	}
+
+	XMLError QueryAttribute( const char* name, unsigned int* value ) const {
+		return QueryUnsignedAttribute( name, value );
+	}
+
+	XMLError QueryAttribute(const char* name, int64_t* value) const {
+		return QueryInt64Attribute(name, value);
+	}
+
+    XMLError QueryAttribute(const char* name, uint64_t* value) const {
+        return QueryUnsigned64Attribute(name, value);
+    }
+
+    XMLError QueryAttribute( const char* name, bool* value ) const {
+		return QueryBoolAttribute( name, value );
+	}
+
+	XMLError QueryAttribute( const char* name, double* value ) const {
+		return QueryDoubleAttribute( name, value );
+	}
+
+	XMLError QueryAttribute( const char* name, float* value ) const {
+		return QueryFloatAttribute( name, value );
+	}
+
+	/// Sets the named attribute to value.
+    void SetAttribute( const char* name, const char* value )	{
+        XMLAttribute* a = FindOrCreateAttribute( name );
+        a->SetAttribute( value );
+    }
+    /// Sets the named attribute to value.
+    void SetAttribute( const char* name, int value )			{
+        XMLAttribute* a = FindOrCreateAttribute( name );
+        a->SetAttribute( value );
+    }
+    /// Sets the named attribute to value.
+    void SetAttribute( const char* name, unsigned value )		{
+        XMLAttribute* a = FindOrCreateAttribute( name );
+        a->SetAttribute( value );
+    }
+
+	/// Sets the named attribute to value.
+	void SetAttribute(const char* name, int64_t value) {
+		XMLAttribute* a = FindOrCreateAttribute(name);
+		a->SetAttribute(value);
+	}
+
+    /// Sets the named attribute to value.
+    void SetAttribute(const char* name, uint64_t value) {
+        XMLAttribute* a = FindOrCreateAttribute(name);
+        a->SetAttribute(value);
+    }
+    
+    /// Sets the named attribute to value.
+    void SetAttribute( const char* name, bool value )			{
+        XMLAttribute* a = FindOrCreateAttribute( name );
+        a->SetAttribute( value );
+    }
+    /// Sets the named attribute to value.
+    void SetAttribute( const char* name, double value )		{
+        XMLAttribute* a = FindOrCreateAttribute( name );
+        a->SetAttribute( value );
+    }
+    /// Sets the named attribute to value.
+    void SetAttribute( const char* name, float value )		{
+        XMLAttribute* a = FindOrCreateAttribute( name );
+        a->SetAttribute( value );
+    }
+
+    /**
+    	Delete an attribute.
+    */
+    void DeleteAttribute( const char* name );
+
+    /// Return the first attribute in the list.
+    const XMLAttribute* FirstAttribute() const {
+        return _rootAttribute;
+    }
+    /// Query a specific attribute in the list.
+    const XMLAttribute* FindAttribute( const char* name ) const;
+
+    /** Convenience function for easy access to the text inside an element. Although easy
+    	and concise, GetText() is limited compared to getting the XMLText child
+    	and accessing it directly.
+
+    	If the first child of 'this' is a XMLText, the GetText()
+    	returns the character string of the Text node, else null is returned.
+
+    	This is a convenient method for getting the text of simple contained text:
+    	@verbatim
+    	<foo>This is text</foo>
+    		const char* str = fooElement->GetText();
+    	@endverbatim
+
+    	'str' will be a pointer to "This is text".
+
+    	Note that this function can be misleading. If the element foo was created from
+    	this XML:
+    	@verbatim
+    		<foo><b>This is text</b></foo>
+    	@endverbatim
+
+    	then the value of str would be null. The first child node isn't a text node, it is
+    	another element. From this XML:
+    	@verbatim
+    		<foo>This is <b>text</b></foo>
+    	@endverbatim
+    	GetText() will return "This is ".
+    */
+    const char* GetText() const;
+
+    /** Convenience function for easy access to the text inside an element. Although easy
+    	and concise, SetText() is limited compared to creating an XMLText child
+    	and mutating it directly.
+
+    	If the first child of 'this' is a XMLText, SetText() sets its value to
+		the given string, otherwise it will create a first child that is an XMLText.
+
+    	This is a convenient method for setting the text of simple contained text:
+    	@verbatim
+    	<foo>This is text</foo>
+    		fooElement->SetText( "Hullaballoo!" );
+     	<foo>Hullaballoo!</foo>
+		@endverbatim
+
+    	Note that this function can be misleading. If the element foo was created from
+    	this XML:
+    	@verbatim
+    		<foo><b>This is text</b></foo>
+    	@endverbatim
+
+    	then it will not change "This is text", but rather prefix it with a text element:
+    	@verbatim
+    		<foo>Hullaballoo!<b>This is text</b></foo>
+    	@endverbatim
+
+		For this XML:
+    	@verbatim
+    		<foo />
+    	@endverbatim
+    	SetText() will generate
+    	@verbatim
+    		<foo>Hullaballoo!</foo>
+    	@endverbatim
+    */
+	void SetText( const char* inText );
+    /// Convenience method for setting text inside an element. See SetText() for important limitations.
+    void SetText( int value );
+    /// Convenience method for setting text inside an element. See SetText() for important limitations.
+    void SetText( unsigned value );
+	/// Convenience method for setting text inside an element. See SetText() for important limitations.
+	void SetText(int64_t value);
+    /// Convenience method for setting text inside an element. See SetText() for important limitations.
+    void SetText(uint64_t value);
+	/// Convenience method for setting text inside an element. See SetText() for important limitations.
+    void SetText( bool value );
+    /// Convenience method for setting text inside an element. See SetText() for important limitations.
+    void SetText( double value );
+    /// Convenience method for setting text inside an element. See SetText() for important limitations.
+    void SetText( float value );
+
+    /**
+    	Convenience method to query the value of a child text node. This is probably best
+    	shown by example. Given you have a document is this form:
+    	@verbatim
+    		<point>
+    			<x>1</x>
+    			<y>1.4</y>
+    		</point>
+    	@endverbatim
+
+    	The QueryIntText() and similar functions provide a safe and easier way to get to the
+    	"value" of x and y.
+
+    	@verbatim
+    		int x = 0;
+    		float y = 0;	// types of x and y are contrived for example
+    		const XMLElement* xElement = pointElement->FirstChildElement( "x" );
+    		const XMLElement* yElement = pointElement->FirstChildElement( "y" );
+    		xElement->QueryIntText( &x );
+    		yElement->QueryFloatText( &y );
+    	@endverbatim
+
+    	@returns XML_SUCCESS (0) on success, XML_CAN_NOT_CONVERT_TEXT if the text cannot be converted
+    			 to the requested type, and XML_NO_TEXT_NODE if there is no child text to query.
+
+    */
+    XMLError QueryIntText( int* ival ) const;
+    /// See QueryIntText()
+    XMLError QueryUnsignedText( unsigned* uval ) const;
+	/// See QueryIntText()
+	XMLError QueryInt64Text(int64_t* uval) const;
+	/// See QueryIntText()
+	XMLError QueryUnsigned64Text(uint64_t* uval) const;
+	/// See QueryIntText()
+    XMLError QueryBoolText( bool* bval ) const;
+    /// See QueryIntText()
+    XMLError QueryDoubleText( double* dval ) const;
+    /// See QueryIntText()
+    XMLError QueryFloatText( float* fval ) const;
+
+	int IntText(int defaultValue = 0) const;
+
+	/// See QueryIntText()
+	unsigned UnsignedText(unsigned defaultValue = 0) const;
+	/// See QueryIntText()
+	int64_t Int64Text(int64_t defaultValue = 0) const;
+    /// See QueryIntText()
+    uint64_t Unsigned64Text(uint64_t defaultValue = 0) const;
+	/// See QueryIntText()
+	bool BoolText(bool defaultValue = false) const;
+	/// See QueryIntText()
+	double DoubleText(double defaultValue = 0) const;
+	/// See QueryIntText()
+	float FloatText(float defaultValue = 0) const;
+
+    // internal:
+    enum ElementClosingType {
+        OPEN,		// <foo>
+        CLOSED,		// <foo/>
+        CLOSING		// </foo>
+    };
+    ElementClosingType ClosingType() const {
+        return _closingType;
+    }
+    virtual XMLNode* ShallowClone( XMLDocument* document ) const;
+    virtual bool ShallowEqual( const XMLNode* compare ) const;
+
+protected:
+    char* ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr );
+
+private:
+    XMLElement( XMLDocument* doc );
+    virtual ~XMLElement();
+    XMLElement( const XMLElement& );	// not supported
+    void operator=( const XMLElement& );	// not supported
+
+    XMLAttribute* FindOrCreateAttribute( const char* name );
+    char* ParseAttributes( char* p, int* curLineNumPtr );
+    static void DeleteAttribute( XMLAttribute* attribute );
+    XMLAttribute* CreateAttribute();
+
+    enum { BUF_SIZE = 200 };
+    ElementClosingType _closingType;
+    // The attribute list is ordered; there is no 'lastAttribute'
+    // because the list needs to be scanned for dupes before adding
+    // a new attribute.
+    XMLAttribute* _rootAttribute;
+};
+
+
+enum Whitespace {
+    PRESERVE_WHITESPACE,
+    COLLAPSE_WHITESPACE
+};
+
+
+/** A Document binds together all the functionality.
+	It can be saved, loaded, and printed to the screen.
+	All Nodes are connected and allocated to a Document.
+	If the Document is deleted, all its Nodes are also deleted.
+*/
+class TINYXML2_LIB XMLDocument : public XMLNode
+{
+    friend class XMLElement;
+    // Gives access to SetError and Push/PopDepth, but over-access for everything else.
+    // Wishing C++ had "internal" scope.
+    friend class XMLNode;
+    friend class XMLText;
+    friend class XMLComment;
+    friend class XMLDeclaration;
+    friend class XMLUnknown;
+public:
+    /// constructor
+    XMLDocument( bool processEntities = true, Whitespace whitespaceMode = PRESERVE_WHITESPACE );
+    ~XMLDocument();
+
+    virtual XMLDocument* ToDocument()				{
+        TIXMLASSERT( this == _document );
+        return this;
+    }
+    virtual const XMLDocument* ToDocument() const	{
+        TIXMLASSERT( this == _document );
+        return this;
+    }
+
+    /**
+    	Parse an XML file from a character string.
+    	Returns XML_SUCCESS (0) on success, or
+    	an errorID.
+
+    	You may optionally pass in the 'nBytes', which is
+    	the number of bytes which will be parsed. If not
+    	specified, TinyXML-2 will assume 'xml' points to a
+    	null terminated string.
+    */
+    XMLError Parse( const char* xml, size_t nBytes=static_cast<size_t>(-1) );
+
+    /**
+    	Load an XML file from disk.
+    	Returns XML_SUCCESS (0) on success, or
+    	an errorID.
+    */
+    XMLError LoadFile( const char* filename );
+
+    /**
+    	Load an XML file from disk. You are responsible
+    	for providing and closing the FILE*.
+
+        NOTE: The file should be opened as binary ("rb")
+        not text in order for TinyXML-2 to correctly
+        do newline normalization.
+
+    	Returns XML_SUCCESS (0) on success, or
+    	an errorID.
+    */
+    XMLError LoadFile( FILE* );
+
+    /**
+    	Save the XML file to disk.
+    	Returns XML_SUCCESS (0) on success, or
+    	an errorID.
+    */
+    XMLError SaveFile( const char* filename, bool compact = false );
+
+    /**
+    	Save the XML file to disk. You are responsible
+    	for providing and closing the FILE*.
+
+    	Returns XML_SUCCESS (0) on success, or
+    	an errorID.
+    */
+    XMLError SaveFile( FILE* fp, bool compact = false );
+
+    bool ProcessEntities() const		{
+        return _processEntities;
+    }
+    Whitespace WhitespaceMode() const	{
+        return _whitespaceMode;
+    }
+
+    /**
+    	Returns true if this document has a leading Byte Order Mark of UTF8.
+    */
+    bool HasBOM() const {
+        return _writeBOM;
+    }
+    /** Sets whether to write the BOM when writing the file.
+    */
+    void SetBOM( bool useBOM ) {
+        _writeBOM = useBOM;
+    }
+
+    /** Return the root element of DOM. Equivalent to FirstChildElement().
+        To get the first node, use FirstChild().
+    */
+    XMLElement* RootElement()				{
+        return FirstChildElement();
+    }
+    const XMLElement* RootElement() const	{
+        return FirstChildElement();
+    }
+
+    /** Print the Document. If the Printer is not provided, it will
+        print to stdout. If you provide Printer, this can print to a file:
+    	@verbatim
+    	XMLPrinter printer( fp );
+    	doc.Print( &printer );
+    	@endverbatim
+
+    	Or you can use a printer to print to memory:
+    	@verbatim
+    	XMLPrinter printer;
+    	doc.Print( &printer );
+    	// printer.CStr() has a const char* to the XML
+    	@endverbatim
+    */
+    void Print( XMLPrinter* streamer=0 ) const;
+    virtual bool Accept( XMLVisitor* visitor ) const;
+
+    /**
+    	Create a new Element associated with
+    	this Document. The memory for the Element
+    	is managed by the Document.
+    */
+    XMLElement* NewElement( const char* name );
+    /**
+    	Create a new Comment associated with
+    	this Document. The memory for the Comment
+    	is managed by the Document.
+    */
+    XMLComment* NewComment( const char* comment );
+    /**
+    	Create a new Text associated with
+    	this Document. The memory for the Text
+    	is managed by the Document.
+    */
+    XMLText* NewText( const char* text );
+    /**
+    	Create a new Declaration associated with
+    	this Document. The memory for the object
+    	is managed by the Document.
+
+    	If the 'text' param is null, the standard
+    	declaration is used.:
+    	@verbatim
+    		<?xml version="1.0" encoding="UTF-8"?>
+    	@endverbatim
+    */
+    XMLDeclaration* NewDeclaration( const char* text=0 );
+    /**
+    	Create a new Unknown associated with
+    	this Document. The memory for the object
+    	is managed by the Document.
+    */
+    XMLUnknown* NewUnknown( const char* text );
+
+    /**
+    	Delete a node associated with this document.
+    	It will be unlinked from the DOM.
+    */
+    void DeleteNode( XMLNode* node );
+
+    void ClearError() {
+        SetError(XML_SUCCESS, 0, 0);
+    }
+
+    /// Return true if there was an error parsing the document.
+    bool Error() const {
+        return _errorID != XML_SUCCESS;
+    }
+    /// Return the errorID.
+    XMLError  ErrorID() const {
+        return _errorID;
+    }
+	const char* ErrorName() const;
+    static const char* ErrorIDToName(XMLError errorID);
+
+    /** Returns a "long form" error description. A hopefully helpful
+        diagnostic with location, line number, and/or additional info.
+    */
+	const char* ErrorStr() const;
+
+    /// A (trivial) utility function that prints the ErrorStr() to stdout.
+    void PrintError() const;
+
+    /// Return the line where the error occurred, or zero if unknown.
+    int ErrorLineNum() const
+    {
+        return _errorLineNum;
+    }
+
+    /// Clear the document, resetting it to the initial state.
+    void Clear();
+
+	/**
+		Copies this document to a target document.
+		The target will be completely cleared before the copy.
+		If you want to copy a sub-tree, see XMLNode::DeepClone().
+
+		NOTE: that the 'target' must be non-null.
+	*/
+	void DeepCopy(XMLDocument* target) const;
+
+	// internal
+    char* Identify( char* p, XMLNode** node );
+
+	// internal
+	void MarkInUse(XMLNode*);
+
+    virtual XMLNode* ShallowClone( XMLDocument* /*document*/ ) const	{
+        return 0;
+    }
+    virtual bool ShallowEqual( const XMLNode* /*compare*/ ) const	{
+        return false;
+    }
+
+private:
+    XMLDocument( const XMLDocument& );	// not supported
+    void operator=( const XMLDocument& );	// not supported
+
+    bool			_writeBOM;
+    bool			_processEntities;
+    XMLError		_errorID;
+    Whitespace		_whitespaceMode;
+    mutable StrPair	_errorStr;
+    int             _errorLineNum;
+    char*			_charBuffer;
+    int				_parseCurLineNum;
+	int				_parsingDepth;
+	// Memory tracking does add some overhead.
+	// However, the code assumes that you don't
+	// have a bunch of unlinked nodes around.
+	// Therefore it takes less memory to track
+	// in the document vs. a linked list in the XMLNode,
+	// and the performance is the same.
+	DynArray<XMLNode*, 10> _unlinked;
+
+    MemPoolT< sizeof(XMLElement) >	 _elementPool;
+    MemPoolT< sizeof(XMLAttribute) > _attributePool;
+    MemPoolT< sizeof(XMLText) >		 _textPool;
+    MemPoolT< sizeof(XMLComment) >	 _commentPool;
+
+	static const char* _errorNames[XML_ERROR_COUNT];
+
+    void Parse();
+
+    void SetError( XMLError error, int lineNum, const char* format, ... );
+
+	// Something of an obvious security hole, once it was discovered.
+	// Either an ill-formed XML or an excessively deep one can overflow
+	// the stack. Track stack depth, and error out if needed.
+	class DepthTracker {
+	public:
+		explicit DepthTracker(XMLDocument * document) {
+			this->_document = document;
+			document->PushDepth();
+		}
+		~DepthTracker() {
+			_document->PopDepth();
+		}
+	private:
+		XMLDocument * _document;
+	};
+	void PushDepth();
+	void PopDepth();
+
+    template<class NodeType, int PoolElementSize>
+    NodeType* CreateUnlinkedNode( MemPoolT<PoolElementSize>& pool );
+};
+
+template<class NodeType, int PoolElementSize>
+inline NodeType* XMLDocument::CreateUnlinkedNode( MemPoolT<PoolElementSize>& pool )
+{
+    TIXMLASSERT( sizeof( NodeType ) == PoolElementSize );
+    TIXMLASSERT( sizeof( NodeType ) == pool.ItemSize() );
+    NodeType* returnNode = new (pool.Alloc()) NodeType( this );
+    TIXMLASSERT( returnNode );
+    returnNode->_memPool = &pool;
+
+	_unlinked.Push(returnNode);
+    return returnNode;
+}
+
+/**
+	A XMLHandle is a class that wraps a node pointer with null checks; this is
+	an incredibly useful thing. Note that XMLHandle is not part of the TinyXML-2
+	DOM structure. It is a separate utility class.
+
+	Take an example:
+	@verbatim
+	<Document>
+		<Element attributeA = "valueA">
+			<Child attributeB = "value1" />
+			<Child attributeB = "value2" />
+		</Element>
+	</Document>
+	@endverbatim
+
+	Assuming you want the value of "attributeB" in the 2nd "Child" element, it's very
+	easy to write a *lot* of code that looks like:
+
+	@verbatim
+	XMLElement* root = document.FirstChildElement( "Document" );
+	if ( root )
+	{
+		XMLElement* element = root->FirstChildElement( "Element" );
+		if ( element )
+		{
+			XMLElement* child = element->FirstChildElement( "Child" );
+			if ( child )
+			{
+				XMLElement* child2 = child->NextSiblingElement( "Child" );
+				if ( child2 )
+				{
+					// Finally do something useful.
+	@endverbatim
+
+	And that doesn't even cover "else" cases. XMLHandle addresses the verbosity
+	of such code. A XMLHandle checks for null pointers so it is perfectly safe
+	and correct to use:
+
+	@verbatim
+	XMLHandle docHandle( &document );
+	XMLElement* child2 = docHandle.FirstChildElement( "Document" ).FirstChildElement( "Element" ).FirstChildElement().NextSiblingElement();
+	if ( child2 )
+	{
+		// do something useful
+	@endverbatim
+
+	Which is MUCH more concise and useful.
+
+	It is also safe to copy handles - internally they are nothing more than node pointers.
+	@verbatim
+	XMLHandle handleCopy = handle;
+	@endverbatim
+
+	See also XMLConstHandle, which is the same as XMLHandle, but operates on const objects.
+*/
+class TINYXML2_LIB XMLHandle
+{
+public:
+    /// Create a handle from any node (at any depth of the tree.) This can be a null pointer.
+    explicit XMLHandle( XMLNode* node ) : _node( node ) {
+    }
+    /// Create a handle from a node.
+    explicit XMLHandle( XMLNode& node ) : _node( &node ) {
+    }
+    /// Copy constructor
+    XMLHandle( const XMLHandle& ref ) : _node( ref._node ) {
+    }
+    /// Assignment
+    XMLHandle& operator=( const XMLHandle& ref )							{
+        _node = ref._node;
+        return *this;
+    }
+
+    /// Get the first child of this handle.
+    XMLHandle FirstChild() 													{
+        return XMLHandle( _node ? _node->FirstChild() : 0 );
+    }
+    /// Get the first child element of this handle.
+    XMLHandle FirstChildElement( const char* name = 0 )						{
+        return XMLHandle( _node ? _node->FirstChildElement( name ) : 0 );
+    }
+    /// Get the last child of this handle.
+    XMLHandle LastChild()													{
+        return XMLHandle( _node ? _node->LastChild() : 0 );
+    }
+    /// Get the last child element of this handle.
+    XMLHandle LastChildElement( const char* name = 0 )						{
+        return XMLHandle( _node ? _node->LastChildElement( name ) : 0 );
+    }
+    /// Get the previous sibling of this handle.
+    XMLHandle PreviousSibling()												{
+        return XMLHandle( _node ? _node->PreviousSibling() : 0 );
+    }
+    /// Get the previous sibling element of this handle.
+    XMLHandle PreviousSiblingElement( const char* name = 0 )				{
+        return XMLHandle( _node ? _node->PreviousSiblingElement( name ) : 0 );
+    }
+    /// Get the next sibling of this handle.
+    XMLHandle NextSibling()													{
+        return XMLHandle( _node ? _node->NextSibling() : 0 );
+    }
+    /// Get the next sibling element of this handle.
+    XMLHandle NextSiblingElement( const char* name = 0 )					{
+        return XMLHandle( _node ? _node->NextSiblingElement( name ) : 0 );
+    }
+
+    /// Safe cast to XMLNode. This can return null.
+    XMLNode* ToNode()							{
+        return _node;
+    }
+    /// Safe cast to XMLElement. This can return null.
+    XMLElement* ToElement() 					{
+        return ( _node ? _node->ToElement() : 0 );
+    }
+    /// Safe cast to XMLText. This can return null.
+    XMLText* ToText() 							{
+        return ( _node ? _node->ToText() : 0 );
+    }
+    /// Safe cast to XMLUnknown. This can return null.
+    XMLUnknown* ToUnknown() 					{
+        return ( _node ? _node->ToUnknown() : 0 );
+    }
+    /// Safe cast to XMLDeclaration. This can return null.
+    XMLDeclaration* ToDeclaration() 			{
+        return ( _node ? _node->ToDeclaration() : 0 );
+    }
+
+private:
+    XMLNode* _node;
+};
+
+
+/**
+	A variant of the XMLHandle class for working with const XMLNodes and Documents. It is the
+	same in all regards, except for the 'const' qualifiers. See XMLHandle for API.
+*/
+class TINYXML2_LIB XMLConstHandle
+{
+public:
+    explicit XMLConstHandle( const XMLNode* node ) : _node( node ) {
+    }
+    explicit XMLConstHandle( const XMLNode& node ) : _node( &node ) {
+    }
+    XMLConstHandle( const XMLConstHandle& ref ) : _node( ref._node ) {
+    }
+
+    XMLConstHandle& operator=( const XMLConstHandle& ref )							{
+        _node = ref._node;
+        return *this;
+    }
+
+    const XMLConstHandle FirstChild() const											{
+        return XMLConstHandle( _node ? _node->FirstChild() : 0 );
+    }
+    const XMLConstHandle FirstChildElement( const char* name = 0 ) const				{
+        return XMLConstHandle( _node ? _node->FirstChildElement( name ) : 0 );
+    }
+    const XMLConstHandle LastChild()	const										{
+        return XMLConstHandle( _node ? _node->LastChild() : 0 );
+    }
+    const XMLConstHandle LastChildElement( const char* name = 0 ) const				{
+        return XMLConstHandle( _node ? _node->LastChildElement( name ) : 0 );
+    }
+    const XMLConstHandle PreviousSibling() const									{
+        return XMLConstHandle( _node ? _node->PreviousSibling() : 0 );
+    }
+    const XMLConstHandle PreviousSiblingElement( const char* name = 0 ) const		{
+        return XMLConstHandle( _node ? _node->PreviousSiblingElement( name ) : 0 );
+    }
+    const XMLConstHandle NextSibling() const										{
+        return XMLConstHandle( _node ? _node->NextSibling() : 0 );
+    }
+    const XMLConstHandle NextSiblingElement( const char* name = 0 ) const			{
+        return XMLConstHandle( _node ? _node->NextSiblingElement( name ) : 0 );
+    }
+
+
+    const XMLNode* ToNode() const				{
+        return _node;
+    }
+    const XMLElement* ToElement() const			{
+        return ( _node ? _node->ToElement() : 0 );
+    }
+    const XMLText* ToText() const				{
+        return ( _node ? _node->ToText() : 0 );
+    }
+    const XMLUnknown* ToUnknown() const			{
+        return ( _node ? _node->ToUnknown() : 0 );
+    }
+    const XMLDeclaration* ToDeclaration() const	{
+        return ( _node ? _node->ToDeclaration() : 0 );
+    }
+
+private:
+    const XMLNode* _node;
+};
+
+
+/**
+	Printing functionality. The XMLPrinter gives you more
+	options than the XMLDocument::Print() method.
+
+	It can:
+	-# Print to memory.
+	-# Print to a file you provide.
+	-# Print XML without a XMLDocument.
+
+	Print to Memory
+
+	@verbatim
+	XMLPrinter printer;
+	doc.Print( &printer );
+	SomeFunction( printer.CStr() );
+	@endverbatim
+
+	Print to a File
+
+	You provide the file pointer.
+	@verbatim
+	XMLPrinter printer( fp );
+	doc.Print( &printer );
+	@endverbatim
+
+	Print without a XMLDocument
+
+	When loading, an XML parser is very useful. However, sometimes
+	when saving, it just gets in the way. The code is often set up
+	for streaming, and constructing the DOM is just overhead.
+
+	The Printer supports the streaming case. The following code
+	prints out a trivially simple XML file without ever creating
+	an XML document.
+
+	@verbatim
+	XMLPrinter printer( fp );
+	printer.OpenElement( "foo" );
+	printer.PushAttribute( "foo", "bar" );
+	printer.CloseElement();
+	@endverbatim
+*/
+class TINYXML2_LIB XMLPrinter : public XMLVisitor
+{
+public:
+    /** Construct the printer. If the FILE* is specified,
+    	this will print to the FILE. Else it will print
+    	to memory, and the result is available in CStr().
+    	If 'compact' is set to true, then output is created
+    	with only required whitespace and newlines.
+    */
+    XMLPrinter( FILE* file=0, bool compact = false, int depth = 0 );
+    virtual ~XMLPrinter()	{}
+
+    /** If streaming, write the BOM and declaration. */
+    void PushHeader( bool writeBOM, bool writeDeclaration );
+    /** If streaming, start writing an element.
+        The element must be closed with CloseElement()
+    */
+    void OpenElement( const char* name, bool compactMode=false );
+    /// If streaming, add an attribute to an open element.
+    void PushAttribute( const char* name, const char* value );
+    void PushAttribute( const char* name, int value );
+    void PushAttribute( const char* name, unsigned value );
+	void PushAttribute( const char* name, int64_t value );
+	void PushAttribute( const char* name, uint64_t value );
+	void PushAttribute( const char* name, bool value );
+    void PushAttribute( const char* name, double value );
+    /// If streaming, close the Element.
+    virtual void CloseElement( bool compactMode=false );
+
+    /// Add a text node.
+    void PushText( const char* text, bool cdata=false );
+    /// Add a text node from an integer.
+    void PushText( int value );
+    /// Add a text node from an unsigned.
+    void PushText( unsigned value );
+	/// Add a text node from a signed 64bit integer.
+	void PushText( int64_t value );
+	/// Add a text node from an unsigned 64bit integer.
+	void PushText( uint64_t value );
+	/// Add a text node from a bool.
+    void PushText( bool value );
+    /// Add a text node from a float.
+    void PushText( float value );
+    /// Add a text node from a double.
+    void PushText( double value );
+
+    /// Add a comment
+    void PushComment( const char* comment );
+
+    void PushDeclaration( const char* value );
+    void PushUnknown( const char* value );
+
+    virtual bool VisitEnter( const XMLDocument& /*doc*/ );
+    virtual bool VisitExit( const XMLDocument& /*doc*/ )			{
+        return true;
+    }
+
+    virtual bool VisitEnter( const XMLElement& element, const XMLAttribute* attribute );
+    virtual bool VisitExit( const XMLElement& element );
+
+    virtual bool Visit( const XMLText& text );
+    virtual bool Visit( const XMLComment& comment );
+    virtual bool Visit( const XMLDeclaration& declaration );
+    virtual bool Visit( const XMLUnknown& unknown );
+
+    /**
+    	If in print to memory mode, return a pointer to
+    	the XML file in memory.
+    */
+    const char* CStr() const {
+        return _buffer.Mem();
+    }
+    /**
+    	If in print to memory mode, return the size
+    	of the XML file in memory. (Note the size returned
+    	includes the terminating null.)
+    */
+    int CStrSize() const {
+        return _buffer.Size();
+    }
+    /**
+    	If in print to memory mode, reset the buffer to the
+    	beginning.
+    */
+    void ClearBuffer( bool resetToFirstElement = true ) {
+        _buffer.Clear();
+        _buffer.Push(0);
+		_firstElement = resetToFirstElement;
+    }
+
+protected:
+	virtual bool CompactMode( const XMLElement& )	{ return _compactMode; }
+
+	/** Prints out the space before an element. You may override to change
+	    the space and tabs used. A PrintSpace() override should call Print().
+	*/
+    virtual void PrintSpace( int depth );
+    void Print( const char* format, ... );
+    void Write( const char* data, size_t size );
+    inline void Write( const char* data )           { Write( data, strlen( data ) ); }
+    void Putc( char ch );
+
+    void SealElementIfJustOpened();
+    bool _elementJustOpened;
+    DynArray< const char*, 10 > _stack;
+
+private:
+    void PrintString( const char*, bool restrictedEntitySet );	// prints out, after detecting entities.
+
+    bool _firstElement;
+    FILE* _fp;
+    int _depth;
+    int _textDepth;
+    bool _processEntities;
+	bool _compactMode;
+
+    enum {
+        ENTITY_RANGE = 64,
+        BUF_SIZE = 200
+    };
+    bool _entityFlag[ENTITY_RANGE];
+    bool _restrictedEntityFlag[ENTITY_RANGE];
+
+    DynArray< char, 20 > _buffer;
+
+    // Prohibit cloning, intentionally not implemented
+    XMLPrinter( const XMLPrinter& );
+    XMLPrinter& operator=( const XMLPrinter& );
+};
+
+
+}	// tinyxml2
+
+#if defined(_MSC_VER)
+#   pragma warning(pop)
+#endif
+
+#endif // TINYXML2_INCLUDED

--- a/include/aws/crt/external/tinyxml2.h
+++ b/include/aws/crt/external/tinyxml2.h
@@ -25,20 +25,20 @@ distribution.
 #define TINYXML2_INCLUDED
 
 #if defined(ANDROID_NDK) || defined(__BORLANDC__) || defined(__QNXNTO__)
-#   include <ctype.h>
-#   include <limits.h>
-#   include <stdio.h>
-#   include <stdlib.h>
-#   include <string.h>
-#	if defined(__PS3__)
-#		include <stddef.h>
-#	endif
+#    include <ctype.h>
+#    include <limits.h>
+#    include <stdio.h>
+#    include <stdlib.h>
+#    include <string.h>
+#    if defined(__PS3__)
+#        include <stddef.h>
+#    endif
 #else
-#   include <cctype>
-#   include <climits>
-#   include <cstdio>
-#   include <cstdlib>
-#   include <cstring>
+#    include <cctype>
+#    include <climits>
+#    include <cstdio>
+#    include <cstdlib>
+#    include <cstring>
 #endif
 #include <stdint.h>
 
@@ -46,57 +46,65 @@ distribution.
    TODO: intern strings instead of allocation.
 */
 /*
-	gcc:
+    gcc:
         g++ -Wall -DTINYXML2_DEBUG tinyxml2.cpp xmltest.cpp -o gccxmltest.exe
 
     Formatting, Artistic Style:
         AStyle.exe --style=1tbs --indent-switches --break-closing-brackets --indent-preprocessor tinyxml2.cpp tinyxml2.h
 */
 
-#if defined( _DEBUG ) || defined (__DEBUG__)
-#   ifndef TINYXML2_DEBUG
-#       define TINYXML2_DEBUG
-#   endif
+#if defined(_DEBUG) || defined(__DEBUG__)
+#    ifndef TINYXML2_DEBUG
+#        define TINYXML2_DEBUG
+#    endif
 #endif
 
 #ifdef _MSC_VER
-#   pragma warning(push)
-#   pragma warning(disable: 4251)
+#    pragma warning(push)
+#    pragma warning(disable : 4251)
 #endif
 
 #ifdef _WIN32
-#   ifdef TINYXML2_EXPORT
-#       define TINYXML2_LIB __declspec(dllexport)
-#   elif defined(TINYXML2_IMPORT)
-#       define TINYXML2_LIB __declspec(dllimport)
-#   else
-#       define TINYXML2_LIB
-#   endif
+#    ifdef TINYXML2_EXPORT
+#        define TINYXML2_LIB __declspec(dllexport)
+#    elif defined(TINYXML2_IMPORT)
+#        define TINYXML2_LIB __declspec(dllimport)
+#    else
+#        define TINYXML2_LIB
+#    endif
 #elif __GNUC__ >= 4
-#   define TINYXML2_LIB __attribute__((visibility("default")))
+#    define TINYXML2_LIB __attribute__((visibility("default")))
 #else
-#   define TINYXML2_LIB
+#    define TINYXML2_LIB
 #endif
-
 
 #if defined(TINYXML2_DEBUG)
-#   if defined(_MSC_VER)
-#       // "(void)0," is for suppressing C4127 warning in "assert(false)", "assert(true)" and the like
-#       define TIXMLASSERT( x )           if ( !((void)0,(x))) { __debugbreak(); }
-#   elif defined (ANDROID_NDK)
-#       include <android/log.h>
-#       define TIXMLASSERT( x )           if ( !(x)) { __android_log_assert( "assert", "grinliz", "ASSERT in '%s' at %d.", __FILE__, __LINE__ ); }
-#   else
-#       include <assert.h>
-#       define TIXMLASSERT                assert
-#   endif
+#    if defined(_MSC_VER)
+#        // "(void)0," is for suppressing C4127 warning in "assert(false)", "assert(true)" and the like
+#        define TIXMLASSERT(x)                                                                                         \
+            if (!((void)0, (x)))                                                                                       \
+            {                                                                                                          \
+                __debugbreak();                                                                                        \
+            }
+#    elif defined(ANDROID_NDK)
+#        include <android/log.h>
+#        define TIXMLASSERT(x)                                                                                         \
+            if (!(x))                                                                                                  \
+            {                                                                                                          \
+                __android_log_assert("assert", "grinliz", "ASSERT in '%s' at %d.", __FILE__, __LINE__);                \
+            }
+#    else
+#        include <assert.h>
+#        define TIXMLASSERT assert
+#    endif
 #else
-#   define TIXMLASSERT( x )               {}
+#    define TIXMLASSERT(x)                                                                                             \
+        {                                                                                                              \
+        }
 #endif
 
-
 /* Versioning, past 1.0.14:
-	http://semver.org/
+    http://semver.org/
 */
 static const int TIXML2_MAJOR_VERSION = 7;
 static const int TIXML2_MINOR_VERSION = 1;
@@ -115,2236 +123,2125 @@ static const int TINYXML2_MAX_ELEMENT_DEPTH = 100;
 
 namespace tinyxml2
 {
-class XMLDocument;
-class XMLElement;
-class XMLAttribute;
-class XMLComment;
-class XMLText;
-class XMLDeclaration;
-class XMLUnknown;
-class XMLPrinter;
+    class XMLDocument;
+    class XMLElement;
+    class XMLAttribute;
+    class XMLComment;
+    class XMLText;
+    class XMLDeclaration;
+    class XMLUnknown;
+    class XMLPrinter;
 
-/*
-	A class that wraps strings. Normally stores the start and end
-	pointers into the XML file itself, and will apply normalization
-	and entity translation if actually read. Can also store (and memory
-	manage) a traditional char[]
+    /*
+        A class that wraps strings. Normally stores the start and end
+        pointers into the XML file itself, and will apply normalization
+        and entity translation if actually read. Can also store (and memory
+        manage) a traditional char[]
 
-    Isn't clear why TINYXML2_LIB is needed; but seems to fix #719
-*/
-class TINYXML2_LIB StrPair
-{
-public:
-    enum {
-        NEEDS_ENTITY_PROCESSING			= 0x01,
-        NEEDS_NEWLINE_NORMALIZATION		= 0x02,
-        NEEDS_WHITESPACE_COLLAPSING     = 0x04,
-
-        TEXT_ELEMENT		            = NEEDS_ENTITY_PROCESSING | NEEDS_NEWLINE_NORMALIZATION,
-        TEXT_ELEMENT_LEAVE_ENTITIES		= NEEDS_NEWLINE_NORMALIZATION,
-        ATTRIBUTE_NAME		            = 0,
-        ATTRIBUTE_VALUE		            = NEEDS_ENTITY_PROCESSING | NEEDS_NEWLINE_NORMALIZATION,
-        ATTRIBUTE_VALUE_LEAVE_ENTITIES  = NEEDS_NEWLINE_NORMALIZATION,
-        COMMENT							= NEEDS_NEWLINE_NORMALIZATION
-    };
-
-    StrPair() : _flags( 0 ), _start( 0 ), _end( 0 ) {}
-    ~StrPair();
-
-    void Set( char* start, char* end, int flags ) {
-        TIXMLASSERT( start );
-        TIXMLASSERT( end );
-        Reset();
-        _start  = start;
-        _end    = end;
-        _flags  = flags | NEEDS_FLUSH;
-    }
-
-    const char* GetStr();
-
-    bool Empty() const {
-        return _start == _end;
-    }
-
-    void SetInternedStr( const char* str ) {
-        Reset();
-        _start = const_cast<char*>(str);
-    }
-
-    void SetStr( const char* str, int flags=0 );
-
-    char* ParseText( char* in, const char* endTag, int strFlags, int* curLineNumPtr );
-    char* ParseName( char* in );
-
-    void TransferTo( StrPair* other );
-	void Reset();
-
-private:
-    void CollapseWhitespace();
-
-    enum {
-        NEEDS_FLUSH = 0x100,
-        NEEDS_DELETE = 0x200
-    };
-
-    int     _flags;
-    char*   _start;
-    char*   _end;
-
-    StrPair( const StrPair& other );	// not supported
-    void operator=( const StrPair& other );	// not supported, use TransferTo()
-};
-
-
-/*
-	A dynamic array of Plain Old Data. Doesn't support constructors, etc.
-	Has a small initial memory pool, so that low or no usage will not
-	cause a call to new/delete
-*/
-template <class T, int INITIAL_SIZE>
-class DynArray
-{
-public:
-    DynArray() :
-        _mem( _pool ),
-        _allocated( INITIAL_SIZE ),
-        _size( 0 )
+        Isn't clear why TINYXML2_LIB is needed; but seems to fix #719
+    */
+    class TINYXML2_LIB StrPair
     {
-    }
+      public:
+        enum
+        {
+            NEEDS_ENTITY_PROCESSING = 0x01,
+            NEEDS_NEWLINE_NORMALIZATION = 0x02,
+            NEEDS_WHITESPACE_COLLAPSING = 0x04,
 
-    ~DynArray() {
-        if ( _mem != _pool ) {
-            delete [] _mem;
+            TEXT_ELEMENT = NEEDS_ENTITY_PROCESSING | NEEDS_NEWLINE_NORMALIZATION,
+            TEXT_ELEMENT_LEAVE_ENTITIES = NEEDS_NEWLINE_NORMALIZATION,
+            ATTRIBUTE_NAME = 0,
+            ATTRIBUTE_VALUE = NEEDS_ENTITY_PROCESSING | NEEDS_NEWLINE_NORMALIZATION,
+            ATTRIBUTE_VALUE_LEAVE_ENTITIES = NEEDS_NEWLINE_NORMALIZATION,
+            COMMENT = NEEDS_NEWLINE_NORMALIZATION
+        };
+
+        StrPair() : _flags(0), _start(0), _end(0) {}
+        ~StrPair();
+
+        void Set(char *start, char *end, int flags)
+        {
+            TIXMLASSERT(start);
+            TIXMLASSERT(end);
+            Reset();
+            _start = start;
+            _end = end;
+            _flags = flags | NEEDS_FLUSH;
         }
-    }
 
-    void Clear() {
-        _size = 0;
-    }
+        const char *GetStr();
 
-    void Push( T t ) {
-        TIXMLASSERT( _size < INT_MAX );
-        EnsureCapacity( _size+1 );
-        _mem[_size] = t;
-        ++_size;
-    }
+        bool Empty() const { return _start == _end; }
 
-    T* PushArr( int count ) {
-        TIXMLASSERT( count >= 0 );
-        TIXMLASSERT( _size <= INT_MAX - count );
-        EnsureCapacity( _size+count );
-        T* ret = &_mem[_size];
-        _size += count;
-        return ret;
-    }
+        void SetInternedStr(const char *str)
+        {
+            Reset();
+            _start = const_cast<char *>(str);
+        }
 
-    T Pop() {
-        TIXMLASSERT( _size > 0 );
-        --_size;
-        return _mem[_size];
-    }
+        void SetStr(const char *str, int flags = 0);
 
-    void PopArr( int count ) {
-        TIXMLASSERT( _size >= count );
-        _size -= count;
-    }
+        char *ParseText(char *in, const char *endTag, int strFlags, int *curLineNumPtr);
+        char *ParseName(char *in);
 
-    bool Empty() const					{
-        return _size == 0;
-    }
+        void TransferTo(StrPair *other);
+        void Reset();
 
-    T& operator[](int i)				{
-        TIXMLASSERT( i>= 0 && i < _size );
-        return _mem[i];
-    }
+      private:
+        void CollapseWhitespace();
 
-    const T& operator[](int i) const	{
-        TIXMLASSERT( i>= 0 && i < _size );
-        return _mem[i];
-    }
+        enum
+        {
+            NEEDS_FLUSH = 0x100,
+            NEEDS_DELETE = 0x200
+        };
 
-    const T& PeekTop() const            {
-        TIXMLASSERT( _size > 0 );
-        return _mem[ _size - 1];
-    }
+        int _flags;
+        char *_start;
+        char *_end;
 
-    int Size() const					{
-        TIXMLASSERT( _size >= 0 );
-        return _size;
-    }
+        StrPair(const StrPair &other);        // not supported
+        void operator=(const StrPair &other); // not supported, use TransferTo()
+    };
 
-    int Capacity() const				{
-        TIXMLASSERT( _allocated >= INITIAL_SIZE );
-        return _allocated;
-    }
+    /*
+        A dynamic array of Plain Old Data. Doesn't support constructors, etc.
+        Has a small initial memory pool, so that low or no usage will not
+        cause a call to new/delete
+    */
+    template <class T, int INITIAL_SIZE> class DynArray
+    {
+      public:
+        DynArray() : _mem(_pool), _allocated(INITIAL_SIZE), _size(0) {}
 
-	void SwapRemove(int i) {
-		TIXMLASSERT(i >= 0 && i < _size);
-		TIXMLASSERT(_size > 0);
-		_mem[i] = _mem[_size - 1];
-		--_size;
-	}
-
-    const T* Mem() const				{
-        TIXMLASSERT( _mem );
-        return _mem;
-    }
-
-    T* Mem() {
-        TIXMLASSERT( _mem );
-        return _mem;
-    }
-
-private:
-    DynArray( const DynArray& ); // not supported
-    void operator=( const DynArray& ); // not supported
-
-    void EnsureCapacity( int cap ) {
-        TIXMLASSERT( cap > 0 );
-        if ( cap > _allocated ) {
-            TIXMLASSERT( cap <= INT_MAX / 2 );
-            const int newAllocated = cap * 2;
-            T* newMem = new T[newAllocated];
-            TIXMLASSERT( newAllocated >= _size );
-            memcpy( newMem, _mem, sizeof(T)*_size );	// warning: not using constructors, only works for PODs
-            if ( _mem != _pool ) {
-                delete [] _mem;
+        ~DynArray()
+        {
+            if (_mem != _pool)
+            {
+                delete[] _mem;
             }
-            _mem = newMem;
-            _allocated = newAllocated;
         }
-    }
 
-    T*  _mem;
-    T   _pool[INITIAL_SIZE];
-    int _allocated;		// objects allocated
-    int _size;			// number objects in use
-};
+        void Clear() { _size = 0; }
 
-
-/*
-	Parent virtual class of a pool for fast allocation
-	and deallocation of objects.
-*/
-class MemPool
-{
-public:
-    MemPool() {}
-    virtual ~MemPool() {}
-
-    virtual int ItemSize() const = 0;
-    virtual void* Alloc() = 0;
-    virtual void Free( void* ) = 0;
-    virtual void SetTracked() = 0;
-};
-
-
-/*
-	Template child class to create pools of the correct type.
-*/
-template< int ITEM_SIZE >
-class MemPoolT : public MemPool
-{
-public:
-    MemPoolT() : _blockPtrs(), _root(0), _currentAllocs(0), _nAllocs(0), _maxAllocs(0), _nUntracked(0)	{}
-    ~MemPoolT() {
-        MemPoolT< ITEM_SIZE >::Clear();
-    }
-
-    void Clear() {
-        // Delete the blocks.
-        while( !_blockPtrs.Empty()) {
-            Block* lastBlock = _blockPtrs.Pop();
-            delete lastBlock;
+        void Push(T t)
+        {
+            TIXMLASSERT(_size < INT_MAX);
+            EnsureCapacity(_size + 1);
+            _mem[_size] = t;
+            ++_size;
         }
-        _root = 0;
-        _currentAllocs = 0;
-        _nAllocs = 0;
-        _maxAllocs = 0;
-        _nUntracked = 0;
-    }
 
-    virtual int ItemSize() const	{
-        return ITEM_SIZE;
-    }
-    int CurrentAllocs() const		{
-        return _currentAllocs;
-    }
+        T *PushArr(int count)
+        {
+            TIXMLASSERT(count >= 0);
+            TIXMLASSERT(_size <= INT_MAX - count);
+            EnsureCapacity(_size + count);
+            T *ret = &_mem[_size];
+            _size += count;
+            return ret;
+        }
 
-    virtual void* Alloc() {
-        if ( !_root ) {
-            // Need a new block.
-            Block* block = new Block();
-            _blockPtrs.Push( block );
+        T Pop()
+        {
+            TIXMLASSERT(_size > 0);
+            --_size;
+            return _mem[_size];
+        }
 
-            Item* blockItems = block->items;
-            for( int i = 0; i < ITEMS_PER_BLOCK - 1; ++i ) {
-                blockItems[i].next = &(blockItems[i + 1]);
+        void PopArr(int count)
+        {
+            TIXMLASSERT(_size >= count);
+            _size -= count;
+        }
+
+        bool Empty() const { return _size == 0; }
+
+        T &operator[](int i)
+        {
+            TIXMLASSERT(i >= 0 && i < _size);
+            return _mem[i];
+        }
+
+        const T &operator[](int i) const
+        {
+            TIXMLASSERT(i >= 0 && i < _size);
+            return _mem[i];
+        }
+
+        const T &PeekTop() const
+        {
+            TIXMLASSERT(_size > 0);
+            return _mem[_size - 1];
+        }
+
+        int Size() const
+        {
+            TIXMLASSERT(_size >= 0);
+            return _size;
+        }
+
+        int Capacity() const
+        {
+            TIXMLASSERT(_allocated >= INITIAL_SIZE);
+            return _allocated;
+        }
+
+        void SwapRemove(int i)
+        {
+            TIXMLASSERT(i >= 0 && i < _size);
+            TIXMLASSERT(_size > 0);
+            _mem[i] = _mem[_size - 1];
+            --_size;
+        }
+
+        const T *Mem() const
+        {
+            TIXMLASSERT(_mem);
+            return _mem;
+        }
+
+        T *Mem()
+        {
+            TIXMLASSERT(_mem);
+            return _mem;
+        }
+
+      private:
+        DynArray(const DynArray &);       // not supported
+        void operator=(const DynArray &); // not supported
+
+        void EnsureCapacity(int cap)
+        {
+            TIXMLASSERT(cap > 0);
+            if (cap > _allocated)
+            {
+                TIXMLASSERT(cap <= INT_MAX / 2);
+                const int newAllocated = cap * 2;
+                T *newMem = new T[newAllocated];
+                TIXMLASSERT(newAllocated >= _size);
+                memcpy(newMem, _mem, sizeof(T) * _size); // warning: not using constructors, only works for PODs
+                if (_mem != _pool)
+                {
+                    delete[] _mem;
+                }
+                _mem = newMem;
+                _allocated = newAllocated;
             }
-            blockItems[ITEMS_PER_BLOCK - 1].next = 0;
-            _root = blockItems;
         }
-        Item* const result = _root;
-        TIXMLASSERT( result != 0 );
-        _root = _root->next;
 
-        ++_currentAllocs;
-        if ( _currentAllocs > _maxAllocs ) {
-            _maxAllocs = _currentAllocs;
-        }
-        ++_nAllocs;
-        ++_nUntracked;
-        return result;
-    }
+        T *_mem;
+        T _pool[INITIAL_SIZE];
+        int _allocated; // objects allocated
+        int _size;      // number objects in use
+    };
 
-    virtual void Free( void* mem ) {
-        if ( !mem ) {
-            return;
+    /*
+        Parent virtual class of a pool for fast allocation
+        and deallocation of objects.
+    */
+    class MemPool
+    {
+      public:
+        MemPool() {}
+        virtual ~MemPool() {}
+
+        virtual int ItemSize() const = 0;
+        virtual void *Alloc() = 0;
+        virtual void Free(void *) = 0;
+        virtual void SetTracked() = 0;
+    };
+
+    /*
+        Template child class to create pools of the correct type.
+    */
+    template <int ITEM_SIZE> class MemPoolT : public MemPool
+    {
+      public:
+        MemPoolT() : _blockPtrs(), _root(0), _currentAllocs(0), _nAllocs(0), _maxAllocs(0), _nUntracked(0) {}
+        ~MemPoolT() { MemPoolT<ITEM_SIZE>::Clear(); }
+
+        void Clear()
+        {
+            // Delete the blocks.
+            while (!_blockPtrs.Empty())
+            {
+                Block *lastBlock = _blockPtrs.Pop();
+                delete lastBlock;
+            }
+            _root = 0;
+            _currentAllocs = 0;
+            _nAllocs = 0;
+            _maxAllocs = 0;
+            _nUntracked = 0;
         }
-        --_currentAllocs;
-        Item* item = static_cast<Item*>( mem );
+
+        virtual int ItemSize() const { return ITEM_SIZE; }
+        int CurrentAllocs() const { return _currentAllocs; }
+
+        virtual void *Alloc()
+        {
+            if (!_root)
+            {
+                // Need a new block.
+                Block *block = new Block();
+                _blockPtrs.Push(block);
+
+                Item *blockItems = block->items;
+                for (int i = 0; i < ITEMS_PER_BLOCK - 1; ++i)
+                {
+                    blockItems[i].next = &(blockItems[i + 1]);
+                }
+                blockItems[ITEMS_PER_BLOCK - 1].next = 0;
+                _root = blockItems;
+            }
+            Item *const result = _root;
+            TIXMLASSERT(result != 0);
+            _root = _root->next;
+
+            ++_currentAllocs;
+            if (_currentAllocs > _maxAllocs)
+            {
+                _maxAllocs = _currentAllocs;
+            }
+            ++_nAllocs;
+            ++_nUntracked;
+            return result;
+        }
+
+        virtual void Free(void *mem)
+        {
+            if (!mem)
+            {
+                return;
+            }
+            --_currentAllocs;
+            Item *item = static_cast<Item *>(mem);
 #ifdef TINYXML2_DEBUG
-        memset( item, 0xfe, sizeof( *item ) );
+            memset(item, 0xfe, sizeof(*item));
 #endif
-        item->next = _root;
-        _root = item;
-    }
-    void Trace( const char* name ) {
-        printf( "Mempool %s watermark=%d [%dk] current=%d size=%d nAlloc=%d blocks=%d\n",
-                name, _maxAllocs, _maxAllocs * ITEM_SIZE / 1024, _currentAllocs,
-                ITEM_SIZE, _nAllocs, _blockPtrs.Size() );
-    }
+            item->next = _root;
+            _root = item;
+        }
+        void Trace(const char *name)
+        {
+            printf(
+                "Mempool %s watermark=%d [%dk] current=%d size=%d nAlloc=%d blocks=%d\n",
+                name,
+                _maxAllocs,
+                _maxAllocs * ITEM_SIZE / 1024,
+                _currentAllocs,
+                ITEM_SIZE,
+                _nAllocs,
+                _blockPtrs.Size());
+        }
 
-    void SetTracked() {
-        --_nUntracked;
-    }
+        void SetTracked() { --_nUntracked; }
 
-    int Untracked() const {
-        return _nUntracked;
-    }
+        int Untracked() const { return _nUntracked; }
 
-	// This number is perf sensitive. 4k seems like a good tradeoff on my machine.
-	// The test file is large, 170k.
-	// Release:		VS2010 gcc(no opt)
-	//		1k:		4000
-	//		2k:		4000
-	//		4k:		3900	21000
-	//		16k:	5200
-	//		32k:	4300
-	//		64k:	4000	21000
-    // Declared public because some compilers do not accept to use ITEMS_PER_BLOCK
-    // in private part if ITEMS_PER_BLOCK is private
-    enum { ITEMS_PER_BLOCK = (4 * 1024) / ITEM_SIZE };
+        // This number is perf sensitive. 4k seems like a good tradeoff on my machine.
+        // The test file is large, 170k.
+        // Release:		VS2010 gcc(no opt)
+        //		1k:		4000
+        //		2k:		4000
+        //		4k:		3900	21000
+        //		16k:	5200
+        //		32k:	4300
+        //		64k:	4000	21000
+        // Declared public because some compilers do not accept to use ITEMS_PER_BLOCK
+        // in private part if ITEMS_PER_BLOCK is private
+        enum
+        {
+            ITEMS_PER_BLOCK = (4 * 1024) / ITEM_SIZE
+        };
 
-private:
-    MemPoolT( const MemPoolT& ); // not supported
-    void operator=( const MemPoolT& ); // not supported
+      private:
+        MemPoolT(const MemPoolT &);       // not supported
+        void operator=(const MemPoolT &); // not supported
 
-    union Item {
-        Item*   next;
-        char    itemData[ITEM_SIZE];
+        union Item {
+            Item *next;
+            char itemData[ITEM_SIZE];
+        };
+        struct Block
+        {
+            Item items[ITEMS_PER_BLOCK];
+        };
+        DynArray<Block *, 10> _blockPtrs;
+        Item *_root;
+
+        int _currentAllocs;
+        int _nAllocs;
+        int _maxAllocs;
+        int _nUntracked;
     };
-    struct Block {
-        Item items[ITEMS_PER_BLOCK];
-    };
-    DynArray< Block*, 10 > _blockPtrs;
-    Item* _root;
-
-    int _currentAllocs;
-    int _nAllocs;
-    int _maxAllocs;
-    int _nUntracked;
-};
-
-
-
-/**
-	Implements the interface to the "Visitor pattern" (see the Accept() method.)
-	If you call the Accept() method, it requires being passed a XMLVisitor
-	class to handle callbacks. For nodes that contain other nodes (Document, Element)
-	you will get called with a VisitEnter/VisitExit pair. Nodes that are always leafs
-	are simply called with Visit().
-
-	If you return 'true' from a Visit method, recursive parsing will continue. If you return
-	false, <b>no children of this node or its siblings</b> will be visited.
-
-	All flavors of Visit methods have a default implementation that returns 'true' (continue
-	visiting). You need to only override methods that are interesting to you.
-
-	Generally Accept() is called on the XMLDocument, although all nodes support visiting.
-
-	You should never change the document from a callback.
-
-	@sa XMLNode::Accept()
-*/
-class TINYXML2_LIB XMLVisitor
-{
-public:
-    virtual ~XMLVisitor() {}
-
-    /// Visit a document.
-    virtual bool VisitEnter( const XMLDocument& /*doc*/ )			{
-        return true;
-    }
-    /// Visit a document.
-    virtual bool VisitExit( const XMLDocument& /*doc*/ )			{
-        return true;
-    }
-
-    /// Visit an element.
-    virtual bool VisitEnter( const XMLElement& /*element*/, const XMLAttribute* /*firstAttribute*/ )	{
-        return true;
-    }
-    /// Visit an element.
-    virtual bool VisitExit( const XMLElement& /*element*/ )			{
-        return true;
-    }
-
-    /// Visit a declaration.
-    virtual bool Visit( const XMLDeclaration& /*declaration*/ )		{
-        return true;
-    }
-    /// Visit a text node.
-    virtual bool Visit( const XMLText& /*text*/ )					{
-        return true;
-    }
-    /// Visit a comment node.
-    virtual bool Visit( const XMLComment& /*comment*/ )				{
-        return true;
-    }
-    /// Visit an unknown node.
-    virtual bool Visit( const XMLUnknown& /*unknown*/ )				{
-        return true;
-    }
-};
-
-// WARNING: must match XMLDocument::_errorNames[]
-enum XMLError {
-    XML_SUCCESS = 0,
-    XML_NO_ATTRIBUTE,
-    XML_WRONG_ATTRIBUTE_TYPE,
-    XML_ERROR_FILE_NOT_FOUND,
-    XML_ERROR_FILE_COULD_NOT_BE_OPENED,
-    XML_ERROR_FILE_READ_ERROR,
-    XML_ERROR_PARSING_ELEMENT,
-    XML_ERROR_PARSING_ATTRIBUTE,
-    XML_ERROR_PARSING_TEXT,
-    XML_ERROR_PARSING_CDATA,
-    XML_ERROR_PARSING_COMMENT,
-    XML_ERROR_PARSING_DECLARATION,
-    XML_ERROR_PARSING_UNKNOWN,
-    XML_ERROR_EMPTY_DOCUMENT,
-    XML_ERROR_MISMATCHED_ELEMENT,
-    XML_ERROR_PARSING,
-    XML_CAN_NOT_CONVERT_TEXT,
-    XML_NO_TEXT_NODE,
-	XML_ELEMENT_DEPTH_EXCEEDED,
-
-	XML_ERROR_COUNT
-};
-
-
-/*
-	Utility functionality.
-*/
-class TINYXML2_LIB XMLUtil
-{
-public:
-    static const char* SkipWhiteSpace( const char* p, int* curLineNumPtr )	{
-        TIXMLASSERT( p );
-
-        while( IsWhiteSpace(*p) ) {
-            if (curLineNumPtr && *p == '\n') {
-                ++(*curLineNumPtr);
-            }
-            ++p;
-        }
-        TIXMLASSERT( p );
-        return p;
-    }
-    static char* SkipWhiteSpace( char* p, int* curLineNumPtr )				{
-        return const_cast<char*>( SkipWhiteSpace( const_cast<const char*>(p), curLineNumPtr ) );
-    }
-
-    // Anything in the high order range of UTF-8 is assumed to not be whitespace. This isn't
-    // correct, but simple, and usually works.
-    static bool IsWhiteSpace( char p )					{
-        return !IsUTF8Continuation(p) && isspace( static_cast<unsigned char>(p) );
-    }
-
-    inline static bool IsNameStartChar( unsigned char ch ) {
-        if ( ch >= 128 ) {
-            // This is a heuristic guess in attempt to not implement Unicode-aware isalpha()
-            return true;
-        }
-        if ( isalpha( ch ) ) {
-            return true;
-        }
-        return ch == ':' || ch == '_';
-    }
-
-    inline static bool IsNameChar( unsigned char ch ) {
-        return IsNameStartChar( ch )
-               || isdigit( ch )
-               || ch == '.'
-               || ch == '-';
-    }
-
-    inline static bool StringEqual( const char* p, const char* q, int nChar=INT_MAX )  {
-        if ( p == q ) {
-            return true;
-        }
-        TIXMLASSERT( p );
-        TIXMLASSERT( q );
-        TIXMLASSERT( nChar >= 0 );
-        return strncmp( p, q, nChar ) == 0;
-    }
-
-    inline static bool IsUTF8Continuation( char p ) {
-        return ( p & 0x80 ) != 0;
-    }
-
-    static const char* ReadBOM( const char* p, bool* hasBOM );
-    // p is the starting location,
-    // the UTF-8 value of the entity will be placed in value, and length filled in.
-    static const char* GetCharacterRef( const char* p, char* value, int* length );
-    static void ConvertUTF32ToUTF8( unsigned long input, char* output, int* length );
-
-    // converts primitive types to strings
-    static void ToStr( int v, char* buffer, int bufferSize );
-    static void ToStr( unsigned v, char* buffer, int bufferSize );
-    static void ToStr( bool v, char* buffer, int bufferSize );
-    static void ToStr( float v, char* buffer, int bufferSize );
-    static void ToStr( double v, char* buffer, int bufferSize );
-	static void ToStr(int64_t v, char* buffer, int bufferSize);
-    static void ToStr(uint64_t v, char* buffer, int bufferSize);
-
-    // converts strings to primitive types
-    static bool	ToInt( const char* str, int* value );
-    static bool ToUnsigned( const char* str, unsigned* value );
-    static bool	ToBool( const char* str, bool* value );
-    static bool	ToFloat( const char* str, float* value );
-    static bool ToDouble( const char* str, double* value );
-	static bool ToInt64(const char* str, int64_t* value);
-    static bool ToUnsigned64(const char* str, uint64_t* value);
-	// Changes what is serialized for a boolean value.
-	// Default to "true" and "false". Shouldn't be changed
-	// unless you have a special testing or compatibility need.
-	// Be careful: static, global, & not thread safe.
-	// Be sure to set static const memory as parameters.
-	static void SetBoolSerialization(const char* writeTrue, const char* writeFalse);
-
-private:
-	static const char* writeBoolTrue;
-	static const char* writeBoolFalse;
-};
-
-
-/** XMLNode is a base class for every object that is in the
-	XML Document Object Model (DOM), except XMLAttributes.
-	Nodes have siblings, a parent, and children which can
-	be navigated. A node is always in a XMLDocument.
-	The type of a XMLNode can be queried, and it can
-	be cast to its more defined type.
-
-	A XMLDocument allocates memory for all its Nodes.
-	When the XMLDocument gets deleted, all its Nodes
-	will also be deleted.
-
-	@verbatim
-	A Document can contain:	Element	(container or leaf)
-							Comment (leaf)
-							Unknown (leaf)
-							Declaration( leaf )
-
-	An Element can contain:	Element (container or leaf)
-							Text	(leaf)
-							Attributes (not on tree)
-							Comment (leaf)
-							Unknown (leaf)
-
-	@endverbatim
-*/
-class TINYXML2_LIB XMLNode
-{
-    friend class XMLDocument;
-    friend class XMLElement;
-public:
-
-    /// Get the XMLDocument that owns this XMLNode.
-    const XMLDocument* GetDocument() const	{
-        TIXMLASSERT( _document );
-        return _document;
-    }
-    /// Get the XMLDocument that owns this XMLNode.
-    XMLDocument* GetDocument()				{
-        TIXMLASSERT( _document );
-        return _document;
-    }
-
-    /// Safely cast to an Element, or null.
-    virtual XMLElement*		ToElement()		{
-        return 0;
-    }
-    /// Safely cast to Text, or null.
-    virtual XMLText*		ToText()		{
-        return 0;
-    }
-    /// Safely cast to a Comment, or null.
-    virtual XMLComment*		ToComment()		{
-        return 0;
-    }
-    /// Safely cast to a Document, or null.
-    virtual XMLDocument*	ToDocument()	{
-        return 0;
-    }
-    /// Safely cast to a Declaration, or null.
-    virtual XMLDeclaration*	ToDeclaration()	{
-        return 0;
-    }
-    /// Safely cast to an Unknown, or null.
-    virtual XMLUnknown*		ToUnknown()		{
-        return 0;
-    }
-
-    virtual const XMLElement*		ToElement() const		{
-        return 0;
-    }
-    virtual const XMLText*			ToText() const			{
-        return 0;
-    }
-    virtual const XMLComment*		ToComment() const		{
-        return 0;
-    }
-    virtual const XMLDocument*		ToDocument() const		{
-        return 0;
-    }
-    virtual const XMLDeclaration*	ToDeclaration() const	{
-        return 0;
-    }
-    virtual const XMLUnknown*		ToUnknown() const		{
-        return 0;
-    }
-
-    /** The meaning of 'value' changes for the specific type.
-    	@verbatim
-    	Document:	empty (NULL is returned, not an empty string)
-    	Element:	name of the element
-    	Comment:	the comment text
-    	Unknown:	the tag contents
-    	Text:		the text string
-    	@endverbatim
-    */
-    const char* Value() const;
-
-    /** Set the Value of an XML node.
-    	@sa Value()
-    */
-    void SetValue( const char* val, bool staticMem=false );
-
-    /// Gets the line number the node is in, if the document was parsed from a file.
-    int GetLineNum() const { return _parseLineNum; }
-
-    /// Get the parent of this node on the DOM.
-    const XMLNode*	Parent() const			{
-        return _parent;
-    }
-
-    XMLNode* Parent()						{
-        return _parent;
-    }
-
-    /// Returns true if this node has no children.
-    bool NoChildren() const					{
-        return !_firstChild;
-    }
-
-    /// Get the first child node, or null if none exists.
-    const XMLNode*  FirstChild() const		{
-        return _firstChild;
-    }
-
-    XMLNode*		FirstChild()			{
-        return _firstChild;
-    }
-
-    /** Get the first child element, or optionally the first child
-        element with the specified name.
-    */
-    const XMLElement* FirstChildElement( const char* name = 0 ) const;
-
-    XMLElement* FirstChildElement( const char* name = 0 )	{
-        return const_cast<XMLElement*>(const_cast<const XMLNode*>(this)->FirstChildElement( name ));
-    }
-
-    /// Get the last child node, or null if none exists.
-    const XMLNode*	LastChild() const						{
-        return _lastChild;
-    }
-
-    XMLNode*		LastChild()								{
-        return _lastChild;
-    }
-
-    /** Get the last child element or optionally the last child
-        element with the specified name.
-    */
-    const XMLElement* LastChildElement( const char* name = 0 ) const;
-
-    XMLElement* LastChildElement( const char* name = 0 )	{
-        return const_cast<XMLElement*>(const_cast<const XMLNode*>(this)->LastChildElement(name) );
-    }
-
-    /// Get the previous (left) sibling node of this node.
-    const XMLNode*	PreviousSibling() const					{
-        return _prev;
-    }
-
-    XMLNode*	PreviousSibling()							{
-        return _prev;
-    }
-
-    /// Get the previous (left) sibling element of this node, with an optionally supplied name.
-    const XMLElement*	PreviousSiblingElement( const char* name = 0 ) const ;
-
-    XMLElement*	PreviousSiblingElement( const char* name = 0 ) {
-        return const_cast<XMLElement*>(const_cast<const XMLNode*>(this)->PreviousSiblingElement( name ) );
-    }
-
-    /// Get the next (right) sibling node of this node.
-    const XMLNode*	NextSibling() const						{
-        return _next;
-    }
-
-    XMLNode*	NextSibling()								{
-        return _next;
-    }
-
-    /// Get the next (right) sibling element of this node, with an optionally supplied name.
-    const XMLElement*	NextSiblingElement( const char* name = 0 ) const;
-
-    XMLElement*	NextSiblingElement( const char* name = 0 )	{
-        return const_cast<XMLElement*>(const_cast<const XMLNode*>(this)->NextSiblingElement( name ) );
-    }
 
     /**
-    	Add a child node as the last (right) child.
-		If the child node is already part of the document,
-		it is moved from its old location to the new location.
-		Returns the addThis argument or 0 if the node does not
-		belong to the same document.
+        Implements the interface to the "Visitor pattern" (see the Accept() method.)
+        If you call the Accept() method, it requires being passed a XMLVisitor
+        class to handle callbacks. For nodes that contain other nodes (Document, Element)
+        you will get called with a VisitEnter/VisitExit pair. Nodes that are always leafs
+        are simply called with Visit().
+
+        If you return 'true' from a Visit method, recursive parsing will continue. If you return
+        false, <b>no children of this node or its siblings</b> will be visited.
+
+        All flavors of Visit methods have a default implementation that returns 'true' (continue
+        visiting). You need to only override methods that are interesting to you.
+
+        Generally Accept() is called on the XMLDocument, although all nodes support visiting.
+
+        You should never change the document from a callback.
+
+        @sa XMLNode::Accept()
     */
-    XMLNode* InsertEndChild( XMLNode* addThis );
-
-    XMLNode* LinkEndChild( XMLNode* addThis )	{
-        return InsertEndChild( addThis );
-    }
-    /**
-    	Add a child node as the first (left) child.
-		If the child node is already part of the document,
-		it is moved from its old location to the new location.
-		Returns the addThis argument or 0 if the node does not
-		belong to the same document.
-    */
-    XMLNode* InsertFirstChild( XMLNode* addThis );
-    /**
-    	Add a node after the specified child node.
-		If the child node is already part of the document,
-		it is moved from its old location to the new location.
-		Returns the addThis argument or 0 if the afterThis node
-		is not a child of this node, or if the node does not
-		belong to the same document.
-    */
-    XMLNode* InsertAfterChild( XMLNode* afterThis, XMLNode* addThis );
-
-    /**
-    	Delete all the children of this node.
-    */
-    void DeleteChildren();
-
-    /**
-    	Delete a child of this node.
-    */
-    void DeleteChild( XMLNode* node );
-
-    /**
-    	Make a copy of this node, but not its children.
-    	You may pass in a Document pointer that will be
-    	the owner of the new Node. If the 'document' is
-    	null, then the node returned will be allocated
-    	from the current Document. (this->GetDocument())
-
-    	Note: if called on a XMLDocument, this will return null.
-    */
-    virtual XMLNode* ShallowClone( XMLDocument* document ) const = 0;
-
-	/**
-		Make a copy of this node and all its children.
-
-		If the 'target' is null, then the nodes will
-		be allocated in the current document. If 'target'
-        is specified, the memory will be allocated is the
-        specified XMLDocument.
-
-		NOTE: This is probably not the correct tool to
-		copy a document, since XMLDocuments can have multiple
-		top level XMLNodes. You probably want to use
-        XMLDocument::DeepCopy()
-	*/
-	XMLNode* DeepClone( XMLDocument* target ) const;
-
-    /**
-    	Test if 2 nodes are the same, but don't test children.
-    	The 2 nodes do not need to be in the same Document.
-
-    	Note: if called on a XMLDocument, this will return false.
-    */
-    virtual bool ShallowEqual( const XMLNode* compare ) const = 0;
-
-    /** Accept a hierarchical visit of the nodes in the TinyXML-2 DOM. Every node in the
-    	XML tree will be conditionally visited and the host will be called back
-    	via the XMLVisitor interface.
-
-    	This is essentially a SAX interface for TinyXML-2. (Note however it doesn't re-parse
-    	the XML for the callbacks, so the performance of TinyXML-2 is unchanged by using this
-    	interface versus any other.)
-
-    	The interface has been based on ideas from:
-
-    	- http://www.saxproject.org/
-    	- http://c2.com/cgi/wiki?HierarchicalVisitorPattern
-
-    	Which are both good references for "visiting".
-
-    	An example of using Accept():
-    	@verbatim
-    	XMLPrinter printer;
-    	tinyxmlDoc.Accept( &printer );
-    	const char* xmlcstr = printer.CStr();
-    	@endverbatim
-    */
-    virtual bool Accept( XMLVisitor* visitor ) const = 0;
-
-	/**
-		Set user data into the XMLNode. TinyXML-2 in
-		no way processes or interprets user data.
-		It is initially 0.
-	*/
-	void SetUserData(void* userData)	{ _userData = userData; }
-
-	/**
-		Get user data set into the XMLNode. TinyXML-2 in
-		no way processes or interprets user data.
-		It is initially 0.
-	*/
-	void* GetUserData() const			{ return _userData; }
-
-protected:
-    explicit XMLNode( XMLDocument* );
-    virtual ~XMLNode();
-
-    virtual char* ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr);
-
-    XMLDocument*	_document;
-    XMLNode*		_parent;
-    mutable StrPair	_value;
-    int             _parseLineNum;
-
-    XMLNode*		_firstChild;
-    XMLNode*		_lastChild;
-
-    XMLNode*		_prev;
-    XMLNode*		_next;
-
-	void*			_userData;
-
-private:
-    MemPool*		_memPool;
-    void Unlink( XMLNode* child );
-    static void DeleteNode( XMLNode* node );
-    void InsertChildPreamble( XMLNode* insertThis ) const;
-    const XMLElement* ToElementWithName( const char* name ) const;
-
-    XMLNode( const XMLNode& );	// not supported
-    XMLNode& operator=( const XMLNode& );	// not supported
-};
-
-
-/** XML text.
-
-	Note that a text node can have child element nodes, for example:
-	@verbatim
-	<root>This is <b>bold</b></root>
-	@endverbatim
-
-	A text node can have 2 ways to output the next. "normal" output
-	and CDATA. It will default to the mode it was parsed from the XML file and
-	you generally want to leave it alone, but you can change the output mode with
-	SetCData() and query it with CData().
-*/
-class TINYXML2_LIB XMLText : public XMLNode
-{
-    friend class XMLDocument;
-public:
-    virtual bool Accept( XMLVisitor* visitor ) const;
-
-    virtual XMLText* ToText()			{
-        return this;
-    }
-    virtual const XMLText* ToText() const	{
-        return this;
-    }
-
-    /// Declare whether this should be CDATA or standard text.
-    void SetCData( bool isCData )			{
-        _isCData = isCData;
-    }
-    /// Returns true if this is a CDATA text element.
-    bool CData() const						{
-        return _isCData;
-    }
-
-    virtual XMLNode* ShallowClone( XMLDocument* document ) const;
-    virtual bool ShallowEqual( const XMLNode* compare ) const;
-
-protected:
-    explicit XMLText( XMLDocument* doc )	: XMLNode( doc ), _isCData( false )	{}
-    virtual ~XMLText()												{}
-
-    char* ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr );
-
-private:
-    bool _isCData;
-
-    XMLText( const XMLText& );	// not supported
-    XMLText& operator=( const XMLText& );	// not supported
-};
-
-
-/** An XML Comment. */
-class TINYXML2_LIB XMLComment : public XMLNode
-{
-    friend class XMLDocument;
-public:
-    virtual XMLComment*	ToComment()					{
-        return this;
-    }
-    virtual const XMLComment* ToComment() const		{
-        return this;
-    }
-
-    virtual bool Accept( XMLVisitor* visitor ) const;
-
-    virtual XMLNode* ShallowClone( XMLDocument* document ) const;
-    virtual bool ShallowEqual( const XMLNode* compare ) const;
-
-protected:
-    explicit XMLComment( XMLDocument* doc );
-    virtual ~XMLComment();
-
-    char* ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr);
-
-private:
-    XMLComment( const XMLComment& );	// not supported
-    XMLComment& operator=( const XMLComment& );	// not supported
-};
-
-
-/** In correct XML the declaration is the first entry in the file.
-	@verbatim
-		<?xml version="1.0" standalone="yes"?>
-	@endverbatim
-
-	TinyXML-2 will happily read or write files without a declaration,
-	however.
-
-	The text of the declaration isn't interpreted. It is parsed
-	and written as a string.
-*/
-class TINYXML2_LIB XMLDeclaration : public XMLNode
-{
-    friend class XMLDocument;
-public:
-    virtual XMLDeclaration*	ToDeclaration()					{
-        return this;
-    }
-    virtual const XMLDeclaration* ToDeclaration() const		{
-        return this;
-    }
-
-    virtual bool Accept( XMLVisitor* visitor ) const;
-
-    virtual XMLNode* ShallowClone( XMLDocument* document ) const;
-    virtual bool ShallowEqual( const XMLNode* compare ) const;
-
-protected:
-    explicit XMLDeclaration( XMLDocument* doc );
-    virtual ~XMLDeclaration();
-
-    char* ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr );
-
-private:
-    XMLDeclaration( const XMLDeclaration& );	// not supported
-    XMLDeclaration& operator=( const XMLDeclaration& );	// not supported
-};
-
-
-/** Any tag that TinyXML-2 doesn't recognize is saved as an
-	unknown. It is a tag of text, but should not be modified.
-	It will be written back to the XML, unchanged, when the file
-	is saved.
-
-	DTD tags get thrown into XMLUnknowns.
-*/
-class TINYXML2_LIB XMLUnknown : public XMLNode
-{
-    friend class XMLDocument;
-public:
-    virtual XMLUnknown*	ToUnknown()					{
-        return this;
-    }
-    virtual const XMLUnknown* ToUnknown() const		{
-        return this;
-    }
-
-    virtual bool Accept( XMLVisitor* visitor ) const;
-
-    virtual XMLNode* ShallowClone( XMLDocument* document ) const;
-    virtual bool ShallowEqual( const XMLNode* compare ) const;
-
-protected:
-    explicit XMLUnknown( XMLDocument* doc );
-    virtual ~XMLUnknown();
-
-    char* ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr );
-
-private:
-    XMLUnknown( const XMLUnknown& );	// not supported
-    XMLUnknown& operator=( const XMLUnknown& );	// not supported
-};
-
-
-
-/** An attribute is a name-value pair. Elements have an arbitrary
-	number of attributes, each with a unique name.
-
-	@note The attributes are not XMLNodes. You may only query the
-	Next() attribute in a list.
-*/
-class TINYXML2_LIB XMLAttribute
-{
-    friend class XMLElement;
-public:
-    /// The name of the attribute.
-    const char* Name() const;
-
-    /// The value of the attribute.
-    const char* Value() const;
-
-    /// Gets the line number the attribute is in, if the document was parsed from a file.
-    int GetLineNum() const { return _parseLineNum; }
-
-    /// The next attribute in the list.
-    const XMLAttribute* Next() const {
-        return _next;
-    }
-
-    /** IntValue interprets the attribute as an integer, and returns the value.
-        If the value isn't an integer, 0 will be returned. There is no error checking;
-    	use QueryIntValue() if you need error checking.
-    */
-	int	IntValue() const {
-		int i = 0;
-		QueryIntValue(&i);
-		return i;
-	}
-
-	int64_t Int64Value() const {
-		int64_t i = 0;
-		QueryInt64Value(&i);
-		return i;
-	}
-
-    uint64_t Unsigned64Value() const {
-        uint64_t i = 0;
-        QueryUnsigned64Value(&i);
-        return i;
-    }
-
-    /// Query as an unsigned integer. See IntValue()
-    unsigned UnsignedValue() const			{
-        unsigned i=0;
-        QueryUnsignedValue( &i );
-        return i;
-    }
-    /// Query as a boolean. See IntValue()
-    bool	 BoolValue() const				{
-        bool b=false;
-        QueryBoolValue( &b );
-        return b;
-    }
-    /// Query as a double. See IntValue()
-    double 	 DoubleValue() const			{
-        double d=0;
-        QueryDoubleValue( &d );
-        return d;
-    }
-    /// Query as a float. See IntValue()
-    float	 FloatValue() const				{
-        float f=0;
-        QueryFloatValue( &f );
-        return f;
-    }
-
-    /** QueryIntValue interprets the attribute as an integer, and returns the value
-    	in the provided parameter. The function will return XML_SUCCESS on success,
-    	and XML_WRONG_ATTRIBUTE_TYPE if the conversion is not successful.
-    */
-    XMLError QueryIntValue( int* value ) const;
-    /// See QueryIntValue
-    XMLError QueryUnsignedValue( unsigned int* value ) const;
-	/// See QueryIntValue
-	XMLError QueryInt64Value(int64_t* value) const;
-    /// See QueryIntValue
-    XMLError QueryUnsigned64Value(uint64_t* value) const;
-	/// See QueryIntValue
-    XMLError QueryBoolValue( bool* value ) const;
-    /// See QueryIntValue
-    XMLError QueryDoubleValue( double* value ) const;
-    /// See QueryIntValue
-    XMLError QueryFloatValue( float* value ) const;
-
-    /// Set the attribute to a string value.
-    void SetAttribute( const char* value );
-    /// Set the attribute to value.
-    void SetAttribute( int value );
-    /// Set the attribute to value.
-    void SetAttribute( unsigned value );
-	/// Set the attribute to value.
-	void SetAttribute(int64_t value);
-    /// Set the attribute to value.
-    void SetAttribute(uint64_t value);
-    /// Set the attribute to value.
-    void SetAttribute( bool value );
-    /// Set the attribute to value.
-    void SetAttribute( double value );
-    /// Set the attribute to value.
-    void SetAttribute( float value );
-
-private:
-    enum { BUF_SIZE = 200 };
-
-    XMLAttribute() : _name(), _value(),_parseLineNum( 0 ), _next( 0 ), _memPool( 0 ) {}
-    virtual ~XMLAttribute()	{}
-
-    XMLAttribute( const XMLAttribute& );	// not supported
-    void operator=( const XMLAttribute& );	// not supported
-    void SetName( const char* name );
-
-    char* ParseDeep( char* p, bool processEntities, int* curLineNumPtr );
-
-    mutable StrPair _name;
-    mutable StrPair _value;
-    int             _parseLineNum;
-    XMLAttribute*   _next;
-    MemPool*        _memPool;
-};
-
-
-/** The element is a container class. It has a value, the element name,
-	and can contain other elements, text, comments, and unknowns.
-	Elements also contain an arbitrary number of attributes.
-*/
-class TINYXML2_LIB XMLElement : public XMLNode
-{
-    friend class XMLDocument;
-public:
-    /// Get the name of an element (which is the Value() of the node.)
-    const char* Name() const		{
-        return Value();
-    }
-    /// Set the name of the element.
-    void SetName( const char* str, bool staticMem=false )	{
-        SetValue( str, staticMem );
-    }
-
-    virtual XMLElement* ToElement()				{
-        return this;
-    }
-    virtual const XMLElement* ToElement() const {
-        return this;
-    }
-    virtual bool Accept( XMLVisitor* visitor ) const;
-
-    /** Given an attribute name, Attribute() returns the value
-    	for the attribute of that name, or null if none
-    	exists. For example:
-
-    	@verbatim
-    	const char* value = ele->Attribute( "foo" );
-    	@endverbatim
-
-    	The 'value' parameter is normally null. However, if specified,
-    	the attribute will only be returned if the 'name' and 'value'
-    	match. This allow you to write code:
-
-    	@verbatim
-    	if ( ele->Attribute( "foo", "bar" ) ) callFooIsBar();
-    	@endverbatim
-
-    	rather than:
-    	@verbatim
-    	if ( ele->Attribute( "foo" ) ) {
-    		if ( strcmp( ele->Attribute( "foo" ), "bar" ) == 0 ) callFooIsBar();
-    	}
-    	@endverbatim
-    */
-    const char* Attribute( const char* name, const char* value=0 ) const;
-
-    /** Given an attribute name, IntAttribute() returns the value
-    	of the attribute interpreted as an integer. The default
-        value will be returned if the attribute isn't present,
-        or if there is an error. (For a method with error
-    	checking, see QueryIntAttribute()).
-    */
-	int IntAttribute(const char* name, int defaultValue = 0) const;
-    /// See IntAttribute()
-	unsigned UnsignedAttribute(const char* name, unsigned defaultValue = 0) const;
-	/// See IntAttribute()
-	int64_t Int64Attribute(const char* name, int64_t defaultValue = 0) const;
-    /// See IntAttribute()
-    uint64_t Unsigned64Attribute(const char* name, uint64_t defaultValue = 0) const;
-	/// See IntAttribute()
-	bool BoolAttribute(const char* name, bool defaultValue = false) const;
-    /// See IntAttribute()
-	double DoubleAttribute(const char* name, double defaultValue = 0) const;
-    /// See IntAttribute()
-	float FloatAttribute(const char* name, float defaultValue = 0) const;
-
-    /** Given an attribute name, QueryIntAttribute() returns
-    	XML_SUCCESS, XML_WRONG_ATTRIBUTE_TYPE if the conversion
-    	can't be performed, or XML_NO_ATTRIBUTE if the attribute
-    	doesn't exist. If successful, the result of the conversion
-    	will be written to 'value'. If not successful, nothing will
-    	be written to 'value'. This allows you to provide default
-    	value:
-
-    	@verbatim
-    	int value = 10;
-    	QueryIntAttribute( "foo", &value );		// if "foo" isn't found, value will still be 10
-    	@endverbatim
-    */
-    XMLError QueryIntAttribute( const char* name, int* value ) const				{
-        const XMLAttribute* a = FindAttribute( name );
-        if ( !a ) {
-            return XML_NO_ATTRIBUTE;
-        }
-        return a->QueryIntValue( value );
-    }
-
-	/// See QueryIntAttribute()
-    XMLError QueryUnsignedAttribute( const char* name, unsigned int* value ) const	{
-        const XMLAttribute* a = FindAttribute( name );
-        if ( !a ) {
-            return XML_NO_ATTRIBUTE;
-        }
-        return a->QueryUnsignedValue( value );
-    }
-
-	/// See QueryIntAttribute()
-	XMLError QueryInt64Attribute(const char* name, int64_t* value) const {
-		const XMLAttribute* a = FindAttribute(name);
-		if (!a) {
-			return XML_NO_ATTRIBUTE;
-		}
-		return a->QueryInt64Value(value);
-	}
-
-    /// See QueryIntAttribute()
-    XMLError QueryUnsigned64Attribute(const char* name, uint64_t* value) const {
-        const XMLAttribute* a = FindAttribute(name);
-        if(!a) {
-            return XML_NO_ATTRIBUTE;
-        }
-        return a->QueryUnsigned64Value(value);
-    }
-
-	/// See QueryIntAttribute()
-    XMLError QueryBoolAttribute( const char* name, bool* value ) const				{
-        const XMLAttribute* a = FindAttribute( name );
-        if ( !a ) {
-            return XML_NO_ATTRIBUTE;
-        }
-        return a->QueryBoolValue( value );
-    }
-    /// See QueryIntAttribute()
-    XMLError QueryDoubleAttribute( const char* name, double* value ) const			{
-        const XMLAttribute* a = FindAttribute( name );
-        if ( !a ) {
-            return XML_NO_ATTRIBUTE;
-        }
-        return a->QueryDoubleValue( value );
-    }
-    /// See QueryIntAttribute()
-    XMLError QueryFloatAttribute( const char* name, float* value ) const			{
-        const XMLAttribute* a = FindAttribute( name );
-        if ( !a ) {
-            return XML_NO_ATTRIBUTE;
-        }
-        return a->QueryFloatValue( value );
-    }
-
-	/// See QueryIntAttribute()
-	XMLError QueryStringAttribute(const char* name, const char** value) const {
-		const XMLAttribute* a = FindAttribute(name);
-		if (!a) {
-			return XML_NO_ATTRIBUTE;
-		}
-		*value = a->Value();
-		return XML_SUCCESS;
-	}
-
-
-
-    /** Given an attribute name, QueryAttribute() returns
-    	XML_SUCCESS, XML_WRONG_ATTRIBUTE_TYPE if the conversion
-    	can't be performed, or XML_NO_ATTRIBUTE if the attribute
-    	doesn't exist. It is overloaded for the primitive types,
-		and is a generally more convenient replacement of
-		QueryIntAttribute() and related functions.
-
-		If successful, the result of the conversion
-    	will be written to 'value'. If not successful, nothing will
-    	be written to 'value'. This allows you to provide default
-    	value:
-
-    	@verbatim
-    	int value = 10;
-    	QueryAttribute( "foo", &value );		// if "foo" isn't found, value will still be 10
-    	@endverbatim
-    */
-	XMLError QueryAttribute( const char* name, int* value ) const {
-		return QueryIntAttribute( name, value );
-	}
-
-	XMLError QueryAttribute( const char* name, unsigned int* value ) const {
-		return QueryUnsignedAttribute( name, value );
-	}
-
-	XMLError QueryAttribute(const char* name, int64_t* value) const {
-		return QueryInt64Attribute(name, value);
-	}
-
-    XMLError QueryAttribute(const char* name, uint64_t* value) const {
-        return QueryUnsigned64Attribute(name, value);
-    }
-
-    XMLError QueryAttribute( const char* name, bool* value ) const {
-		return QueryBoolAttribute( name, value );
-	}
-
-	XMLError QueryAttribute( const char* name, double* value ) const {
-		return QueryDoubleAttribute( name, value );
-	}
-
-	XMLError QueryAttribute( const char* name, float* value ) const {
-		return QueryFloatAttribute( name, value );
-	}
-
-	/// Sets the named attribute to value.
-    void SetAttribute( const char* name, const char* value )	{
-        XMLAttribute* a = FindOrCreateAttribute( name );
-        a->SetAttribute( value );
-    }
-    /// Sets the named attribute to value.
-    void SetAttribute( const char* name, int value )			{
-        XMLAttribute* a = FindOrCreateAttribute( name );
-        a->SetAttribute( value );
-    }
-    /// Sets the named attribute to value.
-    void SetAttribute( const char* name, unsigned value )		{
-        XMLAttribute* a = FindOrCreateAttribute( name );
-        a->SetAttribute( value );
-    }
-
-	/// Sets the named attribute to value.
-	void SetAttribute(const char* name, int64_t value) {
-		XMLAttribute* a = FindOrCreateAttribute(name);
-		a->SetAttribute(value);
-	}
-
-    /// Sets the named attribute to value.
-    void SetAttribute(const char* name, uint64_t value) {
-        XMLAttribute* a = FindOrCreateAttribute(name);
-        a->SetAttribute(value);
-    }
-    
-    /// Sets the named attribute to value.
-    void SetAttribute( const char* name, bool value )			{
-        XMLAttribute* a = FindOrCreateAttribute( name );
-        a->SetAttribute( value );
-    }
-    /// Sets the named attribute to value.
-    void SetAttribute( const char* name, double value )		{
-        XMLAttribute* a = FindOrCreateAttribute( name );
-        a->SetAttribute( value );
-    }
-    /// Sets the named attribute to value.
-    void SetAttribute( const char* name, float value )		{
-        XMLAttribute* a = FindOrCreateAttribute( name );
-        a->SetAttribute( value );
-    }
-
-    /**
-    	Delete an attribute.
-    */
-    void DeleteAttribute( const char* name );
-
-    /// Return the first attribute in the list.
-    const XMLAttribute* FirstAttribute() const {
-        return _rootAttribute;
-    }
-    /// Query a specific attribute in the list.
-    const XMLAttribute* FindAttribute( const char* name ) const;
-
-    /** Convenience function for easy access to the text inside an element. Although easy
-    	and concise, GetText() is limited compared to getting the XMLText child
-    	and accessing it directly.
-
-    	If the first child of 'this' is a XMLText, the GetText()
-    	returns the character string of the Text node, else null is returned.
-
-    	This is a convenient method for getting the text of simple contained text:
-    	@verbatim
-    	<foo>This is text</foo>
-    		const char* str = fooElement->GetText();
-    	@endverbatim
-
-    	'str' will be a pointer to "This is text".
-
-    	Note that this function can be misleading. If the element foo was created from
-    	this XML:
-    	@verbatim
-    		<foo><b>This is text</b></foo>
-    	@endverbatim
-
-    	then the value of str would be null. The first child node isn't a text node, it is
-    	another element. From this XML:
-    	@verbatim
-    		<foo>This is <b>text</b></foo>
-    	@endverbatim
-    	GetText() will return "This is ".
-    */
-    const char* GetText() const;
-
-    /** Convenience function for easy access to the text inside an element. Although easy
-    	and concise, SetText() is limited compared to creating an XMLText child
-    	and mutating it directly.
-
-    	If the first child of 'this' is a XMLText, SetText() sets its value to
-		the given string, otherwise it will create a first child that is an XMLText.
-
-    	This is a convenient method for setting the text of simple contained text:
-    	@verbatim
-    	<foo>This is text</foo>
-    		fooElement->SetText( "Hullaballoo!" );
-     	<foo>Hullaballoo!</foo>
-		@endverbatim
-
-    	Note that this function can be misleading. If the element foo was created from
-    	this XML:
-    	@verbatim
-    		<foo><b>This is text</b></foo>
-    	@endverbatim
-
-    	then it will not change "This is text", but rather prefix it with a text element:
-    	@verbatim
-    		<foo>Hullaballoo!<b>This is text</b></foo>
-    	@endverbatim
-
-		For this XML:
-    	@verbatim
-    		<foo />
-    	@endverbatim
-    	SetText() will generate
-    	@verbatim
-    		<foo>Hullaballoo!</foo>
-    	@endverbatim
-    */
-	void SetText( const char* inText );
-    /// Convenience method for setting text inside an element. See SetText() for important limitations.
-    void SetText( int value );
-    /// Convenience method for setting text inside an element. See SetText() for important limitations.
-    void SetText( unsigned value );
-	/// Convenience method for setting text inside an element. See SetText() for important limitations.
-	void SetText(int64_t value);
-    /// Convenience method for setting text inside an element. See SetText() for important limitations.
-    void SetText(uint64_t value);
-	/// Convenience method for setting text inside an element. See SetText() for important limitations.
-    void SetText( bool value );
-    /// Convenience method for setting text inside an element. See SetText() for important limitations.
-    void SetText( double value );
-    /// Convenience method for setting text inside an element. See SetText() for important limitations.
-    void SetText( float value );
-
-    /**
-    	Convenience method to query the value of a child text node. This is probably best
-    	shown by example. Given you have a document is this form:
-    	@verbatim
-    		<point>
-    			<x>1</x>
-    			<y>1.4</y>
-    		</point>
-    	@endverbatim
-
-    	The QueryIntText() and similar functions provide a safe and easier way to get to the
-    	"value" of x and y.
-
-    	@verbatim
-    		int x = 0;
-    		float y = 0;	// types of x and y are contrived for example
-    		const XMLElement* xElement = pointElement->FirstChildElement( "x" );
-    		const XMLElement* yElement = pointElement->FirstChildElement( "y" );
-    		xElement->QueryIntText( &x );
-    		yElement->QueryFloatText( &y );
-    	@endverbatim
-
-    	@returns XML_SUCCESS (0) on success, XML_CAN_NOT_CONVERT_TEXT if the text cannot be converted
-    			 to the requested type, and XML_NO_TEXT_NODE if there is no child text to query.
-
-    */
-    XMLError QueryIntText( int* ival ) const;
-    /// See QueryIntText()
-    XMLError QueryUnsignedText( unsigned* uval ) const;
-	/// See QueryIntText()
-	XMLError QueryInt64Text(int64_t* uval) const;
-	/// See QueryIntText()
-	XMLError QueryUnsigned64Text(uint64_t* uval) const;
-	/// See QueryIntText()
-    XMLError QueryBoolText( bool* bval ) const;
-    /// See QueryIntText()
-    XMLError QueryDoubleText( double* dval ) const;
-    /// See QueryIntText()
-    XMLError QueryFloatText( float* fval ) const;
-
-	int IntText(int defaultValue = 0) const;
-
-	/// See QueryIntText()
-	unsigned UnsignedText(unsigned defaultValue = 0) const;
-	/// See QueryIntText()
-	int64_t Int64Text(int64_t defaultValue = 0) const;
-    /// See QueryIntText()
-    uint64_t Unsigned64Text(uint64_t defaultValue = 0) const;
-	/// See QueryIntText()
-	bool BoolText(bool defaultValue = false) const;
-	/// See QueryIntText()
-	double DoubleText(double defaultValue = 0) const;
-	/// See QueryIntText()
-	float FloatText(float defaultValue = 0) const;
-
-    // internal:
-    enum ElementClosingType {
-        OPEN,		// <foo>
-        CLOSED,		// <foo/>
-        CLOSING		// </foo>
-    };
-    ElementClosingType ClosingType() const {
-        return _closingType;
-    }
-    virtual XMLNode* ShallowClone( XMLDocument* document ) const;
-    virtual bool ShallowEqual( const XMLNode* compare ) const;
-
-protected:
-    char* ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr );
-
-private:
-    XMLElement( XMLDocument* doc );
-    virtual ~XMLElement();
-    XMLElement( const XMLElement& );	// not supported
-    void operator=( const XMLElement& );	// not supported
-
-    XMLAttribute* FindOrCreateAttribute( const char* name );
-    char* ParseAttributes( char* p, int* curLineNumPtr );
-    static void DeleteAttribute( XMLAttribute* attribute );
-    XMLAttribute* CreateAttribute();
-
-    enum { BUF_SIZE = 200 };
-    ElementClosingType _closingType;
-    // The attribute list is ordered; there is no 'lastAttribute'
-    // because the list needs to be scanned for dupes before adding
-    // a new attribute.
-    XMLAttribute* _rootAttribute;
-};
-
-
-enum Whitespace {
-    PRESERVE_WHITESPACE,
-    COLLAPSE_WHITESPACE
-};
-
-
-/** A Document binds together all the functionality.
-	It can be saved, loaded, and printed to the screen.
-	All Nodes are connected and allocated to a Document.
-	If the Document is deleted, all its Nodes are also deleted.
-*/
-class TINYXML2_LIB XMLDocument : public XMLNode
-{
-    friend class XMLElement;
-    // Gives access to SetError and Push/PopDepth, but over-access for everything else.
-    // Wishing C++ had "internal" scope.
-    friend class XMLNode;
-    friend class XMLText;
-    friend class XMLComment;
-    friend class XMLDeclaration;
-    friend class XMLUnknown;
-public:
-    /// constructor
-    XMLDocument( bool processEntities = true, Whitespace whitespaceMode = PRESERVE_WHITESPACE );
-    ~XMLDocument();
-
-    virtual XMLDocument* ToDocument()				{
-        TIXMLASSERT( this == _document );
-        return this;
-    }
-    virtual const XMLDocument* ToDocument() const	{
-        TIXMLASSERT( this == _document );
-        return this;
-    }
-
-    /**
-    	Parse an XML file from a character string.
-    	Returns XML_SUCCESS (0) on success, or
-    	an errorID.
-
-    	You may optionally pass in the 'nBytes', which is
-    	the number of bytes which will be parsed. If not
-    	specified, TinyXML-2 will assume 'xml' points to a
-    	null terminated string.
-    */
-    XMLError Parse( const char* xml, size_t nBytes=static_cast<size_t>(-1) );
-
-    /**
-    	Load an XML file from disk.
-    	Returns XML_SUCCESS (0) on success, or
-    	an errorID.
-    */
-    XMLError LoadFile( const char* filename );
-
-    /**
-    	Load an XML file from disk. You are responsible
-    	for providing and closing the FILE*.
-
-        NOTE: The file should be opened as binary ("rb")
-        not text in order for TinyXML-2 to correctly
-        do newline normalization.
-
-    	Returns XML_SUCCESS (0) on success, or
-    	an errorID.
-    */
-    XMLError LoadFile( FILE* );
-
-    /**
-    	Save the XML file to disk.
-    	Returns XML_SUCCESS (0) on success, or
-    	an errorID.
-    */
-    XMLError SaveFile( const char* filename, bool compact = false );
-
-    /**
-    	Save the XML file to disk. You are responsible
-    	for providing and closing the FILE*.
-
-    	Returns XML_SUCCESS (0) on success, or
-    	an errorID.
-    */
-    XMLError SaveFile( FILE* fp, bool compact = false );
-
-    bool ProcessEntities() const		{
-        return _processEntities;
-    }
-    Whitespace WhitespaceMode() const	{
-        return _whitespaceMode;
-    }
-
-    /**
-    	Returns true if this document has a leading Byte Order Mark of UTF8.
-    */
-    bool HasBOM() const {
-        return _writeBOM;
-    }
-    /** Sets whether to write the BOM when writing the file.
-    */
-    void SetBOM( bool useBOM ) {
-        _writeBOM = useBOM;
-    }
-
-    /** Return the root element of DOM. Equivalent to FirstChildElement().
-        To get the first node, use FirstChild().
-    */
-    XMLElement* RootElement()				{
-        return FirstChildElement();
-    }
-    const XMLElement* RootElement() const	{
-        return FirstChildElement();
-    }
-
-    /** Print the Document. If the Printer is not provided, it will
-        print to stdout. If you provide Printer, this can print to a file:
-    	@verbatim
-    	XMLPrinter printer( fp );
-    	doc.Print( &printer );
-    	@endverbatim
-
-    	Or you can use a printer to print to memory:
-    	@verbatim
-    	XMLPrinter printer;
-    	doc.Print( &printer );
-    	// printer.CStr() has a const char* to the XML
-    	@endverbatim
-    */
-    void Print( XMLPrinter* streamer=0 ) const;
-    virtual bool Accept( XMLVisitor* visitor ) const;
-
-    /**
-    	Create a new Element associated with
-    	this Document. The memory for the Element
-    	is managed by the Document.
-    */
-    XMLElement* NewElement( const char* name );
-    /**
-    	Create a new Comment associated with
-    	this Document. The memory for the Comment
-    	is managed by the Document.
-    */
-    XMLComment* NewComment( const char* comment );
-    /**
-    	Create a new Text associated with
-    	this Document. The memory for the Text
-    	is managed by the Document.
-    */
-    XMLText* NewText( const char* text );
-    /**
-    	Create a new Declaration associated with
-    	this Document. The memory for the object
-    	is managed by the Document.
-
-    	If the 'text' param is null, the standard
-    	declaration is used.:
-    	@verbatim
-    		<?xml version="1.0" encoding="UTF-8"?>
-    	@endverbatim
-    */
-    XMLDeclaration* NewDeclaration( const char* text=0 );
-    /**
-    	Create a new Unknown associated with
-    	this Document. The memory for the object
-    	is managed by the Document.
-    */
-    XMLUnknown* NewUnknown( const char* text );
-
-    /**
-    	Delete a node associated with this document.
-    	It will be unlinked from the DOM.
-    */
-    void DeleteNode( XMLNode* node );
-
-    void ClearError() {
-        SetError(XML_SUCCESS, 0, 0);
-    }
-
-    /// Return true if there was an error parsing the document.
-    bool Error() const {
-        return _errorID != XML_SUCCESS;
-    }
-    /// Return the errorID.
-    XMLError  ErrorID() const {
-        return _errorID;
-    }
-	const char* ErrorName() const;
-    static const char* ErrorIDToName(XMLError errorID);
-
-    /** Returns a "long form" error description. A hopefully helpful
-        diagnostic with location, line number, and/or additional info.
-    */
-	const char* ErrorStr() const;
-
-    /// A (trivial) utility function that prints the ErrorStr() to stdout.
-    void PrintError() const;
-
-    /// Return the line where the error occurred, or zero if unknown.
-    int ErrorLineNum() const
+    class TINYXML2_LIB XMLVisitor
     {
-        return _errorLineNum;
-    }
+      public:
+        virtual ~XMLVisitor() {}
 
-    /// Clear the document, resetting it to the initial state.
-    void Clear();
+        /// Visit a document.
+        virtual bool VisitEnter(const XMLDocument & /*doc*/) { return true; }
+        /// Visit a document.
+        virtual bool VisitExit(const XMLDocument & /*doc*/) { return true; }
 
-	/**
-		Copies this document to a target document.
-		The target will be completely cleared before the copy.
-		If you want to copy a sub-tree, see XMLNode::DeepClone().
+        /// Visit an element.
+        virtual bool VisitEnter(const XMLElement & /*element*/, const XMLAttribute * /*firstAttribute*/)
+        {
+            return true;
+        }
+        /// Visit an element.
+        virtual bool VisitExit(const XMLElement & /*element*/) { return true; }
 
-		NOTE: that the 'target' must be non-null.
-	*/
-	void DeepCopy(XMLDocument* target) const;
-
-	// internal
-    char* Identify( char* p, XMLNode** node );
-
-	// internal
-	void MarkInUse(XMLNode*);
-
-    virtual XMLNode* ShallowClone( XMLDocument* /*document*/ ) const	{
-        return 0;
-    }
-    virtual bool ShallowEqual( const XMLNode* /*compare*/ ) const	{
-        return false;
-    }
-
-private:
-    XMLDocument( const XMLDocument& );	// not supported
-    void operator=( const XMLDocument& );	// not supported
-
-    bool			_writeBOM;
-    bool			_processEntities;
-    XMLError		_errorID;
-    Whitespace		_whitespaceMode;
-    mutable StrPair	_errorStr;
-    int             _errorLineNum;
-    char*			_charBuffer;
-    int				_parseCurLineNum;
-	int				_parsingDepth;
-	// Memory tracking does add some overhead.
-	// However, the code assumes that you don't
-	// have a bunch of unlinked nodes around.
-	// Therefore it takes less memory to track
-	// in the document vs. a linked list in the XMLNode,
-	// and the performance is the same.
-	DynArray<XMLNode*, 10> _unlinked;
-
-    MemPoolT< sizeof(XMLElement) >	 _elementPool;
-    MemPoolT< sizeof(XMLAttribute) > _attributePool;
-    MemPoolT< sizeof(XMLText) >		 _textPool;
-    MemPoolT< sizeof(XMLComment) >	 _commentPool;
-
-	static const char* _errorNames[XML_ERROR_COUNT];
-
-    void Parse();
-
-    void SetError( XMLError error, int lineNum, const char* format, ... );
-
-	// Something of an obvious security hole, once it was discovered.
-	// Either an ill-formed XML or an excessively deep one can overflow
-	// the stack. Track stack depth, and error out if needed.
-	class DepthTracker {
-	public:
-		explicit DepthTracker(XMLDocument * document) {
-			this->_document = document;
-			document->PushDepth();
-		}
-		~DepthTracker() {
-			_document->PopDepth();
-		}
-	private:
-		XMLDocument * _document;
-	};
-	void PushDepth();
-	void PopDepth();
-
-    template<class NodeType, int PoolElementSize>
-    NodeType* CreateUnlinkedNode( MemPoolT<PoolElementSize>& pool );
-};
-
-template<class NodeType, int PoolElementSize>
-inline NodeType* XMLDocument::CreateUnlinkedNode( MemPoolT<PoolElementSize>& pool )
-{
-    TIXMLASSERT( sizeof( NodeType ) == PoolElementSize );
-    TIXMLASSERT( sizeof( NodeType ) == pool.ItemSize() );
-    NodeType* returnNode = new (pool.Alloc()) NodeType( this );
-    TIXMLASSERT( returnNode );
-    returnNode->_memPool = &pool;
-
-	_unlinked.Push(returnNode);
-    return returnNode;
-}
-
-/**
-	A XMLHandle is a class that wraps a node pointer with null checks; this is
-	an incredibly useful thing. Note that XMLHandle is not part of the TinyXML-2
-	DOM structure. It is a separate utility class.
-
-	Take an example:
-	@verbatim
-	<Document>
-		<Element attributeA = "valueA">
-			<Child attributeB = "value1" />
-			<Child attributeB = "value2" />
-		</Element>
-	</Document>
-	@endverbatim
-
-	Assuming you want the value of "attributeB" in the 2nd "Child" element, it's very
-	easy to write a *lot* of code that looks like:
-
-	@verbatim
-	XMLElement* root = document.FirstChildElement( "Document" );
-	if ( root )
-	{
-		XMLElement* element = root->FirstChildElement( "Element" );
-		if ( element )
-		{
-			XMLElement* child = element->FirstChildElement( "Child" );
-			if ( child )
-			{
-				XMLElement* child2 = child->NextSiblingElement( "Child" );
-				if ( child2 )
-				{
-					// Finally do something useful.
-	@endverbatim
-
-	And that doesn't even cover "else" cases. XMLHandle addresses the verbosity
-	of such code. A XMLHandle checks for null pointers so it is perfectly safe
-	and correct to use:
-
-	@verbatim
-	XMLHandle docHandle( &document );
-	XMLElement* child2 = docHandle.FirstChildElement( "Document" ).FirstChildElement( "Element" ).FirstChildElement().NextSiblingElement();
-	if ( child2 )
-	{
-		// do something useful
-	@endverbatim
-
-	Which is MUCH more concise and useful.
-
-	It is also safe to copy handles - internally they are nothing more than node pointers.
-	@verbatim
-	XMLHandle handleCopy = handle;
-	@endverbatim
-
-	See also XMLConstHandle, which is the same as XMLHandle, but operates on const objects.
-*/
-class TINYXML2_LIB XMLHandle
-{
-public:
-    /// Create a handle from any node (at any depth of the tree.) This can be a null pointer.
-    explicit XMLHandle( XMLNode* node ) : _node( node ) {
-    }
-    /// Create a handle from a node.
-    explicit XMLHandle( XMLNode& node ) : _node( &node ) {
-    }
-    /// Copy constructor
-    XMLHandle( const XMLHandle& ref ) : _node( ref._node ) {
-    }
-    /// Assignment
-    XMLHandle& operator=( const XMLHandle& ref )							{
-        _node = ref._node;
-        return *this;
-    }
-
-    /// Get the first child of this handle.
-    XMLHandle FirstChild() 													{
-        return XMLHandle( _node ? _node->FirstChild() : 0 );
-    }
-    /// Get the first child element of this handle.
-    XMLHandle FirstChildElement( const char* name = 0 )						{
-        return XMLHandle( _node ? _node->FirstChildElement( name ) : 0 );
-    }
-    /// Get the last child of this handle.
-    XMLHandle LastChild()													{
-        return XMLHandle( _node ? _node->LastChild() : 0 );
-    }
-    /// Get the last child element of this handle.
-    XMLHandle LastChildElement( const char* name = 0 )						{
-        return XMLHandle( _node ? _node->LastChildElement( name ) : 0 );
-    }
-    /// Get the previous sibling of this handle.
-    XMLHandle PreviousSibling()												{
-        return XMLHandle( _node ? _node->PreviousSibling() : 0 );
-    }
-    /// Get the previous sibling element of this handle.
-    XMLHandle PreviousSiblingElement( const char* name = 0 )				{
-        return XMLHandle( _node ? _node->PreviousSiblingElement( name ) : 0 );
-    }
-    /// Get the next sibling of this handle.
-    XMLHandle NextSibling()													{
-        return XMLHandle( _node ? _node->NextSibling() : 0 );
-    }
-    /// Get the next sibling element of this handle.
-    XMLHandle NextSiblingElement( const char* name = 0 )					{
-        return XMLHandle( _node ? _node->NextSiblingElement( name ) : 0 );
-    }
-
-    /// Safe cast to XMLNode. This can return null.
-    XMLNode* ToNode()							{
-        return _node;
-    }
-    /// Safe cast to XMLElement. This can return null.
-    XMLElement* ToElement() 					{
-        return ( _node ? _node->ToElement() : 0 );
-    }
-    /// Safe cast to XMLText. This can return null.
-    XMLText* ToText() 							{
-        return ( _node ? _node->ToText() : 0 );
-    }
-    /// Safe cast to XMLUnknown. This can return null.
-    XMLUnknown* ToUnknown() 					{
-        return ( _node ? _node->ToUnknown() : 0 );
-    }
-    /// Safe cast to XMLDeclaration. This can return null.
-    XMLDeclaration* ToDeclaration() 			{
-        return ( _node ? _node->ToDeclaration() : 0 );
-    }
-
-private:
-    XMLNode* _node;
-};
-
-
-/**
-	A variant of the XMLHandle class for working with const XMLNodes and Documents. It is the
-	same in all regards, except for the 'const' qualifiers. See XMLHandle for API.
-*/
-class TINYXML2_LIB XMLConstHandle
-{
-public:
-    explicit XMLConstHandle( const XMLNode* node ) : _node( node ) {
-    }
-    explicit XMLConstHandle( const XMLNode& node ) : _node( &node ) {
-    }
-    XMLConstHandle( const XMLConstHandle& ref ) : _node( ref._node ) {
-    }
-
-    XMLConstHandle& operator=( const XMLConstHandle& ref )							{
-        _node = ref._node;
-        return *this;
-    }
-
-    const XMLConstHandle FirstChild() const											{
-        return XMLConstHandle( _node ? _node->FirstChild() : 0 );
-    }
-    const XMLConstHandle FirstChildElement( const char* name = 0 ) const				{
-        return XMLConstHandle( _node ? _node->FirstChildElement( name ) : 0 );
-    }
-    const XMLConstHandle LastChild()	const										{
-        return XMLConstHandle( _node ? _node->LastChild() : 0 );
-    }
-    const XMLConstHandle LastChildElement( const char* name = 0 ) const				{
-        return XMLConstHandle( _node ? _node->LastChildElement( name ) : 0 );
-    }
-    const XMLConstHandle PreviousSibling() const									{
-        return XMLConstHandle( _node ? _node->PreviousSibling() : 0 );
-    }
-    const XMLConstHandle PreviousSiblingElement( const char* name = 0 ) const		{
-        return XMLConstHandle( _node ? _node->PreviousSiblingElement( name ) : 0 );
-    }
-    const XMLConstHandle NextSibling() const										{
-        return XMLConstHandle( _node ? _node->NextSibling() : 0 );
-    }
-    const XMLConstHandle NextSiblingElement( const char* name = 0 ) const			{
-        return XMLConstHandle( _node ? _node->NextSiblingElement( name ) : 0 );
-    }
-
-
-    const XMLNode* ToNode() const				{
-        return _node;
-    }
-    const XMLElement* ToElement() const			{
-        return ( _node ? _node->ToElement() : 0 );
-    }
-    const XMLText* ToText() const				{
-        return ( _node ? _node->ToText() : 0 );
-    }
-    const XMLUnknown* ToUnknown() const			{
-        return ( _node ? _node->ToUnknown() : 0 );
-    }
-    const XMLDeclaration* ToDeclaration() const	{
-        return ( _node ? _node->ToDeclaration() : 0 );
-    }
-
-private:
-    const XMLNode* _node;
-};
-
-
-/**
-	Printing functionality. The XMLPrinter gives you more
-	options than the XMLDocument::Print() method.
-
-	It can:
-	-# Print to memory.
-	-# Print to a file you provide.
-	-# Print XML without a XMLDocument.
-
-	Print to Memory
-
-	@verbatim
-	XMLPrinter printer;
-	doc.Print( &printer );
-	SomeFunction( printer.CStr() );
-	@endverbatim
-
-	Print to a File
-
-	You provide the file pointer.
-	@verbatim
-	XMLPrinter printer( fp );
-	doc.Print( &printer );
-	@endverbatim
-
-	Print without a XMLDocument
-
-	When loading, an XML parser is very useful. However, sometimes
-	when saving, it just gets in the way. The code is often set up
-	for streaming, and constructing the DOM is just overhead.
-
-	The Printer supports the streaming case. The following code
-	prints out a trivially simple XML file without ever creating
-	an XML document.
-
-	@verbatim
-	XMLPrinter printer( fp );
-	printer.OpenElement( "foo" );
-	printer.PushAttribute( "foo", "bar" );
-	printer.CloseElement();
-	@endverbatim
-*/
-class TINYXML2_LIB XMLPrinter : public XMLVisitor
-{
-public:
-    /** Construct the printer. If the FILE* is specified,
-    	this will print to the FILE. Else it will print
-    	to memory, and the result is available in CStr().
-    	If 'compact' is set to true, then output is created
-    	with only required whitespace and newlines.
-    */
-    XMLPrinter( FILE* file=0, bool compact = false, int depth = 0 );
-    virtual ~XMLPrinter()	{}
-
-    /** If streaming, write the BOM and declaration. */
-    void PushHeader( bool writeBOM, bool writeDeclaration );
-    /** If streaming, start writing an element.
-        The element must be closed with CloseElement()
-    */
-    void OpenElement( const char* name, bool compactMode=false );
-    /// If streaming, add an attribute to an open element.
-    void PushAttribute( const char* name, const char* value );
-    void PushAttribute( const char* name, int value );
-    void PushAttribute( const char* name, unsigned value );
-	void PushAttribute( const char* name, int64_t value );
-	void PushAttribute( const char* name, uint64_t value );
-	void PushAttribute( const char* name, bool value );
-    void PushAttribute( const char* name, double value );
-    /// If streaming, close the Element.
-    virtual void CloseElement( bool compactMode=false );
-
-    /// Add a text node.
-    void PushText( const char* text, bool cdata=false );
-    /// Add a text node from an integer.
-    void PushText( int value );
-    /// Add a text node from an unsigned.
-    void PushText( unsigned value );
-	/// Add a text node from a signed 64bit integer.
-	void PushText( int64_t value );
-	/// Add a text node from an unsigned 64bit integer.
-	void PushText( uint64_t value );
-	/// Add a text node from a bool.
-    void PushText( bool value );
-    /// Add a text node from a float.
-    void PushText( float value );
-    /// Add a text node from a double.
-    void PushText( double value );
-
-    /// Add a comment
-    void PushComment( const char* comment );
-
-    void PushDeclaration( const char* value );
-    void PushUnknown( const char* value );
-
-    virtual bool VisitEnter( const XMLDocument& /*doc*/ );
-    virtual bool VisitExit( const XMLDocument& /*doc*/ )			{
-        return true;
-    }
-
-    virtual bool VisitEnter( const XMLElement& element, const XMLAttribute* attribute );
-    virtual bool VisitExit( const XMLElement& element );
-
-    virtual bool Visit( const XMLText& text );
-    virtual bool Visit( const XMLComment& comment );
-    virtual bool Visit( const XMLDeclaration& declaration );
-    virtual bool Visit( const XMLUnknown& unknown );
-
-    /**
-    	If in print to memory mode, return a pointer to
-    	the XML file in memory.
-    */
-    const char* CStr() const {
-        return _buffer.Mem();
-    }
-    /**
-    	If in print to memory mode, return the size
-    	of the XML file in memory. (Note the size returned
-    	includes the terminating null.)
-    */
-    int CStrSize() const {
-        return _buffer.Size();
-    }
-    /**
-    	If in print to memory mode, reset the buffer to the
-    	beginning.
-    */
-    void ClearBuffer( bool resetToFirstElement = true ) {
-        _buffer.Clear();
-        _buffer.Push(0);
-		_firstElement = resetToFirstElement;
-    }
-
-protected:
-	virtual bool CompactMode( const XMLElement& )	{ return _compactMode; }
-
-	/** Prints out the space before an element. You may override to change
-	    the space and tabs used. A PrintSpace() override should call Print().
-	*/
-    virtual void PrintSpace( int depth );
-    void Print( const char* format, ... );
-    void Write( const char* data, size_t size );
-    inline void Write( const char* data )           { Write( data, strlen( data ) ); }
-    void Putc( char ch );
-
-    void SealElementIfJustOpened();
-    bool _elementJustOpened;
-    DynArray< const char*, 10 > _stack;
-
-private:
-    void PrintString( const char*, bool restrictedEntitySet );	// prints out, after detecting entities.
-
-    bool _firstElement;
-    FILE* _fp;
-    int _depth;
-    int _textDepth;
-    bool _processEntities;
-	bool _compactMode;
-
-    enum {
-        ENTITY_RANGE = 64,
-        BUF_SIZE = 200
+        /// Visit a declaration.
+        virtual bool Visit(const XMLDeclaration & /*declaration*/) { return true; }
+        /// Visit a text node.
+        virtual bool Visit(const XMLText & /*text*/) { return true; }
+        /// Visit a comment node.
+        virtual bool Visit(const XMLComment & /*comment*/) { return true; }
+        /// Visit an unknown node.
+        virtual bool Visit(const XMLUnknown & /*unknown*/) { return true; }
     };
-    bool _entityFlag[ENTITY_RANGE];
-    bool _restrictedEntityFlag[ENTITY_RANGE];
 
-    DynArray< char, 20 > _buffer;
+    // WARNING: must match XMLDocument::_errorNames[]
+    enum XMLError
+    {
+        XML_SUCCESS = 0,
+        XML_NO_ATTRIBUTE,
+        XML_WRONG_ATTRIBUTE_TYPE,
+        XML_ERROR_FILE_NOT_FOUND,
+        XML_ERROR_FILE_COULD_NOT_BE_OPENED,
+        XML_ERROR_FILE_READ_ERROR,
+        XML_ERROR_PARSING_ELEMENT,
+        XML_ERROR_PARSING_ATTRIBUTE,
+        XML_ERROR_PARSING_TEXT,
+        XML_ERROR_PARSING_CDATA,
+        XML_ERROR_PARSING_COMMENT,
+        XML_ERROR_PARSING_DECLARATION,
+        XML_ERROR_PARSING_UNKNOWN,
+        XML_ERROR_EMPTY_DOCUMENT,
+        XML_ERROR_MISMATCHED_ELEMENT,
+        XML_ERROR_PARSING,
+        XML_CAN_NOT_CONVERT_TEXT,
+        XML_NO_TEXT_NODE,
+        XML_ELEMENT_DEPTH_EXCEEDED,
 
-    // Prohibit cloning, intentionally not implemented
-    XMLPrinter( const XMLPrinter& );
-    XMLPrinter& operator=( const XMLPrinter& );
-};
+        XML_ERROR_COUNT
+    };
 
+    /*
+        Utility functionality.
+    */
+    class TINYXML2_LIB XMLUtil
+    {
+      public:
+        static const char *SkipWhiteSpace(const char *p, int *curLineNumPtr)
+        {
+            TIXMLASSERT(p);
 
-}	// tinyxml2
+            while (IsWhiteSpace(*p))
+            {
+                if (curLineNumPtr && *p == '\n')
+                {
+                    ++(*curLineNumPtr);
+                }
+                ++p;
+            }
+            TIXMLASSERT(p);
+            return p;
+        }
+        static char *SkipWhiteSpace(char *p, int *curLineNumPtr)
+        {
+            return const_cast<char *>(SkipWhiteSpace(const_cast<const char *>(p), curLineNumPtr));
+        }
+
+        // Anything in the high order range of UTF-8 is assumed to not be whitespace. This isn't
+        // correct, but simple, and usually works.
+        static bool IsWhiteSpace(char p) { return !IsUTF8Continuation(p) && isspace(static_cast<unsigned char>(p)); }
+
+        inline static bool IsNameStartChar(unsigned char ch)
+        {
+            if (ch >= 128)
+            {
+                // This is a heuristic guess in attempt to not implement Unicode-aware isalpha()
+                return true;
+            }
+            if (isalpha(ch))
+            {
+                return true;
+            }
+            return ch == ':' || ch == '_';
+        }
+
+        inline static bool IsNameChar(unsigned char ch)
+        {
+            return IsNameStartChar(ch) || isdigit(ch) || ch == '.' || ch == '-';
+        }
+
+        inline static bool StringEqual(const char *p, const char *q, int nChar = INT_MAX)
+        {
+            if (p == q)
+            {
+                return true;
+            }
+            TIXMLASSERT(p);
+            TIXMLASSERT(q);
+            TIXMLASSERT(nChar >= 0);
+            return strncmp(p, q, nChar) == 0;
+        }
+
+        inline static bool IsUTF8Continuation(char p) { return (p & 0x80) != 0; }
+
+        static const char *ReadBOM(const char *p, bool *hasBOM);
+        // p is the starting location,
+        // the UTF-8 value of the entity will be placed in value, and length filled in.
+        static const char *GetCharacterRef(const char *p, char *value, int *length);
+        static void ConvertUTF32ToUTF8(unsigned long input, char *output, int *length);
+
+        // converts primitive types to strings
+        static void ToStr(int v, char *buffer, int bufferSize);
+        static void ToStr(unsigned v, char *buffer, int bufferSize);
+        static void ToStr(bool v, char *buffer, int bufferSize);
+        static void ToStr(float v, char *buffer, int bufferSize);
+        static void ToStr(double v, char *buffer, int bufferSize);
+        static void ToStr(int64_t v, char *buffer, int bufferSize);
+        static void ToStr(uint64_t v, char *buffer, int bufferSize);
+
+        // converts strings to primitive types
+        static bool ToInt(const char *str, int *value);
+        static bool ToUnsigned(const char *str, unsigned *value);
+        static bool ToBool(const char *str, bool *value);
+        static bool ToFloat(const char *str, float *value);
+        static bool ToDouble(const char *str, double *value);
+        static bool ToInt64(const char *str, int64_t *value);
+        static bool ToUnsigned64(const char *str, uint64_t *value);
+        // Changes what is serialized for a boolean value.
+        // Default to "true" and "false". Shouldn't be changed
+        // unless you have a special testing or compatibility need.
+        // Be careful: static, global, & not thread safe.
+        // Be sure to set static const memory as parameters.
+        static void SetBoolSerialization(const char *writeTrue, const char *writeFalse);
+
+      private:
+        static const char *writeBoolTrue;
+        static const char *writeBoolFalse;
+    };
+
+    /** XMLNode is a base class for every object that is in the
+        XML Document Object Model (DOM), except XMLAttributes.
+        Nodes have siblings, a parent, and children which can
+        be navigated. A node is always in a XMLDocument.
+        The type of a XMLNode can be queried, and it can
+        be cast to its more defined type.
+
+        A XMLDocument allocates memory for all its Nodes.
+        When the XMLDocument gets deleted, all its Nodes
+        will also be deleted.
+
+        @verbatim
+        A Document can contain:	Element	(container or leaf)
+                                Comment (leaf)
+                                Unknown (leaf)
+                                Declaration( leaf )
+
+        An Element can contain:	Element (container or leaf)
+                                Text	(leaf)
+                                Attributes (not on tree)
+                                Comment (leaf)
+                                Unknown (leaf)
+
+        @endverbatim
+    */
+    class TINYXML2_LIB XMLNode
+    {
+        friend class XMLDocument;
+        friend class XMLElement;
+
+      public:
+        /// Get the XMLDocument that owns this XMLNode.
+        const XMLDocument *GetDocument() const
+        {
+            TIXMLASSERT(_document);
+            return _document;
+        }
+        /// Get the XMLDocument that owns this XMLNode.
+        XMLDocument *GetDocument()
+        {
+            TIXMLASSERT(_document);
+            return _document;
+        }
+
+        /// Safely cast to an Element, or null.
+        virtual XMLElement *ToElement() { return 0; }
+        /// Safely cast to Text, or null.
+        virtual XMLText *ToText() { return 0; }
+        /// Safely cast to a Comment, or null.
+        virtual XMLComment *ToComment() { return 0; }
+        /// Safely cast to a Document, or null.
+        virtual XMLDocument *ToDocument() { return 0; }
+        /// Safely cast to a Declaration, or null.
+        virtual XMLDeclaration *ToDeclaration() { return 0; }
+        /// Safely cast to an Unknown, or null.
+        virtual XMLUnknown *ToUnknown() { return 0; }
+
+        virtual const XMLElement *ToElement() const { return 0; }
+        virtual const XMLText *ToText() const { return 0; }
+        virtual const XMLComment *ToComment() const { return 0; }
+        virtual const XMLDocument *ToDocument() const { return 0; }
+        virtual const XMLDeclaration *ToDeclaration() const { return 0; }
+        virtual const XMLUnknown *ToUnknown() const { return 0; }
+
+        /** The meaning of 'value' changes for the specific type.
+            @verbatim
+            Document:	empty (NULL is returned, not an empty string)
+            Element:	name of the element
+            Comment:	the comment text
+            Unknown:	the tag contents
+            Text:		the text string
+            @endverbatim
+        */
+        const char *Value() const;
+
+        /** Set the Value of an XML node.
+            @sa Value()
+        */
+        void SetValue(const char *val, bool staticMem = false);
+
+        /// Gets the line number the node is in, if the document was parsed from a file.
+        int GetLineNum() const { return _parseLineNum; }
+
+        /// Get the parent of this node on the DOM.
+        const XMLNode *Parent() const { return _parent; }
+
+        XMLNode *Parent() { return _parent; }
+
+        /// Returns true if this node has no children.
+        bool NoChildren() const { return !_firstChild; }
+
+        /// Get the first child node, or null if none exists.
+        const XMLNode *FirstChild() const { return _firstChild; }
+
+        XMLNode *FirstChild() { return _firstChild; }
+
+        /** Get the first child element, or optionally the first child
+            element with the specified name.
+        */
+        const XMLElement *FirstChildElement(const char *name = 0) const;
+
+        XMLElement *FirstChildElement(const char *name = 0)
+        {
+            return const_cast<XMLElement *>(const_cast<const XMLNode *>(this)->FirstChildElement(name));
+        }
+
+        /// Get the last child node, or null if none exists.
+        const XMLNode *LastChild() const { return _lastChild; }
+
+        XMLNode *LastChild() { return _lastChild; }
+
+        /** Get the last child element or optionally the last child
+            element with the specified name.
+        */
+        const XMLElement *LastChildElement(const char *name = 0) const;
+
+        XMLElement *LastChildElement(const char *name = 0)
+        {
+            return const_cast<XMLElement *>(const_cast<const XMLNode *>(this)->LastChildElement(name));
+        }
+
+        /// Get the previous (left) sibling node of this node.
+        const XMLNode *PreviousSibling() const { return _prev; }
+
+        XMLNode *PreviousSibling() { return _prev; }
+
+        /// Get the previous (left) sibling element of this node, with an optionally supplied name.
+        const XMLElement *PreviousSiblingElement(const char *name = 0) const;
+
+        XMLElement *PreviousSiblingElement(const char *name = 0)
+        {
+            return const_cast<XMLElement *>(const_cast<const XMLNode *>(this)->PreviousSiblingElement(name));
+        }
+
+        /// Get the next (right) sibling node of this node.
+        const XMLNode *NextSibling() const { return _next; }
+
+        XMLNode *NextSibling() { return _next; }
+
+        /// Get the next (right) sibling element of this node, with an optionally supplied name.
+        const XMLElement *NextSiblingElement(const char *name = 0) const;
+
+        XMLElement *NextSiblingElement(const char *name = 0)
+        {
+            return const_cast<XMLElement *>(const_cast<const XMLNode *>(this)->NextSiblingElement(name));
+        }
+
+        /**
+            Add a child node as the last (right) child.
+            If the child node is already part of the document,
+            it is moved from its old location to the new location.
+            Returns the addThis argument or 0 if the node does not
+            belong to the same document.
+        */
+        XMLNode *InsertEndChild(XMLNode *addThis);
+
+        XMLNode *LinkEndChild(XMLNode *addThis) { return InsertEndChild(addThis); }
+        /**
+            Add a child node as the first (left) child.
+            If the child node is already part of the document,
+            it is moved from its old location to the new location.
+            Returns the addThis argument or 0 if the node does not
+            belong to the same document.
+        */
+        XMLNode *InsertFirstChild(XMLNode *addThis);
+        /**
+            Add a node after the specified child node.
+            If the child node is already part of the document,
+            it is moved from its old location to the new location.
+            Returns the addThis argument or 0 if the afterThis node
+            is not a child of this node, or if the node does not
+            belong to the same document.
+        */
+        XMLNode *InsertAfterChild(XMLNode *afterThis, XMLNode *addThis);
+
+        /**
+            Delete all the children of this node.
+        */
+        void DeleteChildren();
+
+        /**
+            Delete a child of this node.
+        */
+        void DeleteChild(XMLNode *node);
+
+        /**
+            Make a copy of this node, but not its children.
+            You may pass in a Document pointer that will be
+            the owner of the new Node. If the 'document' is
+            null, then the node returned will be allocated
+            from the current Document. (this->GetDocument())
+
+            Note: if called on a XMLDocument, this will return null.
+        */
+        virtual XMLNode *ShallowClone(XMLDocument *document) const = 0;
+
+        /**
+            Make a copy of this node and all its children.
+
+            If the 'target' is null, then the nodes will
+            be allocated in the current document. If 'target'
+            is specified, the memory will be allocated is the
+            specified XMLDocument.
+
+            NOTE: This is probably not the correct tool to
+            copy a document, since XMLDocuments can have multiple
+            top level XMLNodes. You probably want to use
+            XMLDocument::DeepCopy()
+        */
+        XMLNode *DeepClone(XMLDocument *target) const;
+
+        /**
+            Test if 2 nodes are the same, but don't test children.
+            The 2 nodes do not need to be in the same Document.
+
+            Note: if called on a XMLDocument, this will return false.
+        */
+        virtual bool ShallowEqual(const XMLNode *compare) const = 0;
+
+        /** Accept a hierarchical visit of the nodes in the TinyXML-2 DOM. Every node in the
+            XML tree will be conditionally visited and the host will be called back
+            via the XMLVisitor interface.
+
+            This is essentially a SAX interface for TinyXML-2. (Note however it doesn't re-parse
+            the XML for the callbacks, so the performance of TinyXML-2 is unchanged by using this
+            interface versus any other.)
+
+            The interface has been based on ideas from:
+
+            - http://www.saxproject.org/
+            - http://c2.com/cgi/wiki?HierarchicalVisitorPattern
+
+            Which are both good references for "visiting".
+
+            An example of using Accept():
+            @verbatim
+            XMLPrinter printer;
+            tinyxmlDoc.Accept( &printer );
+            const char* xmlcstr = printer.CStr();
+            @endverbatim
+        */
+        virtual bool Accept(XMLVisitor *visitor) const = 0;
+
+        /**
+            Set user data into the XMLNode. TinyXML-2 in
+            no way processes or interprets user data.
+            It is initially 0.
+        */
+        void SetUserData(void *userData) { _userData = userData; }
+
+        /**
+            Get user data set into the XMLNode. TinyXML-2 in
+            no way processes or interprets user data.
+            It is initially 0.
+        */
+        void *GetUserData() const { return _userData; }
+
+      protected:
+        explicit XMLNode(XMLDocument *);
+        virtual ~XMLNode();
+
+        virtual char *ParseDeep(char *p, StrPair *parentEndTag, int *curLineNumPtr);
+
+        XMLDocument *_document;
+        XMLNode *_parent;
+        mutable StrPair _value;
+        int _parseLineNum;
+
+        XMLNode *_firstChild;
+        XMLNode *_lastChild;
+
+        XMLNode *_prev;
+        XMLNode *_next;
+
+        void *_userData;
+
+      private:
+        MemPool *_memPool;
+        void Unlink(XMLNode *child);
+        static void DeleteNode(XMLNode *node);
+        void InsertChildPreamble(XMLNode *insertThis) const;
+        const XMLElement *ToElementWithName(const char *name) const;
+
+        XMLNode(const XMLNode &);            // not supported
+        XMLNode &operator=(const XMLNode &); // not supported
+    };
+
+    /** XML text.
+
+        Note that a text node can have child element nodes, for example:
+        @verbatim
+        <root>This is <b>bold</b></root>
+        @endverbatim
+
+        A text node can have 2 ways to output the next. "normal" output
+        and CDATA. It will default to the mode it was parsed from the XML file and
+        you generally want to leave it alone, but you can change the output mode with
+        SetCData() and query it with CData().
+    */
+    class TINYXML2_LIB XMLText : public XMLNode
+    {
+        friend class XMLDocument;
+
+      public:
+        virtual bool Accept(XMLVisitor *visitor) const;
+
+        virtual XMLText *ToText() { return this; }
+        virtual const XMLText *ToText() const { return this; }
+
+        /// Declare whether this should be CDATA or standard text.
+        void SetCData(bool isCData) { _isCData = isCData; }
+        /// Returns true if this is a CDATA text element.
+        bool CData() const { return _isCData; }
+
+        virtual XMLNode *ShallowClone(XMLDocument *document) const;
+        virtual bool ShallowEqual(const XMLNode *compare) const;
+
+      protected:
+        explicit XMLText(XMLDocument *doc) : XMLNode(doc), _isCData(false) {}
+        virtual ~XMLText() {}
+
+        char *ParseDeep(char *p, StrPair *parentEndTag, int *curLineNumPtr);
+
+      private:
+        bool _isCData;
+
+        XMLText(const XMLText &);            // not supported
+        XMLText &operator=(const XMLText &); // not supported
+    };
+
+    /** An XML Comment. */
+    class TINYXML2_LIB XMLComment : public XMLNode
+    {
+        friend class XMLDocument;
+
+      public:
+        virtual XMLComment *ToComment() { return this; }
+        virtual const XMLComment *ToComment() const { return this; }
+
+        virtual bool Accept(XMLVisitor *visitor) const;
+
+        virtual XMLNode *ShallowClone(XMLDocument *document) const;
+        virtual bool ShallowEqual(const XMLNode *compare) const;
+
+      protected:
+        explicit XMLComment(XMLDocument *doc);
+        virtual ~XMLComment();
+
+        char *ParseDeep(char *p, StrPair *parentEndTag, int *curLineNumPtr);
+
+      private:
+        XMLComment(const XMLComment &);            // not supported
+        XMLComment &operator=(const XMLComment &); // not supported
+    };
+
+    /** In correct XML the declaration is the first entry in the file.
+        @verbatim
+            <?xml version="1.0" standalone="yes"?>
+        @endverbatim
+
+        TinyXML-2 will happily read or write files without a declaration,
+        however.
+
+        The text of the declaration isn't interpreted. It is parsed
+        and written as a string.
+    */
+    class TINYXML2_LIB XMLDeclaration : public XMLNode
+    {
+        friend class XMLDocument;
+
+      public:
+        virtual XMLDeclaration *ToDeclaration() { return this; }
+        virtual const XMLDeclaration *ToDeclaration() const { return this; }
+
+        virtual bool Accept(XMLVisitor *visitor) const;
+
+        virtual XMLNode *ShallowClone(XMLDocument *document) const;
+        virtual bool ShallowEqual(const XMLNode *compare) const;
+
+      protected:
+        explicit XMLDeclaration(XMLDocument *doc);
+        virtual ~XMLDeclaration();
+
+        char *ParseDeep(char *p, StrPair *parentEndTag, int *curLineNumPtr);
+
+      private:
+        XMLDeclaration(const XMLDeclaration &);            // not supported
+        XMLDeclaration &operator=(const XMLDeclaration &); // not supported
+    };
+
+    /** Any tag that TinyXML-2 doesn't recognize is saved as an
+        unknown. It is a tag of text, but should not be modified.
+        It will be written back to the XML, unchanged, when the file
+        is saved.
+
+        DTD tags get thrown into XMLUnknowns.
+    */
+    class TINYXML2_LIB XMLUnknown : public XMLNode
+    {
+        friend class XMLDocument;
+
+      public:
+        virtual XMLUnknown *ToUnknown() { return this; }
+        virtual const XMLUnknown *ToUnknown() const { return this; }
+
+        virtual bool Accept(XMLVisitor *visitor) const;
+
+        virtual XMLNode *ShallowClone(XMLDocument *document) const;
+        virtual bool ShallowEqual(const XMLNode *compare) const;
+
+      protected:
+        explicit XMLUnknown(XMLDocument *doc);
+        virtual ~XMLUnknown();
+
+        char *ParseDeep(char *p, StrPair *parentEndTag, int *curLineNumPtr);
+
+      private:
+        XMLUnknown(const XMLUnknown &);            // not supported
+        XMLUnknown &operator=(const XMLUnknown &); // not supported
+    };
+
+    /** An attribute is a name-value pair. Elements have an arbitrary
+        number of attributes, each with a unique name.
+
+        @note The attributes are not XMLNodes. You may only query the
+        Next() attribute in a list.
+    */
+    class TINYXML2_LIB XMLAttribute
+    {
+        friend class XMLElement;
+
+      public:
+        /// The name of the attribute.
+        const char *Name() const;
+
+        /// The value of the attribute.
+        const char *Value() const;
+
+        /// Gets the line number the attribute is in, if the document was parsed from a file.
+        int GetLineNum() const { return _parseLineNum; }
+
+        /// The next attribute in the list.
+        const XMLAttribute *Next() const { return _next; }
+
+        /** IntValue interprets the attribute as an integer, and returns the value.
+            If the value isn't an integer, 0 will be returned. There is no error checking;
+            use QueryIntValue() if you need error checking.
+        */
+        int IntValue() const
+        {
+            int i = 0;
+            QueryIntValue(&i);
+            return i;
+        }
+
+        int64_t Int64Value() const
+        {
+            int64_t i = 0;
+            QueryInt64Value(&i);
+            return i;
+        }
+
+        uint64_t Unsigned64Value() const
+        {
+            uint64_t i = 0;
+            QueryUnsigned64Value(&i);
+            return i;
+        }
+
+        /// Query as an unsigned integer. See IntValue()
+        unsigned UnsignedValue() const
+        {
+            unsigned i = 0;
+            QueryUnsignedValue(&i);
+            return i;
+        }
+        /// Query as a boolean. See IntValue()
+        bool BoolValue() const
+        {
+            bool b = false;
+            QueryBoolValue(&b);
+            return b;
+        }
+        /// Query as a double. See IntValue()
+        double DoubleValue() const
+        {
+            double d = 0;
+            QueryDoubleValue(&d);
+            return d;
+        }
+        /// Query as a float. See IntValue()
+        float FloatValue() const
+        {
+            float f = 0;
+            QueryFloatValue(&f);
+            return f;
+        }
+
+        /** QueryIntValue interprets the attribute as an integer, and returns the value
+            in the provided parameter. The function will return XML_SUCCESS on success,
+            and XML_WRONG_ATTRIBUTE_TYPE if the conversion is not successful.
+        */
+        XMLError QueryIntValue(int *value) const;
+        /// See QueryIntValue
+        XMLError QueryUnsignedValue(unsigned int *value) const;
+        /// See QueryIntValue
+        XMLError QueryInt64Value(int64_t *value) const;
+        /// See QueryIntValue
+        XMLError QueryUnsigned64Value(uint64_t *value) const;
+        /// See QueryIntValue
+        XMLError QueryBoolValue(bool *value) const;
+        /// See QueryIntValue
+        XMLError QueryDoubleValue(double *value) const;
+        /// See QueryIntValue
+        XMLError QueryFloatValue(float *value) const;
+
+        /// Set the attribute to a string value.
+        void SetAttribute(const char *value);
+        /// Set the attribute to value.
+        void SetAttribute(int value);
+        /// Set the attribute to value.
+        void SetAttribute(unsigned value);
+        /// Set the attribute to value.
+        void SetAttribute(int64_t value);
+        /// Set the attribute to value.
+        void SetAttribute(uint64_t value);
+        /// Set the attribute to value.
+        void SetAttribute(bool value);
+        /// Set the attribute to value.
+        void SetAttribute(double value);
+        /// Set the attribute to value.
+        void SetAttribute(float value);
+
+      private:
+        enum
+        {
+            BUF_SIZE = 200
+        };
+
+        XMLAttribute() : _name(), _value(), _parseLineNum(0), _next(0), _memPool(0) {}
+        virtual ~XMLAttribute() {}
+
+        XMLAttribute(const XMLAttribute &);   // not supported
+        void operator=(const XMLAttribute &); // not supported
+        void SetName(const char *name);
+
+        char *ParseDeep(char *p, bool processEntities, int *curLineNumPtr);
+
+        mutable StrPair _name;
+        mutable StrPair _value;
+        int _parseLineNum;
+        XMLAttribute *_next;
+        MemPool *_memPool;
+    };
+
+    /** The element is a container class. It has a value, the element name,
+        and can contain other elements, text, comments, and unknowns.
+        Elements also contain an arbitrary number of attributes.
+    */
+    class TINYXML2_LIB XMLElement : public XMLNode
+    {
+        friend class XMLDocument;
+
+      public:
+        /// Get the name of an element (which is the Value() of the node.)
+        const char *Name() const { return Value(); }
+        /// Set the name of the element.
+        void SetName(const char *str, bool staticMem = false) { SetValue(str, staticMem); }
+
+        virtual XMLElement *ToElement() { return this; }
+        virtual const XMLElement *ToElement() const { return this; }
+        virtual bool Accept(XMLVisitor *visitor) const;
+
+        /** Given an attribute name, Attribute() returns the value
+            for the attribute of that name, or null if none
+            exists. For example:
+
+            @verbatim
+            const char* value = ele->Attribute( "foo" );
+            @endverbatim
+
+            The 'value' parameter is normally null. However, if specified,
+            the attribute will only be returned if the 'name' and 'value'
+            match. This allow you to write code:
+
+            @verbatim
+            if ( ele->Attribute( "foo", "bar" ) ) callFooIsBar();
+            @endverbatim
+
+            rather than:
+            @verbatim
+            if ( ele->Attribute( "foo" ) ) {
+                if ( strcmp( ele->Attribute( "foo" ), "bar" ) == 0 ) callFooIsBar();
+            }
+            @endverbatim
+        */
+        const char *Attribute(const char *name, const char *value = 0) const;
+
+        /** Given an attribute name, IntAttribute() returns the value
+            of the attribute interpreted as an integer. The default
+            value will be returned if the attribute isn't present,
+            or if there is an error. (For a method with error
+            checking, see QueryIntAttribute()).
+        */
+        int IntAttribute(const char *name, int defaultValue = 0) const;
+        /// See IntAttribute()
+        unsigned UnsignedAttribute(const char *name, unsigned defaultValue = 0) const;
+        /// See IntAttribute()
+        int64_t Int64Attribute(const char *name, int64_t defaultValue = 0) const;
+        /// See IntAttribute()
+        uint64_t Unsigned64Attribute(const char *name, uint64_t defaultValue = 0) const;
+        /// See IntAttribute()
+        bool BoolAttribute(const char *name, bool defaultValue = false) const;
+        /// See IntAttribute()
+        double DoubleAttribute(const char *name, double defaultValue = 0) const;
+        /// See IntAttribute()
+        float FloatAttribute(const char *name, float defaultValue = 0) const;
+
+        /** Given an attribute name, QueryIntAttribute() returns
+            XML_SUCCESS, XML_WRONG_ATTRIBUTE_TYPE if the conversion
+            can't be performed, or XML_NO_ATTRIBUTE if the attribute
+            doesn't exist. If successful, the result of the conversion
+            will be written to 'value'. If not successful, nothing will
+            be written to 'value'. This allows you to provide default
+            value:
+
+            @verbatim
+            int value = 10;
+            QueryIntAttribute( "foo", &value );		// if "foo" isn't found, value will still be 10
+            @endverbatim
+        */
+        XMLError QueryIntAttribute(const char *name, int *value) const
+        {
+            const XMLAttribute *a = FindAttribute(name);
+            if (!a)
+            {
+                return XML_NO_ATTRIBUTE;
+            }
+            return a->QueryIntValue(value);
+        }
+
+        /// See QueryIntAttribute()
+        XMLError QueryUnsignedAttribute(const char *name, unsigned int *value) const
+        {
+            const XMLAttribute *a = FindAttribute(name);
+            if (!a)
+            {
+                return XML_NO_ATTRIBUTE;
+            }
+            return a->QueryUnsignedValue(value);
+        }
+
+        /// See QueryIntAttribute()
+        XMLError QueryInt64Attribute(const char *name, int64_t *value) const
+        {
+            const XMLAttribute *a = FindAttribute(name);
+            if (!a)
+            {
+                return XML_NO_ATTRIBUTE;
+            }
+            return a->QueryInt64Value(value);
+        }
+
+        /// See QueryIntAttribute()
+        XMLError QueryUnsigned64Attribute(const char *name, uint64_t *value) const
+        {
+            const XMLAttribute *a = FindAttribute(name);
+            if (!a)
+            {
+                return XML_NO_ATTRIBUTE;
+            }
+            return a->QueryUnsigned64Value(value);
+        }
+
+        /// See QueryIntAttribute()
+        XMLError QueryBoolAttribute(const char *name, bool *value) const
+        {
+            const XMLAttribute *a = FindAttribute(name);
+            if (!a)
+            {
+                return XML_NO_ATTRIBUTE;
+            }
+            return a->QueryBoolValue(value);
+        }
+        /// See QueryIntAttribute()
+        XMLError QueryDoubleAttribute(const char *name, double *value) const
+        {
+            const XMLAttribute *a = FindAttribute(name);
+            if (!a)
+            {
+                return XML_NO_ATTRIBUTE;
+            }
+            return a->QueryDoubleValue(value);
+        }
+        /// See QueryIntAttribute()
+        XMLError QueryFloatAttribute(const char *name, float *value) const
+        {
+            const XMLAttribute *a = FindAttribute(name);
+            if (!a)
+            {
+                return XML_NO_ATTRIBUTE;
+            }
+            return a->QueryFloatValue(value);
+        }
+
+        /// See QueryIntAttribute()
+        XMLError QueryStringAttribute(const char *name, const char **value) const
+        {
+            const XMLAttribute *a = FindAttribute(name);
+            if (!a)
+            {
+                return XML_NO_ATTRIBUTE;
+            }
+            *value = a->Value();
+            return XML_SUCCESS;
+        }
+
+        /** Given an attribute name, QueryAttribute() returns
+            XML_SUCCESS, XML_WRONG_ATTRIBUTE_TYPE if the conversion
+            can't be performed, or XML_NO_ATTRIBUTE if the attribute
+            doesn't exist. It is overloaded for the primitive types,
+            and is a generally more convenient replacement of
+            QueryIntAttribute() and related functions.
+
+            If successful, the result of the conversion
+            will be written to 'value'. If not successful, nothing will
+            be written to 'value'. This allows you to provide default
+            value:
+
+            @verbatim
+            int value = 10;
+            QueryAttribute( "foo", &value );		// if "foo" isn't found, value will still be 10
+            @endverbatim
+        */
+        XMLError QueryAttribute(const char *name, int *value) const { return QueryIntAttribute(name, value); }
+
+        XMLError QueryAttribute(const char *name, unsigned int *value) const
+        {
+            return QueryUnsignedAttribute(name, value);
+        }
+
+        XMLError QueryAttribute(const char *name, int64_t *value) const { return QueryInt64Attribute(name, value); }
+
+        XMLError QueryAttribute(const char *name, uint64_t *value) const
+        {
+            return QueryUnsigned64Attribute(name, value);
+        }
+
+        XMLError QueryAttribute(const char *name, bool *value) const { return QueryBoolAttribute(name, value); }
+
+        XMLError QueryAttribute(const char *name, double *value) const { return QueryDoubleAttribute(name, value); }
+
+        XMLError QueryAttribute(const char *name, float *value) const { return QueryFloatAttribute(name, value); }
+
+        /// Sets the named attribute to value.
+        void SetAttribute(const char *name, const char *value)
+        {
+            XMLAttribute *a = FindOrCreateAttribute(name);
+            a->SetAttribute(value);
+        }
+        /// Sets the named attribute to value.
+        void SetAttribute(const char *name, int value)
+        {
+            XMLAttribute *a = FindOrCreateAttribute(name);
+            a->SetAttribute(value);
+        }
+        /// Sets the named attribute to value.
+        void SetAttribute(const char *name, unsigned value)
+        {
+            XMLAttribute *a = FindOrCreateAttribute(name);
+            a->SetAttribute(value);
+        }
+
+        /// Sets the named attribute to value.
+        void SetAttribute(const char *name, int64_t value)
+        {
+            XMLAttribute *a = FindOrCreateAttribute(name);
+            a->SetAttribute(value);
+        }
+
+        /// Sets the named attribute to value.
+        void SetAttribute(const char *name, uint64_t value)
+        {
+            XMLAttribute *a = FindOrCreateAttribute(name);
+            a->SetAttribute(value);
+        }
+
+        /// Sets the named attribute to value.
+        void SetAttribute(const char *name, bool value)
+        {
+            XMLAttribute *a = FindOrCreateAttribute(name);
+            a->SetAttribute(value);
+        }
+        /// Sets the named attribute to value.
+        void SetAttribute(const char *name, double value)
+        {
+            XMLAttribute *a = FindOrCreateAttribute(name);
+            a->SetAttribute(value);
+        }
+        /// Sets the named attribute to value.
+        void SetAttribute(const char *name, float value)
+        {
+            XMLAttribute *a = FindOrCreateAttribute(name);
+            a->SetAttribute(value);
+        }
+
+        /**
+            Delete an attribute.
+        */
+        void DeleteAttribute(const char *name);
+
+        /// Return the first attribute in the list.
+        const XMLAttribute *FirstAttribute() const { return _rootAttribute; }
+        /// Query a specific attribute in the list.
+        const XMLAttribute *FindAttribute(const char *name) const;
+
+        /** Convenience function for easy access to the text inside an element. Although easy
+            and concise, GetText() is limited compared to getting the XMLText child
+            and accessing it directly.
+
+            If the first child of 'this' is a XMLText, the GetText()
+            returns the character string of the Text node, else null is returned.
+
+            This is a convenient method for getting the text of simple contained text:
+            @verbatim
+            <foo>This is text</foo>
+                const char* str = fooElement->GetText();
+            @endverbatim
+
+            'str' will be a pointer to "This is text".
+
+            Note that this function can be misleading. If the element foo was created from
+            this XML:
+            @verbatim
+                <foo><b>This is text</b></foo>
+            @endverbatim
+
+            then the value of str would be null. The first child node isn't a text node, it is
+            another element. From this XML:
+            @verbatim
+                <foo>This is <b>text</b></foo>
+            @endverbatim
+            GetText() will return "This is ".
+        */
+        const char *GetText() const;
+
+        /** Convenience function for easy access to the text inside an element. Although easy
+            and concise, SetText() is limited compared to creating an XMLText child
+            and mutating it directly.
+
+            If the first child of 'this' is a XMLText, SetText() sets its value to
+            the given string, otherwise it will create a first child that is an XMLText.
+
+            This is a convenient method for setting the text of simple contained text:
+            @verbatim
+            <foo>This is text</foo>
+                fooElement->SetText( "Hullaballoo!" );
+            <foo>Hullaballoo!</foo>
+            @endverbatim
+
+            Note that this function can be misleading. If the element foo was created from
+            this XML:
+            @verbatim
+                <foo><b>This is text</b></foo>
+            @endverbatim
+
+            then it will not change "This is text", but rather prefix it with a text element:
+            @verbatim
+                <foo>Hullaballoo!<b>This is text</b></foo>
+            @endverbatim
+
+            For this XML:
+            @verbatim
+                <foo />
+            @endverbatim
+            SetText() will generate
+            @verbatim
+                <foo>Hullaballoo!</foo>
+            @endverbatim
+        */
+        void SetText(const char *inText);
+        /// Convenience method for setting text inside an element. See SetText() for important limitations.
+        void SetText(int value);
+        /// Convenience method for setting text inside an element. See SetText() for important limitations.
+        void SetText(unsigned value);
+        /// Convenience method for setting text inside an element. See SetText() for important limitations.
+        void SetText(int64_t value);
+        /// Convenience method for setting text inside an element. See SetText() for important limitations.
+        void SetText(uint64_t value);
+        /// Convenience method for setting text inside an element. See SetText() for important limitations.
+        void SetText(bool value);
+        /// Convenience method for setting text inside an element. See SetText() for important limitations.
+        void SetText(double value);
+        /// Convenience method for setting text inside an element. See SetText() for important limitations.
+        void SetText(float value);
+
+        /**
+            Convenience method to query the value of a child text node. This is probably best
+            shown by example. Given you have a document is this form:
+            @verbatim
+                <point>
+                    <x>1</x>
+                    <y>1.4</y>
+                </point>
+            @endverbatim
+
+            The QueryIntText() and similar functions provide a safe and easier way to get to the
+            "value" of x and y.
+
+            @verbatim
+                int x = 0;
+                float y = 0;	// types of x and y are contrived for example
+                const XMLElement* xElement = pointElement->FirstChildElement( "x" );
+                const XMLElement* yElement = pointElement->FirstChildElement( "y" );
+                xElement->QueryIntText( &x );
+                yElement->QueryFloatText( &y );
+            @endverbatim
+
+            @returns XML_SUCCESS (0) on success, XML_CAN_NOT_CONVERT_TEXT if the text cannot be converted
+                     to the requested type, and XML_NO_TEXT_NODE if there is no child text to query.
+
+        */
+        XMLError QueryIntText(int *ival) const;
+        /// See QueryIntText()
+        XMLError QueryUnsignedText(unsigned *uval) const;
+        /// See QueryIntText()
+        XMLError QueryInt64Text(int64_t *uval) const;
+        /// See QueryIntText()
+        XMLError QueryUnsigned64Text(uint64_t *uval) const;
+        /// See QueryIntText()
+        XMLError QueryBoolText(bool *bval) const;
+        /// See QueryIntText()
+        XMLError QueryDoubleText(double *dval) const;
+        /// See QueryIntText()
+        XMLError QueryFloatText(float *fval) const;
+
+        int IntText(int defaultValue = 0) const;
+
+        /// See QueryIntText()
+        unsigned UnsignedText(unsigned defaultValue = 0) const;
+        /// See QueryIntText()
+        int64_t Int64Text(int64_t defaultValue = 0) const;
+        /// See QueryIntText()
+        uint64_t Unsigned64Text(uint64_t defaultValue = 0) const;
+        /// See QueryIntText()
+        bool BoolText(bool defaultValue = false) const;
+        /// See QueryIntText()
+        double DoubleText(double defaultValue = 0) const;
+        /// See QueryIntText()
+        float FloatText(float defaultValue = 0) const;
+
+        // internal:
+        enum ElementClosingType
+        {
+            OPEN,   // <foo>
+            CLOSED, // <foo/>
+            CLOSING // </foo>
+        };
+        ElementClosingType ClosingType() const { return _closingType; }
+        virtual XMLNode *ShallowClone(XMLDocument *document) const;
+        virtual bool ShallowEqual(const XMLNode *compare) const;
+
+      protected:
+        char *ParseDeep(char *p, StrPair *parentEndTag, int *curLineNumPtr);
+
+      private:
+        XMLElement(XMLDocument *doc);
+        virtual ~XMLElement();
+        XMLElement(const XMLElement &);     // not supported
+        void operator=(const XMLElement &); // not supported
+
+        XMLAttribute *FindOrCreateAttribute(const char *name);
+        char *ParseAttributes(char *p, int *curLineNumPtr);
+        static void DeleteAttribute(XMLAttribute *attribute);
+        XMLAttribute *CreateAttribute();
+
+        enum
+        {
+            BUF_SIZE = 200
+        };
+        ElementClosingType _closingType;
+        // The attribute list is ordered; there is no 'lastAttribute'
+        // because the list needs to be scanned for dupes before adding
+        // a new attribute.
+        XMLAttribute *_rootAttribute;
+    };
+
+    enum Whitespace
+    {
+        PRESERVE_WHITESPACE,
+        COLLAPSE_WHITESPACE
+    };
+
+    /** A Document binds together all the functionality.
+        It can be saved, loaded, and printed to the screen.
+        All Nodes are connected and allocated to a Document.
+        If the Document is deleted, all its Nodes are also deleted.
+    */
+    class TINYXML2_LIB XMLDocument : public XMLNode
+    {
+        friend class XMLElement;
+        // Gives access to SetError and Push/PopDepth, but over-access for everything else.
+        // Wishing C++ had "internal" scope.
+        friend class XMLNode;
+        friend class XMLText;
+        friend class XMLComment;
+        friend class XMLDeclaration;
+        friend class XMLUnknown;
+
+      public:
+        /// constructor
+        XMLDocument(bool processEntities = true, Whitespace whitespaceMode = PRESERVE_WHITESPACE);
+        ~XMLDocument();
+
+        virtual XMLDocument *ToDocument()
+        {
+            TIXMLASSERT(this == _document);
+            return this;
+        }
+        virtual const XMLDocument *ToDocument() const
+        {
+            TIXMLASSERT(this == _document);
+            return this;
+        }
+
+        /**
+            Parse an XML file from a character string.
+            Returns XML_SUCCESS (0) on success, or
+            an errorID.
+
+            You may optionally pass in the 'nBytes', which is
+            the number of bytes which will be parsed. If not
+            specified, TinyXML-2 will assume 'xml' points to a
+            null terminated string.
+        */
+        XMLError Parse(const char *xml, size_t nBytes = static_cast<size_t>(-1));
+
+        /**
+            Load an XML file from disk.
+            Returns XML_SUCCESS (0) on success, or
+            an errorID.
+        */
+        XMLError LoadFile(const char *filename);
+
+        /**
+            Load an XML file from disk. You are responsible
+            for providing and closing the FILE*.
+
+            NOTE: The file should be opened as binary ("rb")
+            not text in order for TinyXML-2 to correctly
+            do newline normalization.
+
+            Returns XML_SUCCESS (0) on success, or
+            an errorID.
+        */
+        XMLError LoadFile(FILE *);
+
+        /**
+            Save the XML file to disk.
+            Returns XML_SUCCESS (0) on success, or
+            an errorID.
+        */
+        XMLError SaveFile(const char *filename, bool compact = false);
+
+        /**
+            Save the XML file to disk. You are responsible
+            for providing and closing the FILE*.
+
+            Returns XML_SUCCESS (0) on success, or
+            an errorID.
+        */
+        XMLError SaveFile(FILE *fp, bool compact = false);
+
+        bool ProcessEntities() const { return _processEntities; }
+        Whitespace WhitespaceMode() const { return _whitespaceMode; }
+
+        /**
+            Returns true if this document has a leading Byte Order Mark of UTF8.
+        */
+        bool HasBOM() const { return _writeBOM; }
+        /** Sets whether to write the BOM when writing the file.
+         */
+        void SetBOM(bool useBOM) { _writeBOM = useBOM; }
+
+        /** Return the root element of DOM. Equivalent to FirstChildElement().
+            To get the first node, use FirstChild().
+        */
+        XMLElement *RootElement() { return FirstChildElement(); }
+        const XMLElement *RootElement() const { return FirstChildElement(); }
+
+        /** Print the Document. If the Printer is not provided, it will
+            print to stdout. If you provide Printer, this can print to a file:
+            @verbatim
+            XMLPrinter printer( fp );
+            doc.Print( &printer );
+            @endverbatim
+
+            Or you can use a printer to print to memory:
+            @verbatim
+            XMLPrinter printer;
+            doc.Print( &printer );
+            // printer.CStr() has a const char* to the XML
+            @endverbatim
+        */
+        void Print(XMLPrinter *streamer = 0) const;
+        virtual bool Accept(XMLVisitor *visitor) const;
+
+        /**
+            Create a new Element associated with
+            this Document. The memory for the Element
+            is managed by the Document.
+        */
+        XMLElement *NewElement(const char *name);
+        /**
+            Create a new Comment associated with
+            this Document. The memory for the Comment
+            is managed by the Document.
+        */
+        XMLComment *NewComment(const char *comment);
+        /**
+            Create a new Text associated with
+            this Document. The memory for the Text
+            is managed by the Document.
+        */
+        XMLText *NewText(const char *text);
+        /**
+            Create a new Declaration associated with
+            this Document. The memory for the object
+            is managed by the Document.
+
+            If the 'text' param is null, the standard
+            declaration is used.:
+            @verbatim
+                <?xml version="1.0" encoding="UTF-8"?>
+            @endverbatim
+        */
+        XMLDeclaration *NewDeclaration(const char *text = 0);
+        /**
+            Create a new Unknown associated with
+            this Document. The memory for the object
+            is managed by the Document.
+        */
+        XMLUnknown *NewUnknown(const char *text);
+
+        /**
+            Delete a node associated with this document.
+            It will be unlinked from the DOM.
+        */
+        void DeleteNode(XMLNode *node);
+
+        void ClearError() { SetError(XML_SUCCESS, 0, 0); }
+
+        /// Return true if there was an error parsing the document.
+        bool Error() const { return _errorID != XML_SUCCESS; }
+        /// Return the errorID.
+        XMLError ErrorID() const { return _errorID; }
+        const char *ErrorName() const;
+        static const char *ErrorIDToName(XMLError errorID);
+
+        /** Returns a "long form" error description. A hopefully helpful
+            diagnostic with location, line number, and/or additional info.
+        */
+        const char *ErrorStr() const;
+
+        /// A (trivial) utility function that prints the ErrorStr() to stdout.
+        void PrintError() const;
+
+        /// Return the line where the error occurred, or zero if unknown.
+        int ErrorLineNum() const { return _errorLineNum; }
+
+        /// Clear the document, resetting it to the initial state.
+        void Clear();
+
+        /**
+            Copies this document to a target document.
+            The target will be completely cleared before the copy.
+            If you want to copy a sub-tree, see XMLNode::DeepClone().
+
+            NOTE: that the 'target' must be non-null.
+        */
+        void DeepCopy(XMLDocument *target) const;
+
+        // internal
+        char *Identify(char *p, XMLNode **node);
+
+        // internal
+        void MarkInUse(XMLNode *);
+
+        virtual XMLNode *ShallowClone(XMLDocument * /*document*/) const { return 0; }
+        virtual bool ShallowEqual(const XMLNode * /*compare*/) const { return false; }
+
+      private:
+        XMLDocument(const XMLDocument &);    // not supported
+        void operator=(const XMLDocument &); // not supported
+
+        bool _writeBOM;
+        bool _processEntities;
+        XMLError _errorID;
+        Whitespace _whitespaceMode;
+        mutable StrPair _errorStr;
+        int _errorLineNum;
+        char *_charBuffer;
+        int _parseCurLineNum;
+        int _parsingDepth;
+        // Memory tracking does add some overhead.
+        // However, the code assumes that you don't
+        // have a bunch of unlinked nodes around.
+        // Therefore it takes less memory to track
+        // in the document vs. a linked list in the XMLNode,
+        // and the performance is the same.
+        DynArray<XMLNode *, 10> _unlinked;
+
+        MemPoolT<sizeof(XMLElement)> _elementPool;
+        MemPoolT<sizeof(XMLAttribute)> _attributePool;
+        MemPoolT<sizeof(XMLText)> _textPool;
+        MemPoolT<sizeof(XMLComment)> _commentPool;
+
+        static const char *_errorNames[XML_ERROR_COUNT];
+
+        void Parse();
+
+        void SetError(XMLError error, int lineNum, const char *format, ...);
+
+        // Something of an obvious security hole, once it was discovered.
+        // Either an ill-formed XML or an excessively deep one can overflow
+        // the stack. Track stack depth, and error out if needed.
+        class DepthTracker
+        {
+          public:
+            explicit DepthTracker(XMLDocument *document)
+            {
+                this->_document = document;
+                document->PushDepth();
+            }
+            ~DepthTracker() { _document->PopDepth(); }
+
+          private:
+            XMLDocument *_document;
+        };
+        void PushDepth();
+        void PopDepth();
+
+        template <class NodeType, int PoolElementSize> NodeType *CreateUnlinkedNode(MemPoolT<PoolElementSize> &pool);
+    };
+
+    template <class NodeType, int PoolElementSize>
+    inline NodeType *XMLDocument::CreateUnlinkedNode(MemPoolT<PoolElementSize> &pool)
+    {
+        TIXMLASSERT(sizeof(NodeType) == PoolElementSize);
+        TIXMLASSERT(sizeof(NodeType) == pool.ItemSize());
+        NodeType *returnNode = new (pool.Alloc()) NodeType(this);
+        TIXMLASSERT(returnNode);
+        returnNode->_memPool = &pool;
+
+        _unlinked.Push(returnNode);
+        return returnNode;
+    }
+
+    /**
+        A XMLHandle is a class that wraps a node pointer with null checks; this is
+        an incredibly useful thing. Note that XMLHandle is not part of the TinyXML-2
+        DOM structure. It is a separate utility class.
+
+        Take an example:
+        @verbatim
+        <Document>
+            <Element attributeA = "valueA">
+                <Child attributeB = "value1" />
+                <Child attributeB = "value2" />
+            </Element>
+        </Document>
+        @endverbatim
+
+        Assuming you want the value of "attributeB" in the 2nd "Child" element, it's very
+        easy to write a *lot* of code that looks like:
+
+        @verbatim
+        XMLElement* root = document.FirstChildElement( "Document" );
+        if ( root )
+        {
+            XMLElement* element = root->FirstChildElement( "Element" );
+            if ( element )
+            {
+                XMLElement* child = element->FirstChildElement( "Child" );
+                if ( child )
+                {
+                    XMLElement* child2 = child->NextSiblingElement( "Child" );
+                    if ( child2 )
+                    {
+                        // Finally do something useful.
+        @endverbatim
+
+        And that doesn't even cover "else" cases. XMLHandle addresses the verbosity
+        of such code. A XMLHandle checks for null pointers so it is perfectly safe
+        and correct to use:
+
+        @verbatim
+        XMLHandle docHandle( &document );
+        XMLElement* child2 = docHandle.FirstChildElement( "Document" ).FirstChildElement( "Element"
+       ).FirstChildElement().NextSiblingElement(); if ( child2 )
+        {
+            // do something useful
+        @endverbatim
+
+        Which is MUCH more concise and useful.
+
+        It is also safe to copy handles - internally they are nothing more than node pointers.
+        @verbatim
+        XMLHandle handleCopy = handle;
+        @endverbatim
+
+        See also XMLConstHandle, which is the same as XMLHandle, but operates on const objects.
+    */
+    class TINYXML2_LIB XMLHandle
+    {
+      public:
+        /// Create a handle from any node (at any depth of the tree.) This can be a null pointer.
+        explicit XMLHandle(XMLNode *node) : _node(node) {}
+        /// Create a handle from a node.
+        explicit XMLHandle(XMLNode &node) : _node(&node) {}
+        /// Copy constructor
+        XMLHandle(const XMLHandle &ref) : _node(ref._node) {}
+        /// Assignment
+        XMLHandle &operator=(const XMLHandle &ref)
+        {
+            _node = ref._node;
+            return *this;
+        }
+
+        /// Get the first child of this handle.
+        XMLHandle FirstChild() { return XMLHandle(_node ? _node->FirstChild() : 0); }
+        /// Get the first child element of this handle.
+        XMLHandle FirstChildElement(const char *name = 0)
+        {
+            return XMLHandle(_node ? _node->FirstChildElement(name) : 0);
+        }
+        /// Get the last child of this handle.
+        XMLHandle LastChild() { return XMLHandle(_node ? _node->LastChild() : 0); }
+        /// Get the last child element of this handle.
+        XMLHandle LastChildElement(const char *name = 0)
+        {
+            return XMLHandle(_node ? _node->LastChildElement(name) : 0);
+        }
+        /// Get the previous sibling of this handle.
+        XMLHandle PreviousSibling() { return XMLHandle(_node ? _node->PreviousSibling() : 0); }
+        /// Get the previous sibling element of this handle.
+        XMLHandle PreviousSiblingElement(const char *name = 0)
+        {
+            return XMLHandle(_node ? _node->PreviousSiblingElement(name) : 0);
+        }
+        /// Get the next sibling of this handle.
+        XMLHandle NextSibling() { return XMLHandle(_node ? _node->NextSibling() : 0); }
+        /// Get the next sibling element of this handle.
+        XMLHandle NextSiblingElement(const char *name = 0)
+        {
+            return XMLHandle(_node ? _node->NextSiblingElement(name) : 0);
+        }
+
+        /// Safe cast to XMLNode. This can return null.
+        XMLNode *ToNode() { return _node; }
+        /// Safe cast to XMLElement. This can return null.
+        XMLElement *ToElement() { return (_node ? _node->ToElement() : 0); }
+        /// Safe cast to XMLText. This can return null.
+        XMLText *ToText() { return (_node ? _node->ToText() : 0); }
+        /// Safe cast to XMLUnknown. This can return null.
+        XMLUnknown *ToUnknown() { return (_node ? _node->ToUnknown() : 0); }
+        /// Safe cast to XMLDeclaration. This can return null.
+        XMLDeclaration *ToDeclaration() { return (_node ? _node->ToDeclaration() : 0); }
+
+      private:
+        XMLNode *_node;
+    };
+
+    /**
+        A variant of the XMLHandle class for working with const XMLNodes and Documents. It is the
+        same in all regards, except for the 'const' qualifiers. See XMLHandle for API.
+    */
+    class TINYXML2_LIB XMLConstHandle
+    {
+      public:
+        explicit XMLConstHandle(const XMLNode *node) : _node(node) {}
+        explicit XMLConstHandle(const XMLNode &node) : _node(&node) {}
+        XMLConstHandle(const XMLConstHandle &ref) : _node(ref._node) {}
+
+        XMLConstHandle &operator=(const XMLConstHandle &ref)
+        {
+            _node = ref._node;
+            return *this;
+        }
+
+        const XMLConstHandle FirstChild() const { return XMLConstHandle(_node ? _node->FirstChild() : 0); }
+        const XMLConstHandle FirstChildElement(const char *name = 0) const
+        {
+            return XMLConstHandle(_node ? _node->FirstChildElement(name) : 0);
+        }
+        const XMLConstHandle LastChild() const { return XMLConstHandle(_node ? _node->LastChild() : 0); }
+        const XMLConstHandle LastChildElement(const char *name = 0) const
+        {
+            return XMLConstHandle(_node ? _node->LastChildElement(name) : 0);
+        }
+        const XMLConstHandle PreviousSibling() const { return XMLConstHandle(_node ? _node->PreviousSibling() : 0); }
+        const XMLConstHandle PreviousSiblingElement(const char *name = 0) const
+        {
+            return XMLConstHandle(_node ? _node->PreviousSiblingElement(name) : 0);
+        }
+        const XMLConstHandle NextSibling() const { return XMLConstHandle(_node ? _node->NextSibling() : 0); }
+        const XMLConstHandle NextSiblingElement(const char *name = 0) const
+        {
+            return XMLConstHandle(_node ? _node->NextSiblingElement(name) : 0);
+        }
+
+        const XMLNode *ToNode() const { return _node; }
+        const XMLElement *ToElement() const { return (_node ? _node->ToElement() : 0); }
+        const XMLText *ToText() const { return (_node ? _node->ToText() : 0); }
+        const XMLUnknown *ToUnknown() const { return (_node ? _node->ToUnknown() : 0); }
+        const XMLDeclaration *ToDeclaration() const { return (_node ? _node->ToDeclaration() : 0); }
+
+      private:
+        const XMLNode *_node;
+    };
+
+    /**
+        Printing functionality. The XMLPrinter gives you more
+        options than the XMLDocument::Print() method.
+
+        It can:
+        -# Print to memory.
+        -# Print to a file you provide.
+        -# Print XML without a XMLDocument.
+
+        Print to Memory
+
+        @verbatim
+        XMLPrinter printer;
+        doc.Print( &printer );
+        SomeFunction( printer.CStr() );
+        @endverbatim
+
+        Print to a File
+
+        You provide the file pointer.
+        @verbatim
+        XMLPrinter printer( fp );
+        doc.Print( &printer );
+        @endverbatim
+
+        Print without a XMLDocument
+
+        When loading, an XML parser is very useful. However, sometimes
+        when saving, it just gets in the way. The code is often set up
+        for streaming, and constructing the DOM is just overhead.
+
+        The Printer supports the streaming case. The following code
+        prints out a trivially simple XML file without ever creating
+        an XML document.
+
+        @verbatim
+        XMLPrinter printer( fp );
+        printer.OpenElement( "foo" );
+        printer.PushAttribute( "foo", "bar" );
+        printer.CloseElement();
+        @endverbatim
+    */
+    class TINYXML2_LIB XMLPrinter : public XMLVisitor
+    {
+      public:
+        /** Construct the printer. If the FILE* is specified,
+            this will print to the FILE. Else it will print
+            to memory, and the result is available in CStr().
+            If 'compact' is set to true, then output is created
+            with only required whitespace and newlines.
+        */
+        XMLPrinter(FILE *file = 0, bool compact = false, int depth = 0);
+        virtual ~XMLPrinter() {}
+
+        /** If streaming, write the BOM and declaration. */
+        void PushHeader(bool writeBOM, bool writeDeclaration);
+        /** If streaming, start writing an element.
+            The element must be closed with CloseElement()
+        */
+        void OpenElement(const char *name, bool compactMode = false);
+        /// If streaming, add an attribute to an open element.
+        void PushAttribute(const char *name, const char *value);
+        void PushAttribute(const char *name, int value);
+        void PushAttribute(const char *name, unsigned value);
+        void PushAttribute(const char *name, int64_t value);
+        void PushAttribute(const char *name, uint64_t value);
+        void PushAttribute(const char *name, bool value);
+        void PushAttribute(const char *name, double value);
+        /// If streaming, close the Element.
+        virtual void CloseElement(bool compactMode = false);
+
+        /// Add a text node.
+        void PushText(const char *text, bool cdata = false);
+        /// Add a text node from an integer.
+        void PushText(int value);
+        /// Add a text node from an unsigned.
+        void PushText(unsigned value);
+        /// Add a text node from a signed 64bit integer.
+        void PushText(int64_t value);
+        /// Add a text node from an unsigned 64bit integer.
+        void PushText(uint64_t value);
+        /// Add a text node from a bool.
+        void PushText(bool value);
+        /// Add a text node from a float.
+        void PushText(float value);
+        /// Add a text node from a double.
+        void PushText(double value);
+
+        /// Add a comment
+        void PushComment(const char *comment);
+
+        void PushDeclaration(const char *value);
+        void PushUnknown(const char *value);
+
+        virtual bool VisitEnter(const XMLDocument & /*doc*/);
+        virtual bool VisitExit(const XMLDocument & /*doc*/) { return true; }
+
+        virtual bool VisitEnter(const XMLElement &element, const XMLAttribute *attribute);
+        virtual bool VisitExit(const XMLElement &element);
+
+        virtual bool Visit(const XMLText &text);
+        virtual bool Visit(const XMLComment &comment);
+        virtual bool Visit(const XMLDeclaration &declaration);
+        virtual bool Visit(const XMLUnknown &unknown);
+
+        /**
+            If in print to memory mode, return a pointer to
+            the XML file in memory.
+        */
+        const char *CStr() const { return _buffer.Mem(); }
+        /**
+            If in print to memory mode, return the size
+            of the XML file in memory. (Note the size returned
+            includes the terminating null.)
+        */
+        int CStrSize() const { return _buffer.Size(); }
+        /**
+            If in print to memory mode, reset the buffer to the
+            beginning.
+        */
+        void ClearBuffer(bool resetToFirstElement = true)
+        {
+            _buffer.Clear();
+            _buffer.Push(0);
+            _firstElement = resetToFirstElement;
+        }
+
+      protected:
+        virtual bool CompactMode(const XMLElement &) { return _compactMode; }
+
+        /** Prints out the space before an element. You may override to change
+            the space and tabs used. A PrintSpace() override should call Print().
+        */
+        virtual void PrintSpace(int depth);
+        void Print(const char *format, ...);
+        void Write(const char *data, size_t size);
+        inline void Write(const char *data) { Write(data, strlen(data)); }
+        void Putc(char ch);
+
+        void SealElementIfJustOpened();
+        bool _elementJustOpened;
+        DynArray<const char *, 10> _stack;
+
+      private:
+        void PrintString(const char *, bool restrictedEntitySet); // prints out, after detecting entities.
+
+        bool _firstElement;
+        FILE *_fp;
+        int _depth;
+        int _textDepth;
+        bool _processEntities;
+        bool _compactMode;
+
+        enum
+        {
+            ENTITY_RANGE = 64,
+            BUF_SIZE = 200
+        };
+        bool _entityFlag[ENTITY_RANGE];
+        bool _restrictedEntityFlag[ENTITY_RANGE];
+
+        DynArray<char, 20> _buffer;
+
+        // Prohibit cloning, intentionally not implemented
+        XMLPrinter(const XMLPrinter &);
+        XMLPrinter &operator=(const XMLPrinter &);
+    };
+
+} // namespace tinyxml2
 
 #if defined(_MSC_VER)
-#   pragma warning(pop)
+#    pragma warning(pop)
 #endif
 
 #endif // TINYXML2_INCLUDED

--- a/samples/mqtt_pub_sub/main.cpp
+++ b/samples/mqtt_pub_sub/main.cpp
@@ -1,0 +1,384 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#include <aws/crt/Api.h>
+#include <aws/crt/StlAllocator.h>
+
+#include <aws/iot/MqttClient.h>
+
+#include <algorithm>
+#include <aws/crt/UUID.h>
+#include <condition_variable>
+#include <iostream>
+#include <mutex>
+
+using namespace Aws::Crt;
+
+static void s_printHelp()
+{
+    fprintf(stdout, "Usage:\n");
+    fprintf(
+        stdout,
+        "aws-crt-cpp-mqtt-pub-sub --endpoint <endpoint> --cert <path to cert>"
+        " --key <path to key> --topic --ca_file <optional: path to custom ca>"
+        " --use_websocket --signing_region <region> --proxy_host <host> --proxy_port <port>\n\n");
+    fprintf(stdout, "endpoint: the endpoint of the mqtt server not including a port\n");
+    fprintf(
+        stdout,
+        "cert: path to your client certificate in PEM format. If this is not set you must specify use_websocket\n");
+    fprintf(stdout, "key: path to your key in PEM format. If this is not set you must specify use_websocket\n");
+    fprintf(stdout, "topic: topic to publish, subscribe to.\n");
+    fprintf(stdout, "client_id: client id to use (optional)\n");
+    fprintf(
+        stdout,
+        "ca_file: Optional, if the mqtt server uses a certificate that's not already"
+        " in your trust store, set this.\n");
+    fprintf(stdout, "\tIt's the path to a CA file in PEM format\n");
+    fprintf(stdout, "use_websocket: if specified, uses a websocket over https (optional)\n");
+    fprintf(
+        stdout,
+        "signing_region: used for websocket signer it should only be specific if websockets are used. (required for "
+        "websockets)\n");
+    fprintf(stdout, "proxy_host: if you want to use a proxy with websockets, specify the host here (optional).\n");
+    fprintf(
+        stdout, "proxy_port: defaults to 8080 is proxy_host is set. Set this to any value you'd like (optional).\n\n");
+}
+
+bool s_cmdOptionExists(char **begin, char **end, const String &option)
+{
+    return std::find(begin, end, option) != end;
+}
+
+char *s_getCmdOption(char **begin, char **end, const String &option)
+{
+    char **itr = std::find(begin, end, option);
+    if (itr != end && ++itr != end)
+    {
+        return *itr;
+    }
+    return 0;
+}
+
+int main(int argc, char *argv[])
+{
+
+    /************************ Setup the Lib ****************************/
+    /*
+     * Do the global initialization for the API.
+     */
+    ApiHandle apiHandle;
+
+    String endpoint;
+    String certificatePath;
+    String keyPath;
+    String caFile;
+    String topic;
+    String clientId(Aws::Crt::UUID().ToString());
+    String signingRegion;
+    String proxyHost;
+    uint16_t proxyPort(8080);
+
+    bool useWebSocket = false;
+
+    /*********************** Parse Arguments ***************************/
+    if (!(s_cmdOptionExists(argv, argv + argc, "--endpoint") && s_cmdOptionExists(argv, argv + argc, "--topic")))
+    {
+        s_printHelp();
+        return 0;
+    }
+
+    endpoint = s_getCmdOption(argv, argv + argc, "--endpoint");
+
+    if (s_cmdOptionExists(argv, argv + argc, "--key"))
+    {
+        keyPath = s_getCmdOption(argv, argv + argc, "--key");
+    }
+
+    if (s_cmdOptionExists(argv, argv + argc, "--cert"))
+    {
+        certificatePath = s_getCmdOption(argv, argv + argc, "--cert");
+    }
+
+    topic = s_getCmdOption(argv, argv + argc, "--topic");
+    if (s_cmdOptionExists(argv, argv + argc, "--ca_file"))
+    {
+        caFile = s_getCmdOption(argv, argv + argc, "--ca_file");
+    }
+    if (s_cmdOptionExists(argv, argv + argc, "--client_id"))
+    {
+        clientId = s_getCmdOption(argv, argv + argc, "--client_id");
+    }
+    if (s_cmdOptionExists(argv, argv + argc, "--use_websocket"))
+    {
+        if (!s_cmdOptionExists(argv, argv + argc, "--signing_region"))
+        {
+            s_printHelp();
+        }
+        useWebSocket = true;
+        signingRegion = s_getCmdOption(argv, argv + argc, "--signing_region");
+
+        if (s_cmdOptionExists(argv, argv + argc, "--proxy_host"))
+        {
+            proxyHost = s_getCmdOption(argv, argv + argc, "--proxy_host");
+        }
+
+        if (s_cmdOptionExists(argv, argv + argc, "--proxy_port"))
+        {
+            proxyPort = atoi(s_getCmdOption(argv, argv + argc, "--proxy_port"));
+        }
+    }
+
+    /********************** Now Setup an Mqtt Client ******************/
+    /*
+     * You need an event loop group to process IO events.
+     * If you only have a few connections, 1 thread is ideal
+     */
+    Io::EventLoopGroup eventLoopGroup(1);
+    if (!eventLoopGroup)
+    {
+        fprintf(
+            stderr, "Event Loop Group Creation failed with error %s\n", ErrorDebugString(eventLoopGroup.LastError()));
+        exit(-1);
+    }
+
+    Aws::Crt::Io::DefaultHostResolver defaultHostResolver(eventLoopGroup, 1, 5);
+    Io::ClientBootstrap bootstrap(eventLoopGroup, defaultHostResolver);
+
+    if (!bootstrap)
+    {
+        fprintf(stderr, "ClientBootstrap failed with error %s\n", ErrorDebugString(bootstrap.LastError()));
+        exit(-1);
+    }
+
+    Aws::Iot::MqttClientConnectionConfigBuilder builder;
+
+    if (!certificatePath.empty() && !keyPath.empty())
+    {
+        builder = Aws::Iot::MqttClientConnectionConfigBuilder(certificatePath.c_str(), keyPath.c_str());
+    }
+    else if (useWebSocket)
+    {
+        Aws::Iot::WebsocketConfig config(signingRegion, &bootstrap);
+
+        if (!proxyHost.empty())
+        {
+            Aws::Crt::Http::HttpClientConnectionProxyOptions proxyOptions;
+            proxyOptions.HostName = proxyHost;
+            proxyOptions.Port = proxyPort;
+            proxyOptions.AuthType = Aws::Crt::Http::AwsHttpProxyAuthenticationType::None;
+            config.ProxyOptions = std::move(proxyOptions);
+        }
+
+        builder = Aws::Iot::MqttClientConnectionConfigBuilder(config);
+    }
+    else
+    {
+        s_printHelp();
+    }
+
+    if (!caFile.empty())
+    {
+        builder.WithCertificateAuthority(caFile.c_str());
+    }
+
+    builder.WithEndpoint(endpoint);
+
+    auto clientConfig = builder.Build();
+
+    if (!clientConfig)
+    {
+        fprintf(
+            stderr,
+            "Client Configuration initialization failed with error %s\n",
+            ErrorDebugString(clientConfig.LastError()));
+        exit(-1);
+    }
+
+    Aws::Iot::MqttClient mqttClient(bootstrap);
+    /*
+     * Since no exceptions are used, always check the bool operator
+     * when an error could have occurred.
+     */
+    if (!mqttClient)
+    {
+        fprintf(stderr, "MQTT Client Creation failed with error %s\n", ErrorDebugString(mqttClient.LastError()));
+        exit(-1);
+    }
+
+    /*
+     * Now create a connection object. Note: This type is move only
+     * and its underlying memory is managed by the client.
+     */
+    auto connection = mqttClient.NewConnection(clientConfig);
+
+    if (!connection)
+    {
+        fprintf(stderr, "MQTT Connection Creation failed with error %s\n", ErrorDebugString(mqttClient.LastError()));
+        exit(-1);
+    }
+
+    /*
+     * In a real world application you probably don't want to enforce synchronous behavior
+     * but this is a sample console application, so we'll just do that with a condition variable.
+     */
+    std::mutex mutex;
+    std::condition_variable conditionVariable;
+    bool connectionSucceeded = false;
+    bool connectionClosed = false;
+    bool connectionCompleted = false;
+
+    /*
+     * This will execute when an mqtt connect has completed or failed.
+     */
+    auto onConnectionCompleted = [&](Mqtt::MqttConnection &, int errorCode, Mqtt::ReturnCode returnCode, bool) {
+        if (errorCode)
+        {
+            fprintf(stdout, "Connection failed with error %s\n", ErrorDebugString(errorCode));
+            std::lock_guard<std::mutex> lockGuard(mutex);
+            connectionSucceeded = false;
+        }
+        else
+        {
+            fprintf(stdout, "Connection completed with return code %d\n", returnCode);
+            connectionSucceeded = true;
+        }
+        {
+            std::lock_guard<std::mutex> lockGuard(mutex);
+            connectionCompleted = true;
+        }
+        conditionVariable.notify_one();
+    };
+
+    auto onInterrupted = [&](Mqtt::MqttConnection &, int error) {
+        fprintf(stdout, "Connection interrupted with error %s\n", ErrorDebugString(error));
+    };
+
+    auto onResumed = [&](Mqtt::MqttConnection &, Mqtt::ReturnCode, bool) { fprintf(stdout, "Connection resumed\n"); };
+
+    /*
+     * Invoked when a disconnect message has completed.
+     */
+    auto onDisconnect = [&](Mqtt::MqttConnection &) {
+        {
+            fprintf(stdout, "Disconnect completed\n");
+            std::lock_guard<std::mutex> lockGuard(mutex);
+            connectionClosed = true;
+        }
+        conditionVariable.notify_one();
+    };
+
+    connection->OnConnectionCompleted = std::move(onConnectionCompleted);
+    connection->OnDisconnect = std::move(onDisconnect);
+    connection->OnConnectionInterrupted = std::move(onInterrupted);
+    connection->OnConnectionResumed = std::move(onResumed);
+
+    connection->SetOnMessageHandler([](Mqtt::MqttConnection &, const String &topic, const ByteBuf &payload) {
+        fprintf(stdout, "Generic Publish received on topic %s, payload:\n", topic.c_str());
+        fwrite(payload.buffer, 1, payload.len, stdout);
+        fprintf(stdout, "\n");
+    });
+
+    /*
+     * Actually perform the connect dance.
+     * This will use default ping behavior of 1 hour and 3 second timeouts.
+     * If you want different behavior, those arguments go into slots 3 & 4.
+     */
+    fprintf(stdout, "Connecting...\n");
+    if (!connection->Connect(clientId.c_str(), false, 1000))
+    {
+        fprintf(stderr, "MQTT Connection failed with error %s\n", ErrorDebugString(connection->LastError()));
+        exit(-1);
+    }
+
+    std::unique_lock<std::mutex> uniqueLock(mutex);
+    conditionVariable.wait(uniqueLock, [&]() { return connectionCompleted; });
+
+    if (connectionSucceeded)
+    {
+        /*
+         * This is invoked upon the receipt of a Publish on a subscribed topic.
+         */
+        auto onPublish = [&](Mqtt::MqttConnection &, const String &topic, const ByteBuf &byteBuf) {
+            fprintf(stdout, "Publish received on topic %s\n", topic.c_str());
+            fprintf(stdout, "\n Message:\n");
+            fwrite(byteBuf.buffer, 1, byteBuf.len, stdout);
+            fprintf(stdout, "\n");
+        };
+
+        /*
+         * Subscribe for incoming publish messages on topic.
+         */
+        auto onSubAck = [&](Mqtt::MqttConnection &, uint16_t packetId, const String &topic, Mqtt::QOS, int errorCode) {
+            if (packetId)
+            {
+                fprintf(stdout, "Subscribe on topic %s on packetId %d Succeeded\n", topic.c_str(), packetId);
+            }
+            else
+            {
+                fprintf(stdout, "Subscribe failed with error %s\n", aws_error_debug_str(errorCode));
+            }
+            conditionVariable.notify_one();
+        };
+
+        connection->Subscribe(topic.c_str(), AWS_MQTT_QOS_AT_LEAST_ONCE, onPublish, onSubAck);
+        conditionVariable.wait(uniqueLock);
+
+        while (true)
+        {
+            String input;
+            fprintf(
+                stdout,
+                "Enter the message you want to publish to topic %s and press enter. Enter 'exit' to exit this "
+                "program.\n",
+                topic.c_str());
+            std::getline(std::cin, input);
+
+            if (input == "exit")
+            {
+                break;
+            }
+
+            ByteBuf payload = ByteBufNewCopy(DefaultAllocator(), (const uint8_t *)input.data(), input.length());
+            ByteBuf *payloadPtr = &payload;
+
+            auto onPublishComplete = [payloadPtr](Mqtt::MqttConnection &, uint16_t packetId, int errorCode) {
+                aws_byte_buf_clean_up(payloadPtr);
+
+                if (packetId)
+                {
+                    fprintf(stdout, "Operation on packetId %d Succeeded\n", packetId);
+                }
+                else
+                {
+                    fprintf(stdout, "Operation failed with error %s\n", aws_error_debug_str(errorCode));
+                }
+            };
+            connection->Publish(topic.c_str(), AWS_MQTT_QOS_AT_LEAST_ONCE, false, payload, onPublishComplete);
+        }
+
+        /*
+         * Unsubscribe from the topic.
+         */
+        connection->Unsubscribe(
+            topic.c_str(), [&](Mqtt::MqttConnection &, uint16_t, int) { conditionVariable.notify_one(); });
+        conditionVariable.wait(uniqueLock);
+    }
+
+    /* Disconnect */
+    if (connection->Disconnect())
+    {
+        conditionVariable.wait(uniqueLock, [&]() { return connectionClosed; });
+    }
+    return 0;
+}

--- a/source/Api.cpp
+++ b/source/Api.cpp
@@ -27,6 +27,14 @@ namespace Aws
     {
         Allocator *g_allocator = Aws::Crt::DefaultAllocator();
 
+        static struct aws_log_subject_info s_crt_cpp_log_subject_infos[] = {
+            {AWS_LS_CRT_CPP_GENERAL, "CrtCppGeneral", "Subject for aws-crt-cpp logging that defies categorization."},
+            {AWS_LS_CRT_CPP_CANARY, "CrtCppCanary", "Subject for aws-crt-cpp canary logging."}};
+
+        static struct aws_log_subject_info_list s_crt_cpp_log_subject_list = {
+            s_crt_cpp_log_subject_infos,
+            AWS_ARRAY_SIZE(s_crt_cpp_log_subject_infos)};
+
         static void *s_cJSONAlloc(size_t sz) { return aws_mem_acquire(g_allocator, sz); }
 
         static void s_cJSONFree(void *ptr) { return aws_mem_release(g_allocator, ptr); }
@@ -109,6 +117,8 @@ namespace Aws
             }
 
             aws_logger_set(&logger);
+
+            aws_register_log_subject_info_list(&s_crt_cpp_log_subject_list);
         }
 
         const char *ErrorDebugString(int error) noexcept { return aws_error_debug_str(error); }

--- a/source/auth/Sigv4Signing.cpp
+++ b/source/auth/Sigv4Signing.cpp
@@ -114,16 +114,6 @@ namespace Aws
                 m_config.body_signing_type = static_cast<enum aws_body_signing_config_type>(bodysigningType);
             }
 
-            bool AwsSigningConfig::GetUseUnsignedPayloadHash() const noexcept
-            {
-                return m_config.use_unsigned_payload_for_hash;
-            }
-
-            void AwsSigningConfig::SetUseUnsignedPayloadHash(bool useUnsignedPayload) noexcept
-            {
-                m_config.use_unsigned_payload_for_hash = useUnsignedPayload;
-            }
-
             const std::shared_ptr<ICredentialsProvider> &AwsSigningConfig::GetCredentialsProvider() const noexcept
             {
                 return m_credentials;

--- a/source/auth/Sigv4Signing.cpp
+++ b/source/auth/Sigv4Signing.cpp
@@ -114,6 +114,16 @@ namespace Aws
                 m_config.body_signing_type = static_cast<enum aws_body_signing_config_type>(bodysigningType);
             }
 
+            bool AwsSigningConfig::GetUseUnsignedPayloadHash() const noexcept
+            {
+                return m_config.use_unsigned_payload_for_hash;
+            }
+
+            void AwsSigningConfig::SetUseUnsignedPayloadHash(bool useUnsignedPayload) noexcept
+            {
+                m_config.use_unsigned_payload_for_hash = useUnsignedPayload;
+            }
+
             const std::shared_ptr<ICredentialsProvider> &AwsSigningConfig::GetCredentialsProvider() const noexcept
             {
                 return m_credentials;

--- a/source/external/tinyxml2.cpp
+++ b/source/external/tinyxml2.cpp
@@ -1,0 +1,2925 @@
+/*
+Original code by Lee Thomason (www.grinninglizard.com)
+
+This software is provided 'as-is', without any express or implied
+warranty. In no event will the authors be held liable for any
+damages arising from the use of this software.
+
+Permission is granted to anyone to use this software for any
+purpose, including commercial applications, and to alter it and
+redistribute it freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must
+not claim that you wrote the original software. If you use this
+software in a product, an acknowledgment in the product documentation
+would be appreciated but is not required.
+
+2. Altered source versions must be plainly marked as such, and
+must not be misrepresented as being the original software.
+
+3. This notice may not be removed or altered from any source
+distribution.
+*/
+
+#include "tinyxml2.h"
+
+#include <new>		// yes, this one new style header, is in the Android SDK.
+#if defined(ANDROID_NDK) || defined(__BORLANDC__) || defined(__QNXNTO__)
+#   include <stddef.h>
+#   include <stdarg.h>
+#else
+#   include <cstddef>
+#   include <cstdarg>
+#endif
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1400 ) && (!defined WINCE)
+	// Microsoft Visual Studio, version 2005 and higher. Not WinCE.
+	/*int _snprintf_s(
+	   char *buffer,
+	   size_t sizeOfBuffer,
+	   size_t count,
+	   const char *format [,
+		  argument] ...
+	);*/
+	static inline int TIXML_SNPRINTF( char* buffer, size_t size, const char* format, ... )
+	{
+		va_list va;
+		va_start( va, format );
+		const int result = vsnprintf_s( buffer, size, _TRUNCATE, format, va );
+		va_end( va );
+		return result;
+	}
+
+	static inline int TIXML_VSNPRINTF( char* buffer, size_t size, const char* format, va_list va )
+	{
+		const int result = vsnprintf_s( buffer, size, _TRUNCATE, format, va );
+		return result;
+	}
+
+	#define TIXML_VSCPRINTF	_vscprintf
+	#define TIXML_SSCANF	sscanf_s
+#elif defined _MSC_VER
+	// Microsoft Visual Studio 2003 and earlier or WinCE
+	#define TIXML_SNPRINTF	_snprintf
+	#define TIXML_VSNPRINTF _vsnprintf
+	#define TIXML_SSCANF	sscanf
+	#if (_MSC_VER < 1400 ) && (!defined WINCE)
+		// Microsoft Visual Studio 2003 and not WinCE.
+		#define TIXML_VSCPRINTF   _vscprintf // VS2003's C runtime has this, but VC6 C runtime or WinCE SDK doesn't have.
+	#else
+		// Microsoft Visual Studio 2003 and earlier or WinCE.
+		static inline int TIXML_VSCPRINTF( const char* format, va_list va )
+		{
+			int len = 512;
+			for (;;) {
+				len = len*2;
+				char* str = new char[len]();
+				const int required = _vsnprintf(str, len, format, va);
+				delete[] str;
+				if ( required != -1 ) {
+					TIXMLASSERT( required >= 0 );
+					len = required;
+					break;
+				}
+			}
+			TIXMLASSERT( len >= 0 );
+			return len;
+		}
+	#endif
+#else
+	// GCC version 3 and higher
+	//#warning( "Using sn* functions." )
+	#define TIXML_SNPRINTF	snprintf
+	#define TIXML_VSNPRINTF	vsnprintf
+	static inline int TIXML_VSCPRINTF( const char* format, va_list va )
+	{
+		int len = vsnprintf( 0, 0, format, va );
+		TIXMLASSERT( len >= 0 );
+		return len;
+	}
+	#define TIXML_SSCANF   sscanf
+#endif
+
+
+static const char LINE_FEED				= static_cast<char>(0x0a);			// all line endings are normalized to LF
+static const char LF = LINE_FEED;
+static const char CARRIAGE_RETURN		= static_cast<char>(0x0d);			// CR gets filtered out
+static const char CR = CARRIAGE_RETURN;
+static const char SINGLE_QUOTE			= '\'';
+static const char DOUBLE_QUOTE			= '\"';
+
+// Bunch of unicode info at:
+//		http://www.unicode.org/faq/utf_bom.html
+//	ef bb bf (Microsoft "lead bytes") - designates UTF-8
+
+static const unsigned char TIXML_UTF_LEAD_0 = 0xefU;
+static const unsigned char TIXML_UTF_LEAD_1 = 0xbbU;
+static const unsigned char TIXML_UTF_LEAD_2 = 0xbfU;
+
+namespace tinyxml2
+{
+
+struct Entity {
+    const char* pattern;
+    int length;
+    char value;
+};
+
+static const int NUM_ENTITIES = 5;
+static const Entity entities[NUM_ENTITIES] = {
+    { "quot", 4,	DOUBLE_QUOTE },
+    { "amp", 3,		'&'  },
+    { "apos", 4,	SINGLE_QUOTE },
+    { "lt",	2, 		'<'	 },
+    { "gt",	2,		'>'	 }
+};
+
+
+StrPair::~StrPair()
+{
+    Reset();
+}
+
+
+void StrPair::TransferTo( StrPair* other )
+{
+    if ( this == other ) {
+        return;
+    }
+    // This in effect implements the assignment operator by "moving"
+    // ownership (as in auto_ptr).
+
+    TIXMLASSERT( other != 0 );
+    TIXMLASSERT( other->_flags == 0 );
+    TIXMLASSERT( other->_start == 0 );
+    TIXMLASSERT( other->_end == 0 );
+
+    other->Reset();
+
+    other->_flags = _flags;
+    other->_start = _start;
+    other->_end = _end;
+
+    _flags = 0;
+    _start = 0;
+    _end = 0;
+}
+
+
+void StrPair::Reset()
+{
+    if ( _flags & NEEDS_DELETE ) {
+        delete [] _start;
+    }
+    _flags = 0;
+    _start = 0;
+    _end = 0;
+}
+
+
+void StrPair::SetStr( const char* str, int flags )
+{
+    TIXMLASSERT( str );
+    Reset();
+    size_t len = strlen( str );
+    TIXMLASSERT( _start == 0 );
+    _start = new char[ len+1 ];
+    memcpy( _start, str, len+1 );
+    _end = _start + len;
+    _flags = flags | NEEDS_DELETE;
+}
+
+
+char* StrPair::ParseText( char* p, const char* endTag, int strFlags, int* curLineNumPtr )
+{
+    TIXMLASSERT( p );
+    TIXMLASSERT( endTag && *endTag );
+	TIXMLASSERT(curLineNumPtr);
+
+    char* start = p;
+    const char  endChar = *endTag;
+    size_t length = strlen( endTag );
+
+    // Inner loop of text parsing.
+    while ( *p ) {
+        if ( *p == endChar && strncmp( p, endTag, length ) == 0 ) {
+            Set( start, p, strFlags );
+            return p + length;
+        } else if (*p == '\n') {
+            ++(*curLineNumPtr);
+        }
+        ++p;
+        TIXMLASSERT( p );
+    }
+    return 0;
+}
+
+
+char* StrPair::ParseName( char* p )
+{
+    if ( !p || !(*p) ) {
+        return 0;
+    }
+    if ( !XMLUtil::IsNameStartChar( *p ) ) {
+        return 0;
+    }
+
+    char* const start = p;
+    ++p;
+    while ( *p && XMLUtil::IsNameChar( *p ) ) {
+        ++p;
+    }
+
+    Set( start, p, 0 );
+    return p;
+}
+
+
+void StrPair::CollapseWhitespace()
+{
+    // Adjusting _start would cause undefined behavior on delete[]
+    TIXMLASSERT( ( _flags & NEEDS_DELETE ) == 0 );
+    // Trim leading space.
+    _start = XMLUtil::SkipWhiteSpace( _start, 0 );
+
+    if ( *_start ) {
+        const char* p = _start;	// the read pointer
+        char* q = _start;	// the write pointer
+
+        while( *p ) {
+            if ( XMLUtil::IsWhiteSpace( *p )) {
+                p = XMLUtil::SkipWhiteSpace( p, 0 );
+                if ( *p == 0 ) {
+                    break;    // don't write to q; this trims the trailing space.
+                }
+                *q = ' ';
+                ++q;
+            }
+            *q = *p;
+            ++q;
+            ++p;
+        }
+        *q = 0;
+    }
+}
+
+
+const char* StrPair::GetStr()
+{
+    TIXMLASSERT( _start );
+    TIXMLASSERT( _end );
+    if ( _flags & NEEDS_FLUSH ) {
+        *_end = 0;
+        _flags ^= NEEDS_FLUSH;
+
+        if ( _flags ) {
+            const char* p = _start;	// the read pointer
+            char* q = _start;	// the write pointer
+
+            while( p < _end ) {
+                if ( (_flags & NEEDS_NEWLINE_NORMALIZATION) && *p == CR ) {
+                    // CR-LF pair becomes LF
+                    // CR alone becomes LF
+                    // LF-CR becomes LF
+                    if ( *(p+1) == LF ) {
+                        p += 2;
+                    }
+                    else {
+                        ++p;
+                    }
+                    *q = LF;
+                    ++q;
+                }
+                else if ( (_flags & NEEDS_NEWLINE_NORMALIZATION) && *p == LF ) {
+                    if ( *(p+1) == CR ) {
+                        p += 2;
+                    }
+                    else {
+                        ++p;
+                    }
+                    *q = LF;
+                    ++q;
+                }
+                else if ( (_flags & NEEDS_ENTITY_PROCESSING) && *p == '&' ) {
+                    // Entities handled by tinyXML2:
+                    // - special entities in the entity table [in/out]
+                    // - numeric character reference [in]
+                    //   &#20013; or &#x4e2d;
+
+                    if ( *(p+1) == '#' ) {
+                        const int buflen = 10;
+                        char buf[buflen] = { 0 };
+                        int len = 0;
+                        const char* adjusted = const_cast<char*>( XMLUtil::GetCharacterRef( p, buf, &len ) );
+                        if ( adjusted == 0 ) {
+                            *q = *p;
+                            ++p;
+                            ++q;
+                        }
+                        else {
+                            TIXMLASSERT( 0 <= len && len <= buflen );
+                            TIXMLASSERT( q + len <= adjusted );
+                            p = adjusted;
+                            memcpy( q, buf, len );
+                            q += len;
+                        }
+                    }
+                    else {
+                        bool entityFound = false;
+                        for( int i = 0; i < NUM_ENTITIES; ++i ) {
+                            const Entity& entity = entities[i];
+                            if ( strncmp( p + 1, entity.pattern, entity.length ) == 0
+                                    && *( p + entity.length + 1 ) == ';' ) {
+                                // Found an entity - convert.
+                                *q = entity.value;
+                                ++q;
+                                p += entity.length + 2;
+                                entityFound = true;
+                                break;
+                            }
+                        }
+                        if ( !entityFound ) {
+                            // fixme: treat as error?
+                            ++p;
+                            ++q;
+                        }
+                    }
+                }
+                else {
+                    *q = *p;
+                    ++p;
+                    ++q;
+                }
+            }
+            *q = 0;
+        }
+        // The loop below has plenty going on, and this
+        // is a less useful mode. Break it out.
+        if ( _flags & NEEDS_WHITESPACE_COLLAPSING ) {
+            CollapseWhitespace();
+        }
+        _flags = (_flags & NEEDS_DELETE);
+    }
+    TIXMLASSERT( _start );
+    return _start;
+}
+
+
+
+
+// --------- XMLUtil ----------- //
+
+const char* XMLUtil::writeBoolTrue  = "true";
+const char* XMLUtil::writeBoolFalse = "false";
+
+void XMLUtil::SetBoolSerialization(const char* writeTrue, const char* writeFalse)
+{
+	static const char* defTrue  = "true";
+	static const char* defFalse = "false";
+
+	writeBoolTrue = (writeTrue) ? writeTrue : defTrue;
+	writeBoolFalse = (writeFalse) ? writeFalse : defFalse;
+}
+
+
+const char* XMLUtil::ReadBOM( const char* p, bool* bom )
+{
+    TIXMLASSERT( p );
+    TIXMLASSERT( bom );
+    *bom = false;
+    const unsigned char* pu = reinterpret_cast<const unsigned char*>(p);
+    // Check for BOM:
+    if (    *(pu+0) == TIXML_UTF_LEAD_0
+            && *(pu+1) == TIXML_UTF_LEAD_1
+            && *(pu+2) == TIXML_UTF_LEAD_2 ) {
+        *bom = true;
+        p += 3;
+    }
+    TIXMLASSERT( p );
+    return p;
+}
+
+
+void XMLUtil::ConvertUTF32ToUTF8( unsigned long input, char* output, int* length )
+{
+    const unsigned long BYTE_MASK = 0xBF;
+    const unsigned long BYTE_MARK = 0x80;
+    const unsigned long FIRST_BYTE_MARK[7] = { 0x00, 0x00, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC };
+
+    if (input < 0x80) {
+        *length = 1;
+    }
+    else if ( input < 0x800 ) {
+        *length = 2;
+    }
+    else if ( input < 0x10000 ) {
+        *length = 3;
+    }
+    else if ( input < 0x200000 ) {
+        *length = 4;
+    }
+    else {
+        *length = 0;    // This code won't convert this correctly anyway.
+        return;
+    }
+
+    output += *length;
+
+    // Scary scary fall throughs are annotated with carefully designed comments
+    // to suppress compiler warnings such as -Wimplicit-fallthrough in gcc
+    switch (*length) {
+        case 4:
+            --output;
+            *output = static_cast<char>((input | BYTE_MARK) & BYTE_MASK);
+            input >>= 6;
+            //fall through
+        case 3:
+            --output;
+            *output = static_cast<char>((input | BYTE_MARK) & BYTE_MASK);
+            input >>= 6;
+            //fall through
+        case 2:
+            --output;
+            *output = static_cast<char>((input | BYTE_MARK) & BYTE_MASK);
+            input >>= 6;
+            //fall through
+        case 1:
+            --output;
+            *output = static_cast<char>(input | FIRST_BYTE_MARK[*length]);
+            break;
+        default:
+            TIXMLASSERT( false );
+    }
+}
+
+
+const char* XMLUtil::GetCharacterRef( const char* p, char* value, int* length )
+{
+    // Presume an entity, and pull it out.
+    *length = 0;
+
+    if ( *(p+1) == '#' && *(p+2) ) {
+        unsigned long ucs = 0;
+        TIXMLASSERT( sizeof( ucs ) >= 4 );
+        ptrdiff_t delta = 0;
+        unsigned mult = 1;
+        static const char SEMICOLON = ';';
+
+        if ( *(p+2) == 'x' ) {
+            // Hexadecimal.
+            const char* q = p+3;
+            if ( !(*q) ) {
+                return 0;
+            }
+
+            q = strchr( q, SEMICOLON );
+
+            if ( !q ) {
+                return 0;
+            }
+            TIXMLASSERT( *q == SEMICOLON );
+
+            delta = q-p;
+            --q;
+
+            while ( *q != 'x' ) {
+                unsigned int digit = 0;
+
+                if ( *q >= '0' && *q <= '9' ) {
+                    digit = *q - '0';
+                }
+                else if ( *q >= 'a' && *q <= 'f' ) {
+                    digit = *q - 'a' + 10;
+                }
+                else if ( *q >= 'A' && *q <= 'F' ) {
+                    digit = *q - 'A' + 10;
+                }
+                else {
+                    return 0;
+                }
+                TIXMLASSERT( digit < 16 );
+                TIXMLASSERT( digit == 0 || mult <= UINT_MAX / digit );
+                const unsigned int digitScaled = mult * digit;
+                TIXMLASSERT( ucs <= ULONG_MAX - digitScaled );
+                ucs += digitScaled;
+                TIXMLASSERT( mult <= UINT_MAX / 16 );
+                mult *= 16;
+                --q;
+            }
+        }
+        else {
+            // Decimal.
+            const char* q = p+2;
+            if ( !(*q) ) {
+                return 0;
+            }
+
+            q = strchr( q, SEMICOLON );
+
+            if ( !q ) {
+                return 0;
+            }
+            TIXMLASSERT( *q == SEMICOLON );
+
+            delta = q-p;
+            --q;
+
+            while ( *q != '#' ) {
+                if ( *q >= '0' && *q <= '9' ) {
+                    const unsigned int digit = *q - '0';
+                    TIXMLASSERT( digit < 10 );
+                    TIXMLASSERT( digit == 0 || mult <= UINT_MAX / digit );
+                    const unsigned int digitScaled = mult * digit;
+                    TIXMLASSERT( ucs <= ULONG_MAX - digitScaled );
+                    ucs += digitScaled;
+                }
+                else {
+                    return 0;
+                }
+                TIXMLASSERT( mult <= UINT_MAX / 10 );
+                mult *= 10;
+                --q;
+            }
+        }
+        // convert the UCS to UTF-8
+        ConvertUTF32ToUTF8( ucs, value, length );
+        return p + delta + 1;
+    }
+    return p+1;
+}
+
+
+void XMLUtil::ToStr( int v, char* buffer, int bufferSize )
+{
+    TIXML_SNPRINTF( buffer, bufferSize, "%d", v );
+}
+
+
+void XMLUtil::ToStr( unsigned v, char* buffer, int bufferSize )
+{
+    TIXML_SNPRINTF( buffer, bufferSize, "%u", v );
+}
+
+
+void XMLUtil::ToStr( bool v, char* buffer, int bufferSize )
+{
+    TIXML_SNPRINTF( buffer, bufferSize, "%s", v ? writeBoolTrue : writeBoolFalse);
+}
+
+/*
+	ToStr() of a number is a very tricky topic.
+	https://github.com/leethomason/tinyxml2/issues/106
+*/
+void XMLUtil::ToStr( float v, char* buffer, int bufferSize )
+{
+    TIXML_SNPRINTF( buffer, bufferSize, "%.8g", v );
+}
+
+
+void XMLUtil::ToStr( double v, char* buffer, int bufferSize )
+{
+    TIXML_SNPRINTF( buffer, bufferSize, "%.17g", v );
+}
+
+
+void XMLUtil::ToStr( int64_t v, char* buffer, int bufferSize )
+{
+	// horrible syntax trick to make the compiler happy about %lld
+	TIXML_SNPRINTF(buffer, bufferSize, "%lld", static_cast<long long>(v));
+}
+
+void XMLUtil::ToStr( uint64_t v, char* buffer, int bufferSize )
+{
+    // horrible syntax trick to make the compiler happy about %llu
+    TIXML_SNPRINTF(buffer, bufferSize, "%llu", (long long)v);
+}
+
+bool XMLUtil::ToInt( const char* str, int* value )
+{
+    if ( TIXML_SSCANF( str, "%d", value ) == 1 ) {
+        return true;
+    }
+    return false;
+}
+
+bool XMLUtil::ToUnsigned( const char* str, unsigned *value )
+{
+    if ( TIXML_SSCANF( str, "%u", value ) == 1 ) {
+        return true;
+    }
+    return false;
+}
+
+bool XMLUtil::ToBool( const char* str, bool* value )
+{
+    int ival = 0;
+    if ( ToInt( str, &ival )) {
+        *value = (ival==0) ? false : true;
+        return true;
+    }
+    static const char* TRUE[] = { "true", "True", "TRUE", 0 };
+    static const char* FALSE[] = { "false", "False", "FALSE", 0 };
+
+    for (int i = 0; TRUE[i]; ++i) {
+        if (StringEqual(str, TRUE[i])) {
+            *value = true;
+            return true;
+        }
+    }
+    for (int i = 0; FALSE[i]; ++i) {
+        if (StringEqual(str, FALSE[i])) {
+            *value = false;
+            return true;
+        }
+    }
+    return false;
+}
+
+
+bool XMLUtil::ToFloat( const char* str, float* value )
+{
+    if ( TIXML_SSCANF( str, "%f", value ) == 1 ) {
+        return true;
+    }
+    return false;
+}
+
+
+bool XMLUtil::ToDouble( const char* str, double* value )
+{
+    if ( TIXML_SSCANF( str, "%lf", value ) == 1 ) {
+        return true;
+    }
+    return false;
+}
+
+
+bool XMLUtil::ToInt64(const char* str, int64_t* value)
+{
+	long long v = 0;	// horrible syntax trick to make the compiler happy about %lld
+	if (TIXML_SSCANF(str, "%lld", &v) == 1) {
+		*value = static_cast<int64_t>(v);
+		return true;
+	}
+	return false;
+}
+
+
+bool XMLUtil::ToUnsigned64(const char* str, uint64_t* value) {
+    unsigned long long v = 0;	// horrible syntax trick to make the compiler happy about %llu
+    if(TIXML_SSCANF(str, "%llu", &v) == 1) {
+        *value = (uint64_t)v;
+        return true;
+    }
+    return false;
+}
+
+
+char* XMLDocument::Identify( char* p, XMLNode** node )
+{
+    TIXMLASSERT( node );
+    TIXMLASSERT( p );
+    char* const start = p;
+    int const startLine = _parseCurLineNum;
+    p = XMLUtil::SkipWhiteSpace( p, &_parseCurLineNum );
+    if( !*p ) {
+        *node = 0;
+        TIXMLASSERT( p );
+        return p;
+    }
+
+    // These strings define the matching patterns:
+    static const char* xmlHeader		= { "<?" };
+    static const char* commentHeader	= { "<!--" };
+    static const char* cdataHeader		= { "<![CDATA[" };
+    static const char* dtdHeader		= { "<!" };
+    static const char* elementHeader	= { "<" };	// and a header for everything else; check last.
+
+    static const int xmlHeaderLen		= 2;
+    static const int commentHeaderLen	= 4;
+    static const int cdataHeaderLen		= 9;
+    static const int dtdHeaderLen		= 2;
+    static const int elementHeaderLen	= 1;
+
+    TIXMLASSERT( sizeof( XMLComment ) == sizeof( XMLUnknown ) );		// use same memory pool
+    TIXMLASSERT( sizeof( XMLComment ) == sizeof( XMLDeclaration ) );	// use same memory pool
+    XMLNode* returnNode = 0;
+    if ( XMLUtil::StringEqual( p, xmlHeader, xmlHeaderLen ) ) {
+        returnNode = CreateUnlinkedNode<XMLDeclaration>( _commentPool );
+        returnNode->_parseLineNum = _parseCurLineNum;
+        p += xmlHeaderLen;
+    }
+    else if ( XMLUtil::StringEqual( p, commentHeader, commentHeaderLen ) ) {
+        returnNode = CreateUnlinkedNode<XMLComment>( _commentPool );
+        returnNode->_parseLineNum = _parseCurLineNum;
+        p += commentHeaderLen;
+    }
+    else if ( XMLUtil::StringEqual( p, cdataHeader, cdataHeaderLen ) ) {
+        XMLText* text = CreateUnlinkedNode<XMLText>( _textPool );
+        returnNode = text;
+        returnNode->_parseLineNum = _parseCurLineNum;
+        p += cdataHeaderLen;
+        text->SetCData( true );
+    }
+    else if ( XMLUtil::StringEqual( p, dtdHeader, dtdHeaderLen ) ) {
+        returnNode = CreateUnlinkedNode<XMLUnknown>( _commentPool );
+        returnNode->_parseLineNum = _parseCurLineNum;
+        p += dtdHeaderLen;
+    }
+    else if ( XMLUtil::StringEqual( p, elementHeader, elementHeaderLen ) ) {
+        returnNode =  CreateUnlinkedNode<XMLElement>( _elementPool );
+        returnNode->_parseLineNum = _parseCurLineNum;
+        p += elementHeaderLen;
+    }
+    else {
+        returnNode = CreateUnlinkedNode<XMLText>( _textPool );
+        returnNode->_parseLineNum = _parseCurLineNum; // Report line of first non-whitespace character
+        p = start;	// Back it up, all the text counts.
+        _parseCurLineNum = startLine;
+    }
+
+    TIXMLASSERT( returnNode );
+    TIXMLASSERT( p );
+    *node = returnNode;
+    return p;
+}
+
+
+bool XMLDocument::Accept( XMLVisitor* visitor ) const
+{
+    TIXMLASSERT( visitor );
+    if ( visitor->VisitEnter( *this ) ) {
+        for ( const XMLNode* node=FirstChild(); node; node=node->NextSibling() ) {
+            if ( !node->Accept( visitor ) ) {
+                break;
+            }
+        }
+    }
+    return visitor->VisitExit( *this );
+}
+
+
+// --------- XMLNode ----------- //
+
+XMLNode::XMLNode( XMLDocument* doc ) :
+    _document( doc ),
+    _parent( 0 ),
+    _value(),
+    _parseLineNum( 0 ),
+    _firstChild( 0 ), _lastChild( 0 ),
+    _prev( 0 ), _next( 0 ),
+	_userData( 0 ),
+    _memPool( 0 )
+{
+}
+
+
+XMLNode::~XMLNode()
+{
+    DeleteChildren();
+    if ( _parent ) {
+        _parent->Unlink( this );
+    }
+}
+
+const char* XMLNode::Value() const
+{
+    // Edge case: XMLDocuments don't have a Value. Return null.
+    if ( this->ToDocument() )
+        return 0;
+    return _value.GetStr();
+}
+
+void XMLNode::SetValue( const char* str, bool staticMem )
+{
+    if ( staticMem ) {
+        _value.SetInternedStr( str );
+    }
+    else {
+        _value.SetStr( str );
+    }
+}
+
+XMLNode* XMLNode::DeepClone(XMLDocument* target) const
+{
+	XMLNode* clone = this->ShallowClone(target);
+	if (!clone) return 0;
+
+	for (const XMLNode* child = this->FirstChild(); child; child = child->NextSibling()) {
+		XMLNode* childClone = child->DeepClone(target);
+		TIXMLASSERT(childClone);
+		clone->InsertEndChild(childClone);
+	}
+	return clone;
+}
+
+void XMLNode::DeleteChildren()
+{
+    while( _firstChild ) {
+        TIXMLASSERT( _lastChild );
+        DeleteChild( _firstChild );
+    }
+    _firstChild = _lastChild = 0;
+}
+
+
+void XMLNode::Unlink( XMLNode* child )
+{
+    TIXMLASSERT( child );
+    TIXMLASSERT( child->_document == _document );
+    TIXMLASSERT( child->_parent == this );
+    if ( child == _firstChild ) {
+        _firstChild = _firstChild->_next;
+    }
+    if ( child == _lastChild ) {
+        _lastChild = _lastChild->_prev;
+    }
+
+    if ( child->_prev ) {
+        child->_prev->_next = child->_next;
+    }
+    if ( child->_next ) {
+        child->_next->_prev = child->_prev;
+    }
+	child->_next = 0;
+	child->_prev = 0;
+	child->_parent = 0;
+}
+
+
+void XMLNode::DeleteChild( XMLNode* node )
+{
+    TIXMLASSERT( node );
+    TIXMLASSERT( node->_document == _document );
+    TIXMLASSERT( node->_parent == this );
+    Unlink( node );
+	TIXMLASSERT(node->_prev == 0);
+	TIXMLASSERT(node->_next == 0);
+	TIXMLASSERT(node->_parent == 0);
+    DeleteNode( node );
+}
+
+
+XMLNode* XMLNode::InsertEndChild( XMLNode* addThis )
+{
+    TIXMLASSERT( addThis );
+    if ( addThis->_document != _document ) {
+        TIXMLASSERT( false );
+        return 0;
+    }
+    InsertChildPreamble( addThis );
+
+    if ( _lastChild ) {
+        TIXMLASSERT( _firstChild );
+        TIXMLASSERT( _lastChild->_next == 0 );
+        _lastChild->_next = addThis;
+        addThis->_prev = _lastChild;
+        _lastChild = addThis;
+
+        addThis->_next = 0;
+    }
+    else {
+        TIXMLASSERT( _firstChild == 0 );
+        _firstChild = _lastChild = addThis;
+
+        addThis->_prev = 0;
+        addThis->_next = 0;
+    }
+    addThis->_parent = this;
+    return addThis;
+}
+
+
+XMLNode* XMLNode::InsertFirstChild( XMLNode* addThis )
+{
+    TIXMLASSERT( addThis );
+    if ( addThis->_document != _document ) {
+        TIXMLASSERT( false );
+        return 0;
+    }
+    InsertChildPreamble( addThis );
+
+    if ( _firstChild ) {
+        TIXMLASSERT( _lastChild );
+        TIXMLASSERT( _firstChild->_prev == 0 );
+
+        _firstChild->_prev = addThis;
+        addThis->_next = _firstChild;
+        _firstChild = addThis;
+
+        addThis->_prev = 0;
+    }
+    else {
+        TIXMLASSERT( _lastChild == 0 );
+        _firstChild = _lastChild = addThis;
+
+        addThis->_prev = 0;
+        addThis->_next = 0;
+    }
+    addThis->_parent = this;
+    return addThis;
+}
+
+
+XMLNode* XMLNode::InsertAfterChild( XMLNode* afterThis, XMLNode* addThis )
+{
+    TIXMLASSERT( addThis );
+    if ( addThis->_document != _document ) {
+        TIXMLASSERT( false );
+        return 0;
+    }
+
+    TIXMLASSERT( afterThis );
+
+    if ( afterThis->_parent != this ) {
+        TIXMLASSERT( false );
+        return 0;
+    }
+    if ( afterThis == addThis ) {
+        // Current state: BeforeThis -> AddThis -> OneAfterAddThis
+        // Now AddThis must disappear from it's location and then
+        // reappear between BeforeThis and OneAfterAddThis.
+        // So just leave it where it is.
+        return addThis;
+    }
+
+    if ( afterThis->_next == 0 ) {
+        // The last node or the only node.
+        return InsertEndChild( addThis );
+    }
+    InsertChildPreamble( addThis );
+    addThis->_prev = afterThis;
+    addThis->_next = afterThis->_next;
+    afterThis->_next->_prev = addThis;
+    afterThis->_next = addThis;
+    addThis->_parent = this;
+    return addThis;
+}
+
+
+
+
+const XMLElement* XMLNode::FirstChildElement( const char* name ) const
+{
+    for( const XMLNode* node = _firstChild; node; node = node->_next ) {
+        const XMLElement* element = node->ToElementWithName( name );
+        if ( element ) {
+            return element;
+        }
+    }
+    return 0;
+}
+
+
+const XMLElement* XMLNode::LastChildElement( const char* name ) const
+{
+    for( const XMLNode* node = _lastChild; node; node = node->_prev ) {
+        const XMLElement* element = node->ToElementWithName( name );
+        if ( element ) {
+            return element;
+        }
+    }
+    return 0;
+}
+
+
+const XMLElement* XMLNode::NextSiblingElement( const char* name ) const
+{
+    for( const XMLNode* node = _next; node; node = node->_next ) {
+        const XMLElement* element = node->ToElementWithName( name );
+        if ( element ) {
+            return element;
+        }
+    }
+    return 0;
+}
+
+
+const XMLElement* XMLNode::PreviousSiblingElement( const char* name ) const
+{
+    for( const XMLNode* node = _prev; node; node = node->_prev ) {
+        const XMLElement* element = node->ToElementWithName( name );
+        if ( element ) {
+            return element;
+        }
+    }
+    return 0;
+}
+
+
+char* XMLNode::ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr )
+{
+    // This is a recursive method, but thinking about it "at the current level"
+    // it is a pretty simple flat list:
+    //		<foo/>
+    //		<!-- comment -->
+    //
+    // With a special case:
+    //		<foo>
+    //		</foo>
+    //		<!-- comment -->
+    //
+    // Where the closing element (/foo) *must* be the next thing after the opening
+    // element, and the names must match. BUT the tricky bit is that the closing
+    // element will be read by the child.
+    //
+    // 'endTag' is the end tag for this node, it is returned by a call to a child.
+    // 'parentEnd' is the end tag for the parent, which is filled in and returned.
+
+	XMLDocument::DepthTracker tracker(_document);
+	if (_document->Error())
+		return 0;
+
+	while( p && *p ) {
+        XMLNode* node = 0;
+
+        p = _document->Identify( p, &node );
+        TIXMLASSERT( p );
+        if ( node == 0 ) {
+            break;
+        }
+
+       const int initialLineNum = node->_parseLineNum;
+
+        StrPair endTag;
+        p = node->ParseDeep( p, &endTag, curLineNumPtr );
+        if ( !p ) {
+            DeleteNode( node );
+            if ( !_document->Error() ) {
+                _document->SetError( XML_ERROR_PARSING, initialLineNum, 0);
+            }
+            break;
+        }
+
+        const XMLDeclaration* const decl = node->ToDeclaration();
+        if ( decl ) {
+            // Declarations are only allowed at document level
+            //
+            // Multiple declarations are allowed but all declarations
+            // must occur before anything else. 
+            //
+            // Optimized due to a security test case. If the first node is 
+            // a declaration, and the last node is a declaration, then only 
+            // declarations have so far been added.
+            bool wellLocated = false;
+
+            if (ToDocument()) {
+                if (FirstChild()) {
+                    wellLocated =
+                        FirstChild() &&
+                        FirstChild()->ToDeclaration() &&
+                        LastChild() &&
+                        LastChild()->ToDeclaration();
+                }
+                else {
+                    wellLocated = true;
+                }
+            }
+            if ( !wellLocated ) {
+                _document->SetError( XML_ERROR_PARSING_DECLARATION, initialLineNum, "XMLDeclaration value=%s", decl->Value());
+                DeleteNode( node );
+                break;
+            }
+        }
+
+        XMLElement* ele = node->ToElement();
+        if ( ele ) {
+            // We read the end tag. Return it to the parent.
+            if ( ele->ClosingType() == XMLElement::CLOSING ) {
+                if ( parentEndTag ) {
+                    ele->_value.TransferTo( parentEndTag );
+                }
+                node->_memPool->SetTracked();   // created and then immediately deleted.
+                DeleteNode( node );
+                return p;
+            }
+
+            // Handle an end tag returned to this level.
+            // And handle a bunch of annoying errors.
+            bool mismatch = false;
+            if ( endTag.Empty() ) {
+                if ( ele->ClosingType() == XMLElement::OPEN ) {
+                    mismatch = true;
+                }
+            }
+            else {
+                if ( ele->ClosingType() != XMLElement::OPEN ) {
+                    mismatch = true;
+                }
+                else if ( !XMLUtil::StringEqual( endTag.GetStr(), ele->Name() ) ) {
+                    mismatch = true;
+                }
+            }
+            if ( mismatch ) {
+                _document->SetError( XML_ERROR_MISMATCHED_ELEMENT, initialLineNum, "XMLElement name=%s", ele->Name());
+                DeleteNode( node );
+                break;
+            }
+        }
+        InsertEndChild( node );
+    }
+    return 0;
+}
+
+/*static*/ void XMLNode::DeleteNode( XMLNode* node )
+{
+    if ( node == 0 ) {
+        return;
+    }
+	TIXMLASSERT(node->_document);
+	if (!node->ToDocument()) {
+		node->_document->MarkInUse(node);
+	}
+
+    MemPool* pool = node->_memPool;
+    node->~XMLNode();
+    pool->Free( node );
+}
+
+void XMLNode::InsertChildPreamble( XMLNode* insertThis ) const
+{
+    TIXMLASSERT( insertThis );
+    TIXMLASSERT( insertThis->_document == _document );
+
+	if (insertThis->_parent) {
+        insertThis->_parent->Unlink( insertThis );
+	}
+	else {
+		insertThis->_document->MarkInUse(insertThis);
+        insertThis->_memPool->SetTracked();
+	}
+}
+
+const XMLElement* XMLNode::ToElementWithName( const char* name ) const
+{
+    const XMLElement* element = this->ToElement();
+    if ( element == 0 ) {
+        return 0;
+    }
+    if ( name == 0 ) {
+        return element;
+    }
+    if ( XMLUtil::StringEqual( element->Name(), name ) ) {
+       return element;
+    }
+    return 0;
+}
+
+// --------- XMLText ---------- //
+char* XMLText::ParseDeep( char* p, StrPair*, int* curLineNumPtr )
+{
+    if ( this->CData() ) {
+        p = _value.ParseText( p, "]]>", StrPair::NEEDS_NEWLINE_NORMALIZATION, curLineNumPtr );
+        if ( !p ) {
+            _document->SetError( XML_ERROR_PARSING_CDATA, _parseLineNum, 0 );
+        }
+        return p;
+    }
+    else {
+        int flags = _document->ProcessEntities() ? StrPair::TEXT_ELEMENT : StrPair::TEXT_ELEMENT_LEAVE_ENTITIES;
+        if ( _document->WhitespaceMode() == COLLAPSE_WHITESPACE ) {
+            flags |= StrPair::NEEDS_WHITESPACE_COLLAPSING;
+        }
+
+        p = _value.ParseText( p, "<", flags, curLineNumPtr );
+        if ( p && *p ) {
+            return p-1;
+        }
+        if ( !p ) {
+            _document->SetError( XML_ERROR_PARSING_TEXT, _parseLineNum, 0 );
+        }
+    }
+    return 0;
+}
+
+
+XMLNode* XMLText::ShallowClone( XMLDocument* doc ) const
+{
+    if ( !doc ) {
+        doc = _document;
+    }
+    XMLText* text = doc->NewText( Value() );	// fixme: this will always allocate memory. Intern?
+    text->SetCData( this->CData() );
+    return text;
+}
+
+
+bool XMLText::ShallowEqual( const XMLNode* compare ) const
+{
+    TIXMLASSERT( compare );
+    const XMLText* text = compare->ToText();
+    return ( text && XMLUtil::StringEqual( text->Value(), Value() ) );
+}
+
+
+bool XMLText::Accept( XMLVisitor* visitor ) const
+{
+    TIXMLASSERT( visitor );
+    return visitor->Visit( *this );
+}
+
+
+// --------- XMLComment ---------- //
+
+XMLComment::XMLComment( XMLDocument* doc ) : XMLNode( doc )
+{
+}
+
+
+XMLComment::~XMLComment()
+{
+}
+
+
+char* XMLComment::ParseDeep( char* p, StrPair*, int* curLineNumPtr )
+{
+    // Comment parses as text.
+    p = _value.ParseText( p, "-->", StrPair::COMMENT, curLineNumPtr );
+    if ( p == 0 ) {
+        _document->SetError( XML_ERROR_PARSING_COMMENT, _parseLineNum, 0 );
+    }
+    return p;
+}
+
+
+XMLNode* XMLComment::ShallowClone( XMLDocument* doc ) const
+{
+    if ( !doc ) {
+        doc = _document;
+    }
+    XMLComment* comment = doc->NewComment( Value() );	// fixme: this will always allocate memory. Intern?
+    return comment;
+}
+
+
+bool XMLComment::ShallowEqual( const XMLNode* compare ) const
+{
+    TIXMLASSERT( compare );
+    const XMLComment* comment = compare->ToComment();
+    return ( comment && XMLUtil::StringEqual( comment->Value(), Value() ));
+}
+
+
+bool XMLComment::Accept( XMLVisitor* visitor ) const
+{
+    TIXMLASSERT( visitor );
+    return visitor->Visit( *this );
+}
+
+
+// --------- XMLDeclaration ---------- //
+
+XMLDeclaration::XMLDeclaration( XMLDocument* doc ) : XMLNode( doc )
+{
+}
+
+
+XMLDeclaration::~XMLDeclaration()
+{
+    //printf( "~XMLDeclaration\n" );
+}
+
+
+char* XMLDeclaration::ParseDeep( char* p, StrPair*, int* curLineNumPtr )
+{
+    // Declaration parses as text.
+    p = _value.ParseText( p, "?>", StrPair::NEEDS_NEWLINE_NORMALIZATION, curLineNumPtr );
+    if ( p == 0 ) {
+        _document->SetError( XML_ERROR_PARSING_DECLARATION, _parseLineNum, 0 );
+    }
+    return p;
+}
+
+
+XMLNode* XMLDeclaration::ShallowClone( XMLDocument* doc ) const
+{
+    if ( !doc ) {
+        doc = _document;
+    }
+    XMLDeclaration* dec = doc->NewDeclaration( Value() );	// fixme: this will always allocate memory. Intern?
+    return dec;
+}
+
+
+bool XMLDeclaration::ShallowEqual( const XMLNode* compare ) const
+{
+    TIXMLASSERT( compare );
+    const XMLDeclaration* declaration = compare->ToDeclaration();
+    return ( declaration && XMLUtil::StringEqual( declaration->Value(), Value() ));
+}
+
+
+
+bool XMLDeclaration::Accept( XMLVisitor* visitor ) const
+{
+    TIXMLASSERT( visitor );
+    return visitor->Visit( *this );
+}
+
+// --------- XMLUnknown ---------- //
+
+XMLUnknown::XMLUnknown( XMLDocument* doc ) : XMLNode( doc )
+{
+}
+
+
+XMLUnknown::~XMLUnknown()
+{
+}
+
+
+char* XMLUnknown::ParseDeep( char* p, StrPair*, int* curLineNumPtr )
+{
+    // Unknown parses as text.
+    p = _value.ParseText( p, ">", StrPair::NEEDS_NEWLINE_NORMALIZATION, curLineNumPtr );
+    if ( !p ) {
+        _document->SetError( XML_ERROR_PARSING_UNKNOWN, _parseLineNum, 0 );
+    }
+    return p;
+}
+
+
+XMLNode* XMLUnknown::ShallowClone( XMLDocument* doc ) const
+{
+    if ( !doc ) {
+        doc = _document;
+    }
+    XMLUnknown* text = doc->NewUnknown( Value() );	// fixme: this will always allocate memory. Intern?
+    return text;
+}
+
+
+bool XMLUnknown::ShallowEqual( const XMLNode* compare ) const
+{
+    TIXMLASSERT( compare );
+    const XMLUnknown* unknown = compare->ToUnknown();
+    return ( unknown && XMLUtil::StringEqual( unknown->Value(), Value() ));
+}
+
+
+bool XMLUnknown::Accept( XMLVisitor* visitor ) const
+{
+    TIXMLASSERT( visitor );
+    return visitor->Visit( *this );
+}
+
+// --------- XMLAttribute ---------- //
+
+const char* XMLAttribute::Name() const
+{
+    return _name.GetStr();
+}
+
+const char* XMLAttribute::Value() const
+{
+    return _value.GetStr();
+}
+
+char* XMLAttribute::ParseDeep( char* p, bool processEntities, int* curLineNumPtr )
+{
+    // Parse using the name rules: bug fix, was using ParseText before
+    p = _name.ParseName( p );
+    if ( !p || !*p ) {
+        return 0;
+    }
+
+    // Skip white space before =
+    p = XMLUtil::SkipWhiteSpace( p, curLineNumPtr );
+    if ( *p != '=' ) {
+        return 0;
+    }
+
+    ++p;	// move up to opening quote
+    p = XMLUtil::SkipWhiteSpace( p, curLineNumPtr );
+    if ( *p != '\"' && *p != '\'' ) {
+        return 0;
+    }
+
+    const char endTag[2] = { *p, 0 };
+    ++p;	// move past opening quote
+
+    p = _value.ParseText( p, endTag, processEntities ? StrPair::ATTRIBUTE_VALUE : StrPair::ATTRIBUTE_VALUE_LEAVE_ENTITIES, curLineNumPtr );
+    return p;
+}
+
+
+void XMLAttribute::SetName( const char* n )
+{
+    _name.SetStr( n );
+}
+
+
+XMLError XMLAttribute::QueryIntValue( int* value ) const
+{
+    if ( XMLUtil::ToInt( Value(), value )) {
+        return XML_SUCCESS;
+    }
+    return XML_WRONG_ATTRIBUTE_TYPE;
+}
+
+
+XMLError XMLAttribute::QueryUnsignedValue( unsigned int* value ) const
+{
+    if ( XMLUtil::ToUnsigned( Value(), value )) {
+        return XML_SUCCESS;
+    }
+    return XML_WRONG_ATTRIBUTE_TYPE;
+}
+
+
+XMLError XMLAttribute::QueryInt64Value(int64_t* value) const
+{
+	if (XMLUtil::ToInt64(Value(), value)) {
+		return XML_SUCCESS;
+	}
+	return XML_WRONG_ATTRIBUTE_TYPE;
+}
+
+
+XMLError XMLAttribute::QueryUnsigned64Value(uint64_t* value) const
+{
+    if(XMLUtil::ToUnsigned64(Value(), value)) {
+        return XML_SUCCESS;
+    }
+    return XML_WRONG_ATTRIBUTE_TYPE;
+}
+
+
+XMLError XMLAttribute::QueryBoolValue( bool* value ) const
+{
+    if ( XMLUtil::ToBool( Value(), value )) {
+        return XML_SUCCESS;
+    }
+    return XML_WRONG_ATTRIBUTE_TYPE;
+}
+
+
+XMLError XMLAttribute::QueryFloatValue( float* value ) const
+{
+    if ( XMLUtil::ToFloat( Value(), value )) {
+        return XML_SUCCESS;
+    }
+    return XML_WRONG_ATTRIBUTE_TYPE;
+}
+
+
+XMLError XMLAttribute::QueryDoubleValue( double* value ) const
+{
+    if ( XMLUtil::ToDouble( Value(), value )) {
+        return XML_SUCCESS;
+    }
+    return XML_WRONG_ATTRIBUTE_TYPE;
+}
+
+
+void XMLAttribute::SetAttribute( const char* v )
+{
+    _value.SetStr( v );
+}
+
+
+void XMLAttribute::SetAttribute( int v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    _value.SetStr( buf );
+}
+
+
+void XMLAttribute::SetAttribute( unsigned v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    _value.SetStr( buf );
+}
+
+
+void XMLAttribute::SetAttribute(int64_t v)
+{
+	char buf[BUF_SIZE];
+	XMLUtil::ToStr(v, buf, BUF_SIZE);
+	_value.SetStr(buf);
+}
+
+void XMLAttribute::SetAttribute(uint64_t v)
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr(v, buf, BUF_SIZE);
+    _value.SetStr(buf);
+}
+
+
+void XMLAttribute::SetAttribute( bool v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    _value.SetStr( buf );
+}
+
+void XMLAttribute::SetAttribute( double v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    _value.SetStr( buf );
+}
+
+void XMLAttribute::SetAttribute( float v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    _value.SetStr( buf );
+}
+
+
+// --------- XMLElement ---------- //
+XMLElement::XMLElement( XMLDocument* doc ) : XMLNode( doc ),
+    _closingType( OPEN ),
+    _rootAttribute( 0 )
+{
+}
+
+
+XMLElement::~XMLElement()
+{
+    while( _rootAttribute ) {
+        XMLAttribute* next = _rootAttribute->_next;
+        DeleteAttribute( _rootAttribute );
+        _rootAttribute = next;
+    }
+}
+
+
+const XMLAttribute* XMLElement::FindAttribute( const char* name ) const
+{
+    for( XMLAttribute* a = _rootAttribute; a; a = a->_next ) {
+        if ( XMLUtil::StringEqual( a->Name(), name ) ) {
+            return a;
+        }
+    }
+    return 0;
+}
+
+
+const char* XMLElement::Attribute( const char* name, const char* value ) const
+{
+    const XMLAttribute* a = FindAttribute( name );
+    if ( !a ) {
+        return 0;
+    }
+    if ( !value || XMLUtil::StringEqual( a->Value(), value )) {
+        return a->Value();
+    }
+    return 0;
+}
+
+int XMLElement::IntAttribute(const char* name, int defaultValue) const
+{
+	int i = defaultValue;
+	QueryIntAttribute(name, &i);
+	return i;
+}
+
+unsigned XMLElement::UnsignedAttribute(const char* name, unsigned defaultValue) const
+{
+	unsigned i = defaultValue;
+	QueryUnsignedAttribute(name, &i);
+	return i;
+}
+
+int64_t XMLElement::Int64Attribute(const char* name, int64_t defaultValue) const
+{
+	int64_t i = defaultValue;
+	QueryInt64Attribute(name, &i);
+	return i;
+}
+
+uint64_t XMLElement::Unsigned64Attribute(const char* name, uint64_t defaultValue) const
+{
+	uint64_t i = defaultValue;
+	QueryUnsigned64Attribute(name, &i);
+	return i;
+}
+
+bool XMLElement::BoolAttribute(const char* name, bool defaultValue) const
+{
+	bool b = defaultValue;
+	QueryBoolAttribute(name, &b);
+	return b;
+}
+
+double XMLElement::DoubleAttribute(const char* name, double defaultValue) const
+{
+	double d = defaultValue;
+	QueryDoubleAttribute(name, &d);
+	return d;
+}
+
+float XMLElement::FloatAttribute(const char* name, float defaultValue) const
+{
+	float f = defaultValue;
+	QueryFloatAttribute(name, &f);
+	return f;
+}
+
+const char* XMLElement::GetText() const
+{
+    if ( FirstChild() && FirstChild()->ToText() ) {
+        return FirstChild()->Value();
+    }
+    return 0;
+}
+
+
+void	XMLElement::SetText( const char* inText )
+{
+	if ( FirstChild() && FirstChild()->ToText() )
+		FirstChild()->SetValue( inText );
+	else {
+		XMLText*	theText = GetDocument()->NewText( inText );
+		InsertFirstChild( theText );
+	}
+}
+
+
+void XMLElement::SetText( int v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    SetText( buf );
+}
+
+
+void XMLElement::SetText( unsigned v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    SetText( buf );
+}
+
+
+void XMLElement::SetText(int64_t v)
+{
+	char buf[BUF_SIZE];
+	XMLUtil::ToStr(v, buf, BUF_SIZE);
+	SetText(buf);
+}
+
+void XMLElement::SetText(uint64_t v) {
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr(v, buf, BUF_SIZE);
+    SetText(buf);
+}
+
+
+void XMLElement::SetText( bool v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    SetText( buf );
+}
+
+
+void XMLElement::SetText( float v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    SetText( buf );
+}
+
+
+void XMLElement::SetText( double v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    SetText( buf );
+}
+
+
+XMLError XMLElement::QueryIntText( int* ival ) const
+{
+    if ( FirstChild() && FirstChild()->ToText() ) {
+        const char* t = FirstChild()->Value();
+        if ( XMLUtil::ToInt( t, ival ) ) {
+            return XML_SUCCESS;
+        }
+        return XML_CAN_NOT_CONVERT_TEXT;
+    }
+    return XML_NO_TEXT_NODE;
+}
+
+
+XMLError XMLElement::QueryUnsignedText( unsigned* uval ) const
+{
+    if ( FirstChild() && FirstChild()->ToText() ) {
+        const char* t = FirstChild()->Value();
+        if ( XMLUtil::ToUnsigned( t, uval ) ) {
+            return XML_SUCCESS;
+        }
+        return XML_CAN_NOT_CONVERT_TEXT;
+    }
+    return XML_NO_TEXT_NODE;
+}
+
+
+XMLError XMLElement::QueryInt64Text(int64_t* ival) const
+{
+	if (FirstChild() && FirstChild()->ToText()) {
+		const char* t = FirstChild()->Value();
+		if (XMLUtil::ToInt64(t, ival)) {
+			return XML_SUCCESS;
+		}
+		return XML_CAN_NOT_CONVERT_TEXT;
+	}
+	return XML_NO_TEXT_NODE;
+}
+
+
+XMLError XMLElement::QueryUnsigned64Text(uint64_t* ival) const
+{
+    if(FirstChild() && FirstChild()->ToText()) {
+        const char* t = FirstChild()->Value();
+        if(XMLUtil::ToUnsigned64(t, ival)) {
+            return XML_SUCCESS;
+        }
+        return XML_CAN_NOT_CONVERT_TEXT;
+    }
+    return XML_NO_TEXT_NODE;
+}
+
+
+XMLError XMLElement::QueryBoolText( bool* bval ) const
+{
+    if ( FirstChild() && FirstChild()->ToText() ) {
+        const char* t = FirstChild()->Value();
+        if ( XMLUtil::ToBool( t, bval ) ) {
+            return XML_SUCCESS;
+        }
+        return XML_CAN_NOT_CONVERT_TEXT;
+    }
+    return XML_NO_TEXT_NODE;
+}
+
+
+XMLError XMLElement::QueryDoubleText( double* dval ) const
+{
+    if ( FirstChild() && FirstChild()->ToText() ) {
+        const char* t = FirstChild()->Value();
+        if ( XMLUtil::ToDouble( t, dval ) ) {
+            return XML_SUCCESS;
+        }
+        return XML_CAN_NOT_CONVERT_TEXT;
+    }
+    return XML_NO_TEXT_NODE;
+}
+
+
+XMLError XMLElement::QueryFloatText( float* fval ) const
+{
+    if ( FirstChild() && FirstChild()->ToText() ) {
+        const char* t = FirstChild()->Value();
+        if ( XMLUtil::ToFloat( t, fval ) ) {
+            return XML_SUCCESS;
+        }
+        return XML_CAN_NOT_CONVERT_TEXT;
+    }
+    return XML_NO_TEXT_NODE;
+}
+
+int XMLElement::IntText(int defaultValue) const
+{
+	int i = defaultValue;
+	QueryIntText(&i);
+	return i;
+}
+
+unsigned XMLElement::UnsignedText(unsigned defaultValue) const
+{
+	unsigned i = defaultValue;
+	QueryUnsignedText(&i);
+	return i;
+}
+
+int64_t XMLElement::Int64Text(int64_t defaultValue) const
+{
+	int64_t i = defaultValue;
+	QueryInt64Text(&i);
+	return i;
+}
+
+uint64_t XMLElement::Unsigned64Text(uint64_t defaultValue) const
+{
+	uint64_t i = defaultValue;
+	QueryUnsigned64Text(&i);
+	return i;
+}
+
+bool XMLElement::BoolText(bool defaultValue) const
+{
+	bool b = defaultValue;
+	QueryBoolText(&b);
+	return b;
+}
+
+double XMLElement::DoubleText(double defaultValue) const
+{
+	double d = defaultValue;
+	QueryDoubleText(&d);
+	return d;
+}
+
+float XMLElement::FloatText(float defaultValue) const
+{
+	float f = defaultValue;
+	QueryFloatText(&f);
+	return f;
+}
+
+
+XMLAttribute* XMLElement::FindOrCreateAttribute( const char* name )
+{
+    XMLAttribute* last = 0;
+    XMLAttribute* attrib = 0;
+    for( attrib = _rootAttribute;
+            attrib;
+            last = attrib, attrib = attrib->_next ) {
+        if ( XMLUtil::StringEqual( attrib->Name(), name ) ) {
+            break;
+        }
+    }
+    if ( !attrib ) {
+        attrib = CreateAttribute();
+        TIXMLASSERT( attrib );
+        if ( last ) {
+            TIXMLASSERT( last->_next == 0 );
+            last->_next = attrib;
+        }
+        else {
+            TIXMLASSERT( _rootAttribute == 0 );
+            _rootAttribute = attrib;
+        }
+        attrib->SetName( name );
+    }
+    return attrib;
+}
+
+
+void XMLElement::DeleteAttribute( const char* name )
+{
+    XMLAttribute* prev = 0;
+    for( XMLAttribute* a=_rootAttribute; a; a=a->_next ) {
+        if ( XMLUtil::StringEqual( name, a->Name() ) ) {
+            if ( prev ) {
+                prev->_next = a->_next;
+            }
+            else {
+                _rootAttribute = a->_next;
+            }
+            DeleteAttribute( a );
+            break;
+        }
+        prev = a;
+    }
+}
+
+
+char* XMLElement::ParseAttributes( char* p, int* curLineNumPtr )
+{
+    XMLAttribute* prevAttribute = 0;
+
+    // Read the attributes.
+    while( p ) {
+        p = XMLUtil::SkipWhiteSpace( p, curLineNumPtr );
+        if ( !(*p) ) {
+            _document->SetError( XML_ERROR_PARSING_ELEMENT, _parseLineNum, "XMLElement name=%s", Name() );
+            return 0;
+        }
+
+        // attribute.
+        if (XMLUtil::IsNameStartChar( *p ) ) {
+            XMLAttribute* attrib = CreateAttribute();
+            TIXMLASSERT( attrib );
+            attrib->_parseLineNum = _document->_parseCurLineNum;
+
+            const int attrLineNum = attrib->_parseLineNum;
+
+            p = attrib->ParseDeep( p, _document->ProcessEntities(), curLineNumPtr );
+            if ( !p || Attribute( attrib->Name() ) ) {
+                DeleteAttribute( attrib );
+                _document->SetError( XML_ERROR_PARSING_ATTRIBUTE, attrLineNum, "XMLElement name=%s", Name() );
+                return 0;
+            }
+            // There is a minor bug here: if the attribute in the source xml
+            // document is duplicated, it will not be detected and the
+            // attribute will be doubly added. However, tracking the 'prevAttribute'
+            // avoids re-scanning the attribute list. Preferring performance for
+            // now, may reconsider in the future.
+            if ( prevAttribute ) {
+                TIXMLASSERT( prevAttribute->_next == 0 );
+                prevAttribute->_next = attrib;
+            }
+            else {
+                TIXMLASSERT( _rootAttribute == 0 );
+                _rootAttribute = attrib;
+            }
+            prevAttribute = attrib;
+        }
+        // end of the tag
+        else if ( *p == '>' ) {
+            ++p;
+            break;
+        }
+        // end of the tag
+        else if ( *p == '/' && *(p+1) == '>' ) {
+            _closingType = CLOSED;
+            return p+2;	// done; sealed element.
+        }
+        else {
+            _document->SetError( XML_ERROR_PARSING_ELEMENT, _parseLineNum, 0 );
+            return 0;
+        }
+    }
+    return p;
+}
+
+void XMLElement::DeleteAttribute( XMLAttribute* attribute )
+{
+    if ( attribute == 0 ) {
+        return;
+    }
+    MemPool* pool = attribute->_memPool;
+    attribute->~XMLAttribute();
+    pool->Free( attribute );
+}
+
+XMLAttribute* XMLElement::CreateAttribute()
+{
+    TIXMLASSERT( sizeof( XMLAttribute ) == _document->_attributePool.ItemSize() );
+    XMLAttribute* attrib = new (_document->_attributePool.Alloc() ) XMLAttribute();
+    TIXMLASSERT( attrib );
+    attrib->_memPool = &_document->_attributePool;
+    attrib->_memPool->SetTracked();
+    return attrib;
+}
+
+//
+//	<ele></ele>
+//	<ele>foo<b>bar</b></ele>
+//
+char* XMLElement::ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr )
+{
+    // Read the element name.
+    p = XMLUtil::SkipWhiteSpace( p, curLineNumPtr );
+
+    // The closing element is the </element> form. It is
+    // parsed just like a regular element then deleted from
+    // the DOM.
+    if ( *p == '/' ) {
+        _closingType = CLOSING;
+        ++p;
+    }
+
+    p = _value.ParseName( p );
+    if ( _value.Empty() ) {
+        return 0;
+    }
+
+    p = ParseAttributes( p, curLineNumPtr );
+    if ( !p || !*p || _closingType != OPEN ) {
+        return p;
+    }
+
+    p = XMLNode::ParseDeep( p, parentEndTag, curLineNumPtr );
+    return p;
+}
+
+
+
+XMLNode* XMLElement::ShallowClone( XMLDocument* doc ) const
+{
+    if ( !doc ) {
+        doc = _document;
+    }
+    XMLElement* element = doc->NewElement( Value() );					// fixme: this will always allocate memory. Intern?
+    for( const XMLAttribute* a=FirstAttribute(); a; a=a->Next() ) {
+        element->SetAttribute( a->Name(), a->Value() );					// fixme: this will always allocate memory. Intern?
+    }
+    return element;
+}
+
+
+bool XMLElement::ShallowEqual( const XMLNode* compare ) const
+{
+    TIXMLASSERT( compare );
+    const XMLElement* other = compare->ToElement();
+    if ( other && XMLUtil::StringEqual( other->Name(), Name() )) {
+
+        const XMLAttribute* a=FirstAttribute();
+        const XMLAttribute* b=other->FirstAttribute();
+
+        while ( a && b ) {
+            if ( !XMLUtil::StringEqual( a->Value(), b->Value() ) ) {
+                return false;
+            }
+            a = a->Next();
+            b = b->Next();
+        }
+        if ( a || b ) {
+            // different count
+            return false;
+        }
+        return true;
+    }
+    return false;
+}
+
+
+bool XMLElement::Accept( XMLVisitor* visitor ) const
+{
+    TIXMLASSERT( visitor );
+    if ( visitor->VisitEnter( *this, _rootAttribute ) ) {
+        for ( const XMLNode* node=FirstChild(); node; node=node->NextSibling() ) {
+            if ( !node->Accept( visitor ) ) {
+                break;
+            }
+        }
+    }
+    return visitor->VisitExit( *this );
+}
+
+
+// --------- XMLDocument ----------- //
+
+// Warning: List must match 'enum XMLError'
+const char* XMLDocument::_errorNames[XML_ERROR_COUNT] = {
+    "XML_SUCCESS",
+    "XML_NO_ATTRIBUTE",
+    "XML_WRONG_ATTRIBUTE_TYPE",
+    "XML_ERROR_FILE_NOT_FOUND",
+    "XML_ERROR_FILE_COULD_NOT_BE_OPENED",
+    "XML_ERROR_FILE_READ_ERROR",
+    "XML_ERROR_PARSING_ELEMENT",
+    "XML_ERROR_PARSING_ATTRIBUTE",
+    "XML_ERROR_PARSING_TEXT",
+    "XML_ERROR_PARSING_CDATA",
+    "XML_ERROR_PARSING_COMMENT",
+    "XML_ERROR_PARSING_DECLARATION",
+    "XML_ERROR_PARSING_UNKNOWN",
+    "XML_ERROR_EMPTY_DOCUMENT",
+    "XML_ERROR_MISMATCHED_ELEMENT",
+    "XML_ERROR_PARSING",
+    "XML_CAN_NOT_CONVERT_TEXT",
+    "XML_NO_TEXT_NODE",
+	"XML_ELEMENT_DEPTH_EXCEEDED"
+};
+
+
+XMLDocument::XMLDocument( bool processEntities, Whitespace whitespaceMode ) :
+    XMLNode( 0 ),
+    _writeBOM( false ),
+    _processEntities( processEntities ),
+    _errorID(XML_SUCCESS),
+    _whitespaceMode( whitespaceMode ),
+    _errorStr(),
+    _errorLineNum( 0 ),
+    _charBuffer( 0 ),
+    _parseCurLineNum( 0 ),
+	_parsingDepth(0),
+    _unlinked(),
+    _elementPool(),
+    _attributePool(),
+    _textPool(),
+    _commentPool()
+{
+    // avoid VC++ C4355 warning about 'this' in initializer list (C4355 is off by default in VS2012+)
+    _document = this;
+}
+
+
+XMLDocument::~XMLDocument()
+{
+    Clear();
+}
+
+
+void XMLDocument::MarkInUse(XMLNode* node)
+{
+	TIXMLASSERT(node);
+	TIXMLASSERT(node->_parent == 0);
+
+	for (int i = 0; i < _unlinked.Size(); ++i) {
+		if (node == _unlinked[i]) {
+			_unlinked.SwapRemove(i);
+			break;
+		}
+	}
+}
+
+void XMLDocument::Clear()
+{
+    DeleteChildren();
+	while( _unlinked.Size()) {
+		DeleteNode(_unlinked[0]);	// Will remove from _unlinked as part of delete.
+	}
+
+#ifdef TINYXML2_DEBUG
+    const bool hadError = Error();
+#endif
+    ClearError();
+
+    delete [] _charBuffer;
+    _charBuffer = 0;
+	_parsingDepth = 0;
+
+#if 0
+    _textPool.Trace( "text" );
+    _elementPool.Trace( "element" );
+    _commentPool.Trace( "comment" );
+    _attributePool.Trace( "attribute" );
+#endif
+
+#ifdef TINYXML2_DEBUG
+    if ( !hadError ) {
+        TIXMLASSERT( _elementPool.CurrentAllocs()   == _elementPool.Untracked() );
+        TIXMLASSERT( _attributePool.CurrentAllocs() == _attributePool.Untracked() );
+        TIXMLASSERT( _textPool.CurrentAllocs()      == _textPool.Untracked() );
+        TIXMLASSERT( _commentPool.CurrentAllocs()   == _commentPool.Untracked() );
+    }
+#endif
+}
+
+
+void XMLDocument::DeepCopy(XMLDocument* target) const
+{
+	TIXMLASSERT(target);
+    if (target == this) {
+        return; // technically success - a no-op.
+    }
+
+	target->Clear();
+	for (const XMLNode* node = this->FirstChild(); node; node = node->NextSibling()) {
+		target->InsertEndChild(node->DeepClone(target));
+	}
+}
+
+XMLElement* XMLDocument::NewElement( const char* name )
+{
+    XMLElement* ele = CreateUnlinkedNode<XMLElement>( _elementPool );
+    ele->SetName( name );
+    return ele;
+}
+
+
+XMLComment* XMLDocument::NewComment( const char* str )
+{
+    XMLComment* comment = CreateUnlinkedNode<XMLComment>( _commentPool );
+    comment->SetValue( str );
+    return comment;
+}
+
+
+XMLText* XMLDocument::NewText( const char* str )
+{
+    XMLText* text = CreateUnlinkedNode<XMLText>( _textPool );
+    text->SetValue( str );
+    return text;
+}
+
+
+XMLDeclaration* XMLDocument::NewDeclaration( const char* str )
+{
+    XMLDeclaration* dec = CreateUnlinkedNode<XMLDeclaration>( _commentPool );
+    dec->SetValue( str ? str : "xml version=\"1.0\" encoding=\"UTF-8\"" );
+    return dec;
+}
+
+
+XMLUnknown* XMLDocument::NewUnknown( const char* str )
+{
+    XMLUnknown* unk = CreateUnlinkedNode<XMLUnknown>( _commentPool );
+    unk->SetValue( str );
+    return unk;
+}
+
+static FILE* callfopen( const char* filepath, const char* mode )
+{
+    TIXMLASSERT( filepath );
+    TIXMLASSERT( mode );
+#if defined(_MSC_VER) && (_MSC_VER >= 1400 ) && (!defined WINCE)
+    FILE* fp = 0;
+    const errno_t err = fopen_s( &fp, filepath, mode );
+    if ( err ) {
+        return 0;
+    }
+#else
+    FILE* fp = fopen( filepath, mode );
+#endif
+    return fp;
+}
+
+void XMLDocument::DeleteNode( XMLNode* node )	{
+    TIXMLASSERT( node );
+    TIXMLASSERT(node->_document == this );
+    if (node->_parent) {
+        node->_parent->DeleteChild( node );
+    }
+    else {
+        // Isn't in the tree.
+        // Use the parent delete.
+        // Also, we need to mark it tracked: we 'know'
+        // it was never used.
+        node->_memPool->SetTracked();
+        // Call the static XMLNode version:
+        XMLNode::DeleteNode(node);
+    }
+}
+
+
+XMLError XMLDocument::LoadFile( const char* filename )
+{
+    if ( !filename ) {
+        TIXMLASSERT( false );
+        SetError( XML_ERROR_FILE_COULD_NOT_BE_OPENED, 0, "filename=<null>" );
+        return _errorID;
+    }
+
+    Clear();
+    FILE* fp = callfopen( filename, "rb" );
+    if ( !fp ) {
+        SetError( XML_ERROR_FILE_NOT_FOUND, 0, "filename=%s", filename );
+        return _errorID;
+    }
+    LoadFile( fp );
+    fclose( fp );
+    return _errorID;
+}
+
+// This is likely overengineered template art to have a check that unsigned long value incremented
+// by one still fits into size_t. If size_t type is larger than unsigned long type
+// (x86_64-w64-mingw32 target) then the check is redundant and gcc and clang emit
+// -Wtype-limits warning. This piece makes the compiler select code with a check when a check
+// is useful and code with no check when a check is redundant depending on how size_t and unsigned long
+// types sizes relate to each other.
+template
+<bool = (sizeof(unsigned long) >= sizeof(size_t))>
+struct LongFitsIntoSizeTMinusOne {
+    static bool Fits( unsigned long value )
+    {
+        return value < static_cast<size_t>(-1);
+    }
+};
+
+template <>
+struct LongFitsIntoSizeTMinusOne<false> {
+    static bool Fits( unsigned long )
+    {
+        return true;
+    }
+};
+
+XMLError XMLDocument::LoadFile( FILE* fp )
+{
+    Clear();
+
+    fseek( fp, 0, SEEK_SET );
+    if ( fgetc( fp ) == EOF && ferror( fp ) != 0 ) {
+        SetError( XML_ERROR_FILE_READ_ERROR, 0, 0 );
+        return _errorID;
+    }
+
+    fseek( fp, 0, SEEK_END );
+    const long filelength = ftell( fp );
+    fseek( fp, 0, SEEK_SET );
+    if ( filelength == -1L ) {
+        SetError( XML_ERROR_FILE_READ_ERROR, 0, 0 );
+        return _errorID;
+    }
+    TIXMLASSERT( filelength >= 0 );
+
+    if ( !LongFitsIntoSizeTMinusOne<>::Fits( filelength ) ) {
+        // Cannot handle files which won't fit in buffer together with null terminator
+        SetError( XML_ERROR_FILE_READ_ERROR, 0, 0 );
+        return _errorID;
+    }
+
+    if ( filelength == 0 ) {
+        SetError( XML_ERROR_EMPTY_DOCUMENT, 0, 0 );
+        return _errorID;
+    }
+
+    const size_t size = filelength;
+    TIXMLASSERT( _charBuffer == 0 );
+    _charBuffer = new char[size+1];
+    const size_t read = fread( _charBuffer, 1, size, fp );
+    if ( read != size ) {
+        SetError( XML_ERROR_FILE_READ_ERROR, 0, 0 );
+        return _errorID;
+    }
+
+    _charBuffer[size] = 0;
+
+    Parse();
+    return _errorID;
+}
+
+
+XMLError XMLDocument::SaveFile( const char* filename, bool compact )
+{
+    if ( !filename ) {
+        TIXMLASSERT( false );
+        SetError( XML_ERROR_FILE_COULD_NOT_BE_OPENED, 0, "filename=<null>" );
+        return _errorID;
+    }
+
+    FILE* fp = callfopen( filename, "w" );
+    if ( !fp ) {
+        SetError( XML_ERROR_FILE_COULD_NOT_BE_OPENED, 0, "filename=%s", filename );
+        return _errorID;
+    }
+    SaveFile(fp, compact);
+    fclose( fp );
+    return _errorID;
+}
+
+
+XMLError XMLDocument::SaveFile( FILE* fp, bool compact )
+{
+    // Clear any error from the last save, otherwise it will get reported
+    // for *this* call.
+    ClearError();
+    XMLPrinter stream( fp, compact );
+    Print( &stream );
+    return _errorID;
+}
+
+
+XMLError XMLDocument::Parse( const char* p, size_t len )
+{
+    Clear();
+
+    if ( len == 0 || !p || !*p ) {
+        SetError( XML_ERROR_EMPTY_DOCUMENT, 0, 0 );
+        return _errorID;
+    }
+    if ( len == static_cast<size_t>(-1) ) {
+        len = strlen( p );
+    }
+    TIXMLASSERT( _charBuffer == 0 );
+    _charBuffer = new char[ len+1 ];
+    memcpy( _charBuffer, p, len );
+    _charBuffer[len] = 0;
+
+    Parse();
+    if ( Error() ) {
+        // clean up now essentially dangling memory.
+        // and the parse fail can put objects in the
+        // pools that are dead and inaccessible.
+        DeleteChildren();
+        _elementPool.Clear();
+        _attributePool.Clear();
+        _textPool.Clear();
+        _commentPool.Clear();
+    }
+    return _errorID;
+}
+
+
+void XMLDocument::Print( XMLPrinter* streamer ) const
+{
+    if ( streamer ) {
+        Accept( streamer );
+    }
+    else {
+        XMLPrinter stdoutStreamer( stdout );
+        Accept( &stdoutStreamer );
+    }
+}
+
+
+void XMLDocument::SetError( XMLError error, int lineNum, const char* format, ... )
+{
+    TIXMLASSERT( error >= 0 && error < XML_ERROR_COUNT );
+    _errorID = error;
+    _errorLineNum = lineNum;
+	_errorStr.Reset();
+
+    const size_t BUFFER_SIZE = 1000;
+    char* buffer = new char[BUFFER_SIZE];
+
+    TIXMLASSERT(sizeof(error) <= sizeof(int));
+    TIXML_SNPRINTF(buffer, BUFFER_SIZE, "Error=%s ErrorID=%d (0x%x) Line number=%d", ErrorIDToName(error), int(error), int(error), lineNum);
+
+	if (format) {
+		size_t len = strlen(buffer);
+		TIXML_SNPRINTF(buffer + len, BUFFER_SIZE - len, ": ");
+		len = strlen(buffer);
+
+		va_list va;
+		va_start(va, format);
+		TIXML_VSNPRINTF(buffer + len, BUFFER_SIZE - len, format, va);
+		va_end(va);
+	}
+	_errorStr.SetStr(buffer);
+	delete[] buffer;
+}
+
+
+/*static*/ const char* XMLDocument::ErrorIDToName(XMLError errorID)
+{
+	TIXMLASSERT( errorID >= 0 && errorID < XML_ERROR_COUNT );
+    const char* errorName = _errorNames[errorID];
+    TIXMLASSERT( errorName && errorName[0] );
+    return errorName;
+}
+
+const char* XMLDocument::ErrorStr() const
+{
+	return _errorStr.Empty() ? "" : _errorStr.GetStr();
+}
+
+
+void XMLDocument::PrintError() const
+{
+    printf("%s\n", ErrorStr());
+}
+
+const char* XMLDocument::ErrorName() const
+{
+    return ErrorIDToName(_errorID);
+}
+
+void XMLDocument::Parse()
+{
+    TIXMLASSERT( NoChildren() ); // Clear() must have been called previously
+    TIXMLASSERT( _charBuffer );
+    _parseCurLineNum = 1;
+    _parseLineNum = 1;
+    char* p = _charBuffer;
+    p = XMLUtil::SkipWhiteSpace( p, &_parseCurLineNum );
+    p = const_cast<char*>( XMLUtil::ReadBOM( p, &_writeBOM ) );
+    if ( !*p ) {
+        SetError( XML_ERROR_EMPTY_DOCUMENT, 0, 0 );
+        return;
+    }
+    ParseDeep(p, 0, &_parseCurLineNum );
+}
+
+void XMLDocument::PushDepth()
+{
+	_parsingDepth++;
+	if (_parsingDepth == TINYXML2_MAX_ELEMENT_DEPTH) {
+		SetError(XML_ELEMENT_DEPTH_EXCEEDED, _parseCurLineNum, "Element nesting is too deep." );
+	}
+}
+
+void XMLDocument::PopDepth()
+{
+	TIXMLASSERT(_parsingDepth > 0);
+	--_parsingDepth;
+}
+
+XMLPrinter::XMLPrinter( FILE* file, bool compact, int depth ) :
+    _elementJustOpened( false ),
+    _stack(),
+    _firstElement( true ),
+    _fp( file ),
+    _depth( depth ),
+    _textDepth( -1 ),
+    _processEntities( true ),
+    _compactMode( compact ),
+    _buffer()
+{
+    for( int i=0; i<ENTITY_RANGE; ++i ) {
+        _entityFlag[i] = false;
+        _restrictedEntityFlag[i] = false;
+    }
+    for( int i=0; i<NUM_ENTITIES; ++i ) {
+        const char entityValue = entities[i].value;
+        const unsigned char flagIndex = static_cast<unsigned char>(entityValue);
+        TIXMLASSERT( flagIndex < ENTITY_RANGE );
+        _entityFlag[flagIndex] = true;
+    }
+    _restrictedEntityFlag[static_cast<unsigned char>('&')] = true;
+    _restrictedEntityFlag[static_cast<unsigned char>('<')] = true;
+    _restrictedEntityFlag[static_cast<unsigned char>('>')] = true;	// not required, but consistency is nice
+    _buffer.Push( 0 );
+}
+
+
+void XMLPrinter::Print( const char* format, ... )
+{
+    va_list     va;
+    va_start( va, format );
+
+    if ( _fp ) {
+        vfprintf( _fp, format, va );
+    }
+    else {
+        const int len = TIXML_VSCPRINTF( format, va );
+        // Close out and re-start the va-args
+        va_end( va );
+        TIXMLASSERT( len >= 0 );
+        va_start( va, format );
+        TIXMLASSERT( _buffer.Size() > 0 && _buffer[_buffer.Size() - 1] == 0 );
+        char* p = _buffer.PushArr( len ) - 1;	// back up over the null terminator.
+		TIXML_VSNPRINTF( p, len+1, format, va );
+    }
+    va_end( va );
+}
+
+
+void XMLPrinter::Write( const char* data, size_t size )
+{
+    if ( _fp ) {
+        fwrite ( data , sizeof(char), size, _fp);
+    }
+    else {
+        char* p = _buffer.PushArr( static_cast<int>(size) ) - 1;   // back up over the null terminator.
+        memcpy( p, data, size );
+        p[size] = 0;
+    }
+}
+
+
+void XMLPrinter::Putc( char ch )
+{
+    if ( _fp ) {
+        fputc ( ch, _fp);
+    }
+    else {
+        char* p = _buffer.PushArr( sizeof(char) ) - 1;   // back up over the null terminator.
+        p[0] = ch;
+        p[1] = 0;
+    }
+}
+
+
+void XMLPrinter::PrintSpace( int depth )
+{
+    for( int i=0; i<depth; ++i ) {
+        Write( "    " );
+    }
+}
+
+
+void XMLPrinter::PrintString( const char* p, bool restricted )
+{
+    // Look for runs of bytes between entities to print.
+    const char* q = p;
+
+    if ( _processEntities ) {
+        const bool* flag = restricted ? _restrictedEntityFlag : _entityFlag;
+        while ( *q ) {
+            TIXMLASSERT( p <= q );
+            // Remember, char is sometimes signed. (How many times has that bitten me?)
+            if ( *q > 0 && *q < ENTITY_RANGE ) {
+                // Check for entities. If one is found, flush
+                // the stream up until the entity, write the
+                // entity, and keep looking.
+                if ( flag[static_cast<unsigned char>(*q)] ) {
+                    while ( p < q ) {
+                        const size_t delta = q - p;
+                        const int toPrint = ( INT_MAX < delta ) ? INT_MAX : static_cast<int>(delta);
+                        Write( p, toPrint );
+                        p += toPrint;
+                    }
+                    bool entityPatternPrinted = false;
+                    for( int i=0; i<NUM_ENTITIES; ++i ) {
+                        if ( entities[i].value == *q ) {
+                            Putc( '&' );
+                            Write( entities[i].pattern, entities[i].length );
+                            Putc( ';' );
+                            entityPatternPrinted = true;
+                            break;
+                        }
+                    }
+                    if ( !entityPatternPrinted ) {
+                        // TIXMLASSERT( entityPatternPrinted ) causes gcc -Wunused-but-set-variable in release
+                        TIXMLASSERT( false );
+                    }
+                    ++p;
+                }
+            }
+            ++q;
+            TIXMLASSERT( p <= q );
+        }
+        // Flush the remaining string. This will be the entire
+        // string if an entity wasn't found.
+        if ( p < q ) {
+            const size_t delta = q - p;
+            const int toPrint = ( INT_MAX < delta ) ? INT_MAX : static_cast<int>(delta);
+            Write( p, toPrint );
+        }
+    }
+    else {
+        Write( p );
+    }
+}
+
+
+void XMLPrinter::PushHeader( bool writeBOM, bool writeDec )
+{
+    if ( writeBOM ) {
+        static const unsigned char bom[] = { TIXML_UTF_LEAD_0, TIXML_UTF_LEAD_1, TIXML_UTF_LEAD_2, 0 };
+        Write( reinterpret_cast< const char* >( bom ) );
+    }
+    if ( writeDec ) {
+        PushDeclaration( "xml version=\"1.0\"" );
+    }
+}
+
+
+void XMLPrinter::OpenElement( const char* name, bool compactMode )
+{
+    SealElementIfJustOpened();
+    _stack.Push( name );
+
+    if ( _textDepth < 0 && !_firstElement && !compactMode ) {
+        Putc( '\n' );
+    }
+    if ( !compactMode ) {
+        PrintSpace( _depth );
+    }
+
+    Write ( "<" );
+    Write ( name );
+
+    _elementJustOpened = true;
+    _firstElement = false;
+    ++_depth;
+}
+
+
+void XMLPrinter::PushAttribute( const char* name, const char* value )
+{
+    TIXMLASSERT( _elementJustOpened );
+    Putc ( ' ' );
+    Write( name );
+    Write( "=\"" );
+    PrintString( value, false );
+    Putc ( '\"' );
+}
+
+
+void XMLPrinter::PushAttribute( const char* name, int v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    PushAttribute( name, buf );
+}
+
+
+void XMLPrinter::PushAttribute( const char* name, unsigned v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    PushAttribute( name, buf );
+}
+
+
+void XMLPrinter::PushAttribute(const char* name, int64_t v)
+{
+	char buf[BUF_SIZE];
+	XMLUtil::ToStr(v, buf, BUF_SIZE);
+	PushAttribute(name, buf);
+}
+
+
+void XMLPrinter::PushAttribute(const char* name, uint64_t v)
+{
+	char buf[BUF_SIZE];
+	XMLUtil::ToStr(v, buf, BUF_SIZE);
+	PushAttribute(name, buf);
+}
+
+
+void XMLPrinter::PushAttribute( const char* name, bool v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    PushAttribute( name, buf );
+}
+
+
+void XMLPrinter::PushAttribute( const char* name, double v )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( v, buf, BUF_SIZE );
+    PushAttribute( name, buf );
+}
+
+
+void XMLPrinter::CloseElement( bool compactMode )
+{
+    --_depth;
+    const char* name = _stack.Pop();
+
+    if ( _elementJustOpened ) {
+        Write( "/>" );
+    }
+    else {
+        if ( _textDepth < 0 && !compactMode) {
+            Putc( '\n' );
+            PrintSpace( _depth );
+        }
+        Write ( "</" );
+        Write ( name );
+        Write ( ">" );
+    }
+
+    if ( _textDepth == _depth ) {
+        _textDepth = -1;
+    }
+    if ( _depth == 0 && !compactMode) {
+        Putc( '\n' );
+    }
+    _elementJustOpened = false;
+}
+
+
+void XMLPrinter::SealElementIfJustOpened()
+{
+    if ( !_elementJustOpened ) {
+        return;
+    }
+    _elementJustOpened = false;
+    Putc( '>' );
+}
+
+
+void XMLPrinter::PushText( const char* text, bool cdata )
+{
+    _textDepth = _depth-1;
+
+    SealElementIfJustOpened();
+    if ( cdata ) {
+        Write( "<![CDATA[" );
+        Write( text );
+        Write( "]]>" );
+    }
+    else {
+        PrintString( text, true );
+    }
+}
+
+
+void XMLPrinter::PushText( int64_t value )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( value, buf, BUF_SIZE );
+    PushText( buf, false );
+}
+
+
+void XMLPrinter::PushText( uint64_t value )
+{
+	char buf[BUF_SIZE];
+	XMLUtil::ToStr(value, buf, BUF_SIZE);
+	PushText(buf, false);
+}
+
+
+void XMLPrinter::PushText( int value )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( value, buf, BUF_SIZE );
+    PushText( buf, false );
+}
+
+
+void XMLPrinter::PushText( unsigned value )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( value, buf, BUF_SIZE );
+    PushText( buf, false );
+}
+
+
+void XMLPrinter::PushText( bool value )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( value, buf, BUF_SIZE );
+    PushText( buf, false );
+}
+
+
+void XMLPrinter::PushText( float value )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( value, buf, BUF_SIZE );
+    PushText( buf, false );
+}
+
+
+void XMLPrinter::PushText( double value )
+{
+    char buf[BUF_SIZE];
+    XMLUtil::ToStr( value, buf, BUF_SIZE );
+    PushText( buf, false );
+}
+
+
+void XMLPrinter::PushComment( const char* comment )
+{
+    SealElementIfJustOpened();
+    if ( _textDepth < 0 && !_firstElement && !_compactMode) {
+        Putc( '\n' );
+        PrintSpace( _depth );
+    }
+    _firstElement = false;
+
+    Write( "<!--" );
+    Write( comment );
+    Write( "-->" );
+}
+
+
+void XMLPrinter::PushDeclaration( const char* value )
+{
+    SealElementIfJustOpened();
+    if ( _textDepth < 0 && !_firstElement && !_compactMode) {
+        Putc( '\n' );
+        PrintSpace( _depth );
+    }
+    _firstElement = false;
+
+    Write( "<?" );
+    Write( value );
+    Write( "?>" );
+}
+
+
+void XMLPrinter::PushUnknown( const char* value )
+{
+    SealElementIfJustOpened();
+    if ( _textDepth < 0 && !_firstElement && !_compactMode) {
+        Putc( '\n' );
+        PrintSpace( _depth );
+    }
+    _firstElement = false;
+
+    Write( "<!" );
+    Write( value );
+    Putc( '>' );
+}
+
+
+bool XMLPrinter::VisitEnter( const XMLDocument& doc )
+{
+    _processEntities = doc.ProcessEntities();
+    if ( doc.HasBOM() ) {
+        PushHeader( true, false );
+    }
+    return true;
+}
+
+
+bool XMLPrinter::VisitEnter( const XMLElement& element, const XMLAttribute* attribute )
+{
+    const XMLElement* parentElem = 0;
+    if ( element.Parent() ) {
+        parentElem = element.Parent()->ToElement();
+    }
+    const bool compactMode = parentElem ? CompactMode( *parentElem ) : _compactMode;
+    OpenElement( element.Name(), compactMode );
+    while ( attribute ) {
+        PushAttribute( attribute->Name(), attribute->Value() );
+        attribute = attribute->Next();
+    }
+    return true;
+}
+
+
+bool XMLPrinter::VisitExit( const XMLElement& element )
+{
+    CloseElement( CompactMode(element) );
+    return true;
+}
+
+
+bool XMLPrinter::Visit( const XMLText& text )
+{
+    PushText( text.Value(), text.CData() );
+    return true;
+}
+
+
+bool XMLPrinter::Visit( const XMLComment& comment )
+{
+    PushComment( comment.Value() );
+    return true;
+}
+
+bool XMLPrinter::Visit( const XMLDeclaration& declaration )
+{
+    PushDeclaration( declaration.Value() );
+    return true;
+}
+
+
+bool XMLPrinter::Visit( const XMLUnknown& unknown )
+{
+    PushUnknown( unknown.Value() );
+    return true;
+}
+
+}   // namespace tinyxml2

--- a/source/external/tinyxml2.cpp
+++ b/source/external/tinyxml2.cpp
@@ -21,92 +21,98 @@ must not be misrepresented as being the original software.
 distribution.
 */
 
-#include "tinyxml2.h"
+/*
+    Changes:
+    * Altered include path for tinyxml2.h
+    * Ran clang-format on tinyxml2.h/tinyxml2.cpp
+*/
+#include "aws/crt/external/tinyxml2.h"
 
-#include <new>		// yes, this one new style header, is in the Android SDK.
+#include <new> // yes, this one new style header, is in the Android SDK.
 #if defined(ANDROID_NDK) || defined(__BORLANDC__) || defined(__QNXNTO__)
-#   include <stddef.h>
-#   include <stdarg.h>
+#    include <stdarg.h>
+#    include <stddef.h>
 #else
-#   include <cstddef>
-#   include <cstdarg>
+#    include <cstdarg>
+#    include <cstddef>
 #endif
 
-#if defined(_MSC_VER) && (_MSC_VER >= 1400 ) && (!defined WINCE)
-	// Microsoft Visual Studio, version 2005 and higher. Not WinCE.
-	/*int _snprintf_s(
-	   char *buffer,
-	   size_t sizeOfBuffer,
-	   size_t count,
-	   const char *format [,
-		  argument] ...
-	);*/
-	static inline int TIXML_SNPRINTF( char* buffer, size_t size, const char* format, ... )
-	{
-		va_list va;
-		va_start( va, format );
-		const int result = vsnprintf_s( buffer, size, _TRUNCATE, format, va );
-		va_end( va );
-		return result;
-	}
+#if defined(_MSC_VER) && (_MSC_VER >= 1400) && (!defined WINCE)
+// Microsoft Visual Studio, version 2005 and higher. Not WinCE.
+/*int _snprintf_s(
+   char *buffer,
+   size_t sizeOfBuffer,
+   size_t count,
+   const char *format [,
+      argument] ...
+);*/
+static inline int TIXML_SNPRINTF(char *buffer, size_t size, const char *format, ...)
+{
+    va_list va;
+    va_start(va, format);
+    const int result = vsnprintf_s(buffer, size, _TRUNCATE, format, va);
+    va_end(va);
+    return result;
+}
 
-	static inline int TIXML_VSNPRINTF( char* buffer, size_t size, const char* format, va_list va )
-	{
-		const int result = vsnprintf_s( buffer, size, _TRUNCATE, format, va );
-		return result;
-	}
+static inline int TIXML_VSNPRINTF(char *buffer, size_t size, const char *format, va_list va)
+{
+    const int result = vsnprintf_s(buffer, size, _TRUNCATE, format, va);
+    return result;
+}
 
-	#define TIXML_VSCPRINTF	_vscprintf
-	#define TIXML_SSCANF	sscanf_s
+#    define TIXML_VSCPRINTF _vscprintf
+#    define TIXML_SSCANF sscanf_s
 #elif defined _MSC_VER
-	// Microsoft Visual Studio 2003 and earlier or WinCE
-	#define TIXML_SNPRINTF	_snprintf
-	#define TIXML_VSNPRINTF _vsnprintf
-	#define TIXML_SSCANF	sscanf
-	#if (_MSC_VER < 1400 ) && (!defined WINCE)
-		// Microsoft Visual Studio 2003 and not WinCE.
-		#define TIXML_VSCPRINTF   _vscprintf // VS2003's C runtime has this, but VC6 C runtime or WinCE SDK doesn't have.
-	#else
-		// Microsoft Visual Studio 2003 and earlier or WinCE.
-		static inline int TIXML_VSCPRINTF( const char* format, va_list va )
-		{
-			int len = 512;
-			for (;;) {
-				len = len*2;
-				char* str = new char[len]();
-				const int required = _vsnprintf(str, len, format, va);
-				delete[] str;
-				if ( required != -1 ) {
-					TIXMLASSERT( required >= 0 );
-					len = required;
-					break;
-				}
-			}
-			TIXMLASSERT( len >= 0 );
-			return len;
-		}
-	#endif
+// Microsoft Visual Studio 2003 and earlier or WinCE
+#    define TIXML_SNPRINTF _snprintf
+#    define TIXML_VSNPRINTF _vsnprintf
+#    define TIXML_SSCANF sscanf
+#    if (_MSC_VER < 1400) && (!defined WINCE)
+// Microsoft Visual Studio 2003 and not WinCE.
+#        define TIXML_VSCPRINTF _vscprintf // VS2003's C runtime has this, but VC6 C runtime or WinCE SDK doesn't have.
+#    else
+// Microsoft Visual Studio 2003 and earlier or WinCE.
+static inline int TIXML_VSCPRINTF(const char *format, va_list va)
+{
+    int len = 512;
+    for (;;)
+    {
+        len = len * 2;
+        char *str = new char[len]();
+        const int required = _vsnprintf(str, len, format, va);
+        delete[] str;
+        if (required != -1)
+        {
+            TIXMLASSERT(required >= 0);
+            len = required;
+            break;
+        }
+    }
+    TIXMLASSERT(len >= 0);
+    return len;
+}
+#    endif
 #else
-	// GCC version 3 and higher
-	//#warning( "Using sn* functions." )
-	#define TIXML_SNPRINTF	snprintf
-	#define TIXML_VSNPRINTF	vsnprintf
-	static inline int TIXML_VSCPRINTF( const char* format, va_list va )
-	{
-		int len = vsnprintf( 0, 0, format, va );
-		TIXMLASSERT( len >= 0 );
-		return len;
-	}
-	#define TIXML_SSCANF   sscanf
+// GCC version 3 and higher
+//#warning( "Using sn* functions." )
+#    define TIXML_SNPRINTF snprintf
+#    define TIXML_VSNPRINTF vsnprintf
+static inline int TIXML_VSCPRINTF(const char *format, va_list va)
+{
+    int len = vsnprintf(0, 0, format, va);
+    TIXMLASSERT(len >= 0);
+    return len;
+}
+#    define TIXML_SSCANF sscanf
 #endif
 
-
-static const char LINE_FEED				= static_cast<char>(0x0a);			// all line endings are normalized to LF
+static const char LINE_FEED = static_cast<char>(0x0a); // all line endings are normalized to LF
 static const char LF = LINE_FEED;
-static const char CARRIAGE_RETURN		= static_cast<char>(0x0d);			// CR gets filtered out
+static const char CARRIAGE_RETURN = static_cast<char>(0x0d); // CR gets filtered out
 static const char CR = CARRIAGE_RETURN;
-static const char SINGLE_QUOTE			= '\'';
-static const char DOUBLE_QUOTE			= '\"';
+static const char SINGLE_QUOTE = '\'';
+static const char DOUBLE_QUOTE = '\"';
 
 // Bunch of unicode info at:
 //		http://www.unicode.org/faq/utf_bom.html
@@ -119,2016 +125,2056 @@ static const unsigned char TIXML_UTF_LEAD_2 = 0xbfU;
 namespace tinyxml2
 {
 
-struct Entity {
-    const char* pattern;
-    int length;
-    char value;
-};
+    struct Entity
+    {
+        const char *pattern;
+        int length;
+        char value;
+    };
 
-static const int NUM_ENTITIES = 5;
-static const Entity entities[NUM_ENTITIES] = {
-    { "quot", 4,	DOUBLE_QUOTE },
-    { "amp", 3,		'&'  },
-    { "apos", 4,	SINGLE_QUOTE },
-    { "lt",	2, 		'<'	 },
-    { "gt",	2,		'>'	 }
-};
+    static const int NUM_ENTITIES = 5;
+    static const Entity entities[NUM_ENTITIES] = {{"quot", 4, DOUBLE_QUOTE},
+                                                  {"amp", 3, '&'},
+                                                  {"apos", 4, SINGLE_QUOTE},
+                                                  {"lt", 2, '<'},
+                                                  {"gt", 2, '>'}};
 
+    StrPair::~StrPair() { Reset(); }
 
-StrPair::~StrPair()
-{
-    Reset();
-}
-
-
-void StrPair::TransferTo( StrPair* other )
-{
-    if ( this == other ) {
-        return;
-    }
-    // This in effect implements the assignment operator by "moving"
-    // ownership (as in auto_ptr).
-
-    TIXMLASSERT( other != 0 );
-    TIXMLASSERT( other->_flags == 0 );
-    TIXMLASSERT( other->_start == 0 );
-    TIXMLASSERT( other->_end == 0 );
-
-    other->Reset();
-
-    other->_flags = _flags;
-    other->_start = _start;
-    other->_end = _end;
-
-    _flags = 0;
-    _start = 0;
-    _end = 0;
-}
-
-
-void StrPair::Reset()
-{
-    if ( _flags & NEEDS_DELETE ) {
-        delete [] _start;
-    }
-    _flags = 0;
-    _start = 0;
-    _end = 0;
-}
-
-
-void StrPair::SetStr( const char* str, int flags )
-{
-    TIXMLASSERT( str );
-    Reset();
-    size_t len = strlen( str );
-    TIXMLASSERT( _start == 0 );
-    _start = new char[ len+1 ];
-    memcpy( _start, str, len+1 );
-    _end = _start + len;
-    _flags = flags | NEEDS_DELETE;
-}
-
-
-char* StrPair::ParseText( char* p, const char* endTag, int strFlags, int* curLineNumPtr )
-{
-    TIXMLASSERT( p );
-    TIXMLASSERT( endTag && *endTag );
-	TIXMLASSERT(curLineNumPtr);
-
-    char* start = p;
-    const char  endChar = *endTag;
-    size_t length = strlen( endTag );
-
-    // Inner loop of text parsing.
-    while ( *p ) {
-        if ( *p == endChar && strncmp( p, endTag, length ) == 0 ) {
-            Set( start, p, strFlags );
-            return p + length;
-        } else if (*p == '\n') {
-            ++(*curLineNumPtr);
+    void StrPair::TransferTo(StrPair *other)
+    {
+        if (this == other)
+        {
+            return;
         }
-        ++p;
-        TIXMLASSERT( p );
-    }
-    return 0;
-}
+        // This in effect implements the assignment operator by "moving"
+        // ownership (as in auto_ptr).
 
+        TIXMLASSERT(other != 0);
+        TIXMLASSERT(other->_flags == 0);
+        TIXMLASSERT(other->_start == 0);
+        TIXMLASSERT(other->_end == 0);
 
-char* StrPair::ParseName( char* p )
-{
-    if ( !p || !(*p) ) {
-        return 0;
-    }
-    if ( !XMLUtil::IsNameStartChar( *p ) ) {
-        return 0;
-    }
+        other->Reset();
 
-    char* const start = p;
-    ++p;
-    while ( *p && XMLUtil::IsNameChar( *p ) ) {
-        ++p;
+        other->_flags = _flags;
+        other->_start = _start;
+        other->_end = _end;
+
+        _flags = 0;
+        _start = 0;
+        _end = 0;
     }
 
-    Set( start, p, 0 );
-    return p;
-}
+    void StrPair::Reset()
+    {
+        if (_flags & NEEDS_DELETE)
+        {
+            delete[] _start;
+        }
+        _flags = 0;
+        _start = 0;
+        _end = 0;
+    }
 
+    void StrPair::SetStr(const char *str, int flags)
+    {
+        TIXMLASSERT(str);
+        Reset();
+        size_t len = strlen(str);
+        TIXMLASSERT(_start == 0);
+        _start = new char[len + 1];
+        memcpy(_start, str, len + 1);
+        _end = _start + len;
+        _flags = flags | NEEDS_DELETE;
+    }
 
-void StrPair::CollapseWhitespace()
-{
-    // Adjusting _start would cause undefined behavior on delete[]
-    TIXMLASSERT( ( _flags & NEEDS_DELETE ) == 0 );
-    // Trim leading space.
-    _start = XMLUtil::SkipWhiteSpace( _start, 0 );
+    char *StrPair::ParseText(char *p, const char *endTag, int strFlags, int *curLineNumPtr)
+    {
+        TIXMLASSERT(p);
+        TIXMLASSERT(endTag && *endTag);
+        TIXMLASSERT(curLineNumPtr);
 
-    if ( *_start ) {
-        const char* p = _start;	// the read pointer
-        char* q = _start;	// the write pointer
+        char *start = p;
+        const char endChar = *endTag;
+        size_t length = strlen(endTag);
 
-        while( *p ) {
-            if ( XMLUtil::IsWhiteSpace( *p )) {
-                p = XMLUtil::SkipWhiteSpace( p, 0 );
-                if ( *p == 0 ) {
-                    break;    // don't write to q; this trims the trailing space.
-                }
-                *q = ' ';
-                ++q;
+        // Inner loop of text parsing.
+        while (*p)
+        {
+            if (*p == endChar && strncmp(p, endTag, length) == 0)
+            {
+                Set(start, p, strFlags);
+                return p + length;
             }
-            *q = *p;
-            ++q;
+            else if (*p == '\n')
+            {
+                ++(*curLineNumPtr);
+            }
+            ++p;
+            TIXMLASSERT(p);
+        }
+        return 0;
+    }
+
+    char *StrPair::ParseName(char *p)
+    {
+        if (!p || !(*p))
+        {
+            return 0;
+        }
+        if (!XMLUtil::IsNameStartChar(*p))
+        {
+            return 0;
+        }
+
+        char *const start = p;
+        ++p;
+        while (*p && XMLUtil::IsNameChar(*p))
+        {
             ++p;
         }
-        *q = 0;
+
+        Set(start, p, 0);
+        return p;
     }
-}
 
+    void StrPair::CollapseWhitespace()
+    {
+        // Adjusting _start would cause undefined behavior on delete[]
+        TIXMLASSERT((_flags & NEEDS_DELETE) == 0);
+        // Trim leading space.
+        _start = XMLUtil::SkipWhiteSpace(_start, 0);
 
-const char* StrPair::GetStr()
-{
-    TIXMLASSERT( _start );
-    TIXMLASSERT( _end );
-    if ( _flags & NEEDS_FLUSH ) {
-        *_end = 0;
-        _flags ^= NEEDS_FLUSH;
+        if (*_start)
+        {
+            const char *p = _start; // the read pointer
+            char *q = _start;       // the write pointer
 
-        if ( _flags ) {
-            const char* p = _start;	// the read pointer
-            char* q = _start;	// the write pointer
-
-            while( p < _end ) {
-                if ( (_flags & NEEDS_NEWLINE_NORMALIZATION) && *p == CR ) {
-                    // CR-LF pair becomes LF
-                    // CR alone becomes LF
-                    // LF-CR becomes LF
-                    if ( *(p+1) == LF ) {
-                        p += 2;
+            while (*p)
+            {
+                if (XMLUtil::IsWhiteSpace(*p))
+                {
+                    p = XMLUtil::SkipWhiteSpace(p, 0);
+                    if (*p == 0)
+                    {
+                        break; // don't write to q; this trims the trailing space.
                     }
-                    else {
-                        ++p;
-                    }
-                    *q = LF;
+                    *q = ' ';
                     ++q;
                 }
-                else if ( (_flags & NEEDS_NEWLINE_NORMALIZATION) && *p == LF ) {
-                    if ( *(p+1) == CR ) {
-                        p += 2;
-                    }
-                    else {
-                        ++p;
-                    }
-                    *q = LF;
-                    ++q;
-                }
-                else if ( (_flags & NEEDS_ENTITY_PROCESSING) && *p == '&' ) {
-                    // Entities handled by tinyXML2:
-                    // - special entities in the entity table [in/out]
-                    // - numeric character reference [in]
-                    //   &#20013; or &#x4e2d;
-
-                    if ( *(p+1) == '#' ) {
-                        const int buflen = 10;
-                        char buf[buflen] = { 0 };
-                        int len = 0;
-                        const char* adjusted = const_cast<char*>( XMLUtil::GetCharacterRef( p, buf, &len ) );
-                        if ( adjusted == 0 ) {
-                            *q = *p;
-                            ++p;
-                            ++q;
-                        }
-                        else {
-                            TIXMLASSERT( 0 <= len && len <= buflen );
-                            TIXMLASSERT( q + len <= adjusted );
-                            p = adjusted;
-                            memcpy( q, buf, len );
-                            q += len;
-                        }
-                    }
-                    else {
-                        bool entityFound = false;
-                        for( int i = 0; i < NUM_ENTITIES; ++i ) {
-                            const Entity& entity = entities[i];
-                            if ( strncmp( p + 1, entity.pattern, entity.length ) == 0
-                                    && *( p + entity.length + 1 ) == ';' ) {
-                                // Found an entity - convert.
-                                *q = entity.value;
-                                ++q;
-                                p += entity.length + 2;
-                                entityFound = true;
-                                break;
-                            }
-                        }
-                        if ( !entityFound ) {
-                            // fixme: treat as error?
-                            ++p;
-                            ++q;
-                        }
-                    }
-                }
-                else {
-                    *q = *p;
-                    ++p;
-                    ++q;
-                }
+                *q = *p;
+                ++q;
+                ++p;
             }
             *q = 0;
         }
-        // The loop below has plenty going on, and this
-        // is a less useful mode. Break it out.
-        if ( _flags & NEEDS_WHITESPACE_COLLAPSING ) {
-            CollapseWhitespace();
+    }
+
+    const char *StrPair::GetStr()
+    {
+        TIXMLASSERT(_start);
+        TIXMLASSERT(_end);
+        if (_flags & NEEDS_FLUSH)
+        {
+            *_end = 0;
+            _flags ^= NEEDS_FLUSH;
+
+            if (_flags)
+            {
+                const char *p = _start; // the read pointer
+                char *q = _start;       // the write pointer
+
+                while (p < _end)
+                {
+                    if ((_flags & NEEDS_NEWLINE_NORMALIZATION) && *p == CR)
+                    {
+                        // CR-LF pair becomes LF
+                        // CR alone becomes LF
+                        // LF-CR becomes LF
+                        if (*(p + 1) == LF)
+                        {
+                            p += 2;
+                        }
+                        else
+                        {
+                            ++p;
+                        }
+                        *q = LF;
+                        ++q;
+                    }
+                    else if ((_flags & NEEDS_NEWLINE_NORMALIZATION) && *p == LF)
+                    {
+                        if (*(p + 1) == CR)
+                        {
+                            p += 2;
+                        }
+                        else
+                        {
+                            ++p;
+                        }
+                        *q = LF;
+                        ++q;
+                    }
+                    else if ((_flags & NEEDS_ENTITY_PROCESSING) && *p == '&')
+                    {
+                        // Entities handled by tinyXML2:
+                        // - special entities in the entity table [in/out]
+                        // - numeric character reference [in]
+                        //   &#20013; or &#x4e2d;
+
+                        if (*(p + 1) == '#')
+                        {
+                            const int buflen = 10;
+                            char buf[buflen] = {0};
+                            int len = 0;
+                            const char *adjusted = const_cast<char *>(XMLUtil::GetCharacterRef(p, buf, &len));
+                            if (adjusted == 0)
+                            {
+                                *q = *p;
+                                ++p;
+                                ++q;
+                            }
+                            else
+                            {
+                                TIXMLASSERT(0 <= len && len <= buflen);
+                                TIXMLASSERT(q + len <= adjusted);
+                                p = adjusted;
+                                memcpy(q, buf, len);
+                                q += len;
+                            }
+                        }
+                        else
+                        {
+                            bool entityFound = false;
+                            for (int i = 0; i < NUM_ENTITIES; ++i)
+                            {
+                                const Entity &entity = entities[i];
+                                if (strncmp(p + 1, entity.pattern, entity.length) == 0 &&
+                                    *(p + entity.length + 1) == ';')
+                                {
+                                    // Found an entity - convert.
+                                    *q = entity.value;
+                                    ++q;
+                                    p += entity.length + 2;
+                                    entityFound = true;
+                                    break;
+                                }
+                            }
+                            if (!entityFound)
+                            {
+                                // fixme: treat as error?
+                                ++p;
+                                ++q;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        *q = *p;
+                        ++p;
+                        ++q;
+                    }
+                }
+                *q = 0;
+            }
+            // The loop below has plenty going on, and this
+            // is a less useful mode. Break it out.
+            if (_flags & NEEDS_WHITESPACE_COLLAPSING)
+            {
+                CollapseWhitespace();
+            }
+            _flags = (_flags & NEEDS_DELETE);
         }
-        _flags = (_flags & NEEDS_DELETE);
-    }
-    TIXMLASSERT( _start );
-    return _start;
-}
-
-
-
-
-// --------- XMLUtil ----------- //
-
-const char* XMLUtil::writeBoolTrue  = "true";
-const char* XMLUtil::writeBoolFalse = "false";
-
-void XMLUtil::SetBoolSerialization(const char* writeTrue, const char* writeFalse)
-{
-	static const char* defTrue  = "true";
-	static const char* defFalse = "false";
-
-	writeBoolTrue = (writeTrue) ? writeTrue : defTrue;
-	writeBoolFalse = (writeFalse) ? writeFalse : defFalse;
-}
-
-
-const char* XMLUtil::ReadBOM( const char* p, bool* bom )
-{
-    TIXMLASSERT( p );
-    TIXMLASSERT( bom );
-    *bom = false;
-    const unsigned char* pu = reinterpret_cast<const unsigned char*>(p);
-    // Check for BOM:
-    if (    *(pu+0) == TIXML_UTF_LEAD_0
-            && *(pu+1) == TIXML_UTF_LEAD_1
-            && *(pu+2) == TIXML_UTF_LEAD_2 ) {
-        *bom = true;
-        p += 3;
-    }
-    TIXMLASSERT( p );
-    return p;
-}
-
-
-void XMLUtil::ConvertUTF32ToUTF8( unsigned long input, char* output, int* length )
-{
-    const unsigned long BYTE_MASK = 0xBF;
-    const unsigned long BYTE_MARK = 0x80;
-    const unsigned long FIRST_BYTE_MARK[7] = { 0x00, 0x00, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC };
-
-    if (input < 0x80) {
-        *length = 1;
-    }
-    else if ( input < 0x800 ) {
-        *length = 2;
-    }
-    else if ( input < 0x10000 ) {
-        *length = 3;
-    }
-    else if ( input < 0x200000 ) {
-        *length = 4;
-    }
-    else {
-        *length = 0;    // This code won't convert this correctly anyway.
-        return;
+        TIXMLASSERT(_start);
+        return _start;
     }
 
-    output += *length;
+    // --------- XMLUtil ----------- //
 
-    // Scary scary fall throughs are annotated with carefully designed comments
-    // to suppress compiler warnings such as -Wimplicit-fallthrough in gcc
-    switch (*length) {
-        case 4:
-            --output;
-            *output = static_cast<char>((input | BYTE_MARK) & BYTE_MASK);
-            input >>= 6;
-            //fall through
-        case 3:
-            --output;
-            *output = static_cast<char>((input | BYTE_MARK) & BYTE_MASK);
-            input >>= 6;
-            //fall through
-        case 2:
-            --output;
-            *output = static_cast<char>((input | BYTE_MARK) & BYTE_MASK);
-            input >>= 6;
-            //fall through
-        case 1:
-            --output;
-            *output = static_cast<char>(input | FIRST_BYTE_MARK[*length]);
-            break;
-        default:
-            TIXMLASSERT( false );
+    const char *XMLUtil::writeBoolTrue = "true";
+    const char *XMLUtil::writeBoolFalse = "false";
+
+    void XMLUtil::SetBoolSerialization(const char *writeTrue, const char *writeFalse)
+    {
+        static const char *defTrue = "true";
+        static const char *defFalse = "false";
+
+        writeBoolTrue = (writeTrue) ? writeTrue : defTrue;
+        writeBoolFalse = (writeFalse) ? writeFalse : defFalse;
     }
-}
 
-
-const char* XMLUtil::GetCharacterRef( const char* p, char* value, int* length )
-{
-    // Presume an entity, and pull it out.
-    *length = 0;
-
-    if ( *(p+1) == '#' && *(p+2) ) {
-        unsigned long ucs = 0;
-        TIXMLASSERT( sizeof( ucs ) >= 4 );
-        ptrdiff_t delta = 0;
-        unsigned mult = 1;
-        static const char SEMICOLON = ';';
-
-        if ( *(p+2) == 'x' ) {
-            // Hexadecimal.
-            const char* q = p+3;
-            if ( !(*q) ) {
-                return 0;
-            }
-
-            q = strchr( q, SEMICOLON );
-
-            if ( !q ) {
-                return 0;
-            }
-            TIXMLASSERT( *q == SEMICOLON );
-
-            delta = q-p;
-            --q;
-
-            while ( *q != 'x' ) {
-                unsigned int digit = 0;
-
-                if ( *q >= '0' && *q <= '9' ) {
-                    digit = *q - '0';
-                }
-                else if ( *q >= 'a' && *q <= 'f' ) {
-                    digit = *q - 'a' + 10;
-                }
-                else if ( *q >= 'A' && *q <= 'F' ) {
-                    digit = *q - 'A' + 10;
-                }
-                else {
-                    return 0;
-                }
-                TIXMLASSERT( digit < 16 );
-                TIXMLASSERT( digit == 0 || mult <= UINT_MAX / digit );
-                const unsigned int digitScaled = mult * digit;
-                TIXMLASSERT( ucs <= ULONG_MAX - digitScaled );
-                ucs += digitScaled;
-                TIXMLASSERT( mult <= UINT_MAX / 16 );
-                mult *= 16;
-                --q;
-            }
+    const char *XMLUtil::ReadBOM(const char *p, bool *bom)
+    {
+        TIXMLASSERT(p);
+        TIXMLASSERT(bom);
+        *bom = false;
+        const unsigned char *pu = reinterpret_cast<const unsigned char *>(p);
+        // Check for BOM:
+        if (*(pu + 0) == TIXML_UTF_LEAD_0 && *(pu + 1) == TIXML_UTF_LEAD_1 && *(pu + 2) == TIXML_UTF_LEAD_2)
+        {
+            *bom = true;
+            p += 3;
         }
-        else {
-            // Decimal.
-            const char* q = p+2;
-            if ( !(*q) ) {
-                return 0;
-            }
-
-            q = strchr( q, SEMICOLON );
-
-            if ( !q ) {
-                return 0;
-            }
-            TIXMLASSERT( *q == SEMICOLON );
-
-            delta = q-p;
-            --q;
-
-            while ( *q != '#' ) {
-                if ( *q >= '0' && *q <= '9' ) {
-                    const unsigned int digit = *q - '0';
-                    TIXMLASSERT( digit < 10 );
-                    TIXMLASSERT( digit == 0 || mult <= UINT_MAX / digit );
-                    const unsigned int digitScaled = mult * digit;
-                    TIXMLASSERT( ucs <= ULONG_MAX - digitScaled );
-                    ucs += digitScaled;
-                }
-                else {
-                    return 0;
-                }
-                TIXMLASSERT( mult <= UINT_MAX / 10 );
-                mult *= 10;
-                --q;
-            }
-        }
-        // convert the UCS to UTF-8
-        ConvertUTF32ToUTF8( ucs, value, length );
-        return p + delta + 1;
-    }
-    return p+1;
-}
-
-
-void XMLUtil::ToStr( int v, char* buffer, int bufferSize )
-{
-    TIXML_SNPRINTF( buffer, bufferSize, "%d", v );
-}
-
-
-void XMLUtil::ToStr( unsigned v, char* buffer, int bufferSize )
-{
-    TIXML_SNPRINTF( buffer, bufferSize, "%u", v );
-}
-
-
-void XMLUtil::ToStr( bool v, char* buffer, int bufferSize )
-{
-    TIXML_SNPRINTF( buffer, bufferSize, "%s", v ? writeBoolTrue : writeBoolFalse);
-}
-
-/*
-	ToStr() of a number is a very tricky topic.
-	https://github.com/leethomason/tinyxml2/issues/106
-*/
-void XMLUtil::ToStr( float v, char* buffer, int bufferSize )
-{
-    TIXML_SNPRINTF( buffer, bufferSize, "%.8g", v );
-}
-
-
-void XMLUtil::ToStr( double v, char* buffer, int bufferSize )
-{
-    TIXML_SNPRINTF( buffer, bufferSize, "%.17g", v );
-}
-
-
-void XMLUtil::ToStr( int64_t v, char* buffer, int bufferSize )
-{
-	// horrible syntax trick to make the compiler happy about %lld
-	TIXML_SNPRINTF(buffer, bufferSize, "%lld", static_cast<long long>(v));
-}
-
-void XMLUtil::ToStr( uint64_t v, char* buffer, int bufferSize )
-{
-    // horrible syntax trick to make the compiler happy about %llu
-    TIXML_SNPRINTF(buffer, bufferSize, "%llu", (long long)v);
-}
-
-bool XMLUtil::ToInt( const char* str, int* value )
-{
-    if ( TIXML_SSCANF( str, "%d", value ) == 1 ) {
-        return true;
-    }
-    return false;
-}
-
-bool XMLUtil::ToUnsigned( const char* str, unsigned *value )
-{
-    if ( TIXML_SSCANF( str, "%u", value ) == 1 ) {
-        return true;
-    }
-    return false;
-}
-
-bool XMLUtil::ToBool( const char* str, bool* value )
-{
-    int ival = 0;
-    if ( ToInt( str, &ival )) {
-        *value = (ival==0) ? false : true;
-        return true;
-    }
-    static const char* TRUE[] = { "true", "True", "TRUE", 0 };
-    static const char* FALSE[] = { "false", "False", "FALSE", 0 };
-
-    for (int i = 0; TRUE[i]; ++i) {
-        if (StringEqual(str, TRUE[i])) {
-            *value = true;
-            return true;
-        }
-    }
-    for (int i = 0; FALSE[i]; ++i) {
-        if (StringEqual(str, FALSE[i])) {
-            *value = false;
-            return true;
-        }
-    }
-    return false;
-}
-
-
-bool XMLUtil::ToFloat( const char* str, float* value )
-{
-    if ( TIXML_SSCANF( str, "%f", value ) == 1 ) {
-        return true;
-    }
-    return false;
-}
-
-
-bool XMLUtil::ToDouble( const char* str, double* value )
-{
-    if ( TIXML_SSCANF( str, "%lf", value ) == 1 ) {
-        return true;
-    }
-    return false;
-}
-
-
-bool XMLUtil::ToInt64(const char* str, int64_t* value)
-{
-	long long v = 0;	// horrible syntax trick to make the compiler happy about %lld
-	if (TIXML_SSCANF(str, "%lld", &v) == 1) {
-		*value = static_cast<int64_t>(v);
-		return true;
-	}
-	return false;
-}
-
-
-bool XMLUtil::ToUnsigned64(const char* str, uint64_t* value) {
-    unsigned long long v = 0;	// horrible syntax trick to make the compiler happy about %llu
-    if(TIXML_SSCANF(str, "%llu", &v) == 1) {
-        *value = (uint64_t)v;
-        return true;
-    }
-    return false;
-}
-
-
-char* XMLDocument::Identify( char* p, XMLNode** node )
-{
-    TIXMLASSERT( node );
-    TIXMLASSERT( p );
-    char* const start = p;
-    int const startLine = _parseCurLineNum;
-    p = XMLUtil::SkipWhiteSpace( p, &_parseCurLineNum );
-    if( !*p ) {
-        *node = 0;
-        TIXMLASSERT( p );
+        TIXMLASSERT(p);
         return p;
     }
 
-    // These strings define the matching patterns:
-    static const char* xmlHeader		= { "<?" };
-    static const char* commentHeader	= { "<!--" };
-    static const char* cdataHeader		= { "<![CDATA[" };
-    static const char* dtdHeader		= { "<!" };
-    static const char* elementHeader	= { "<" };	// and a header for everything else; check last.
+    void XMLUtil::ConvertUTF32ToUTF8(unsigned long input, char *output, int *length)
+    {
+        const unsigned long BYTE_MASK = 0xBF;
+        const unsigned long BYTE_MARK = 0x80;
+        const unsigned long FIRST_BYTE_MARK[7] = {0x00, 0x00, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC};
 
-    static const int xmlHeaderLen		= 2;
-    static const int commentHeaderLen	= 4;
-    static const int cdataHeaderLen		= 9;
-    static const int dtdHeaderLen		= 2;
-    static const int elementHeaderLen	= 1;
+        if (input < 0x80)
+        {
+            *length = 1;
+        }
+        else if (input < 0x800)
+        {
+            *length = 2;
+        }
+        else if (input < 0x10000)
+        {
+            *length = 3;
+        }
+        else if (input < 0x200000)
+        {
+            *length = 4;
+        }
+        else
+        {
+            *length = 0; // This code won't convert this correctly anyway.
+            return;
+        }
 
-    TIXMLASSERT( sizeof( XMLComment ) == sizeof( XMLUnknown ) );		// use same memory pool
-    TIXMLASSERT( sizeof( XMLComment ) == sizeof( XMLDeclaration ) );	// use same memory pool
-    XMLNode* returnNode = 0;
-    if ( XMLUtil::StringEqual( p, xmlHeader, xmlHeaderLen ) ) {
-        returnNode = CreateUnlinkedNode<XMLDeclaration>( _commentPool );
-        returnNode->_parseLineNum = _parseCurLineNum;
-        p += xmlHeaderLen;
-    }
-    else if ( XMLUtil::StringEqual( p, commentHeader, commentHeaderLen ) ) {
-        returnNode = CreateUnlinkedNode<XMLComment>( _commentPool );
-        returnNode->_parseLineNum = _parseCurLineNum;
-        p += commentHeaderLen;
-    }
-    else if ( XMLUtil::StringEqual( p, cdataHeader, cdataHeaderLen ) ) {
-        XMLText* text = CreateUnlinkedNode<XMLText>( _textPool );
-        returnNode = text;
-        returnNode->_parseLineNum = _parseCurLineNum;
-        p += cdataHeaderLen;
-        text->SetCData( true );
-    }
-    else if ( XMLUtil::StringEqual( p, dtdHeader, dtdHeaderLen ) ) {
-        returnNode = CreateUnlinkedNode<XMLUnknown>( _commentPool );
-        returnNode->_parseLineNum = _parseCurLineNum;
-        p += dtdHeaderLen;
-    }
-    else if ( XMLUtil::StringEqual( p, elementHeader, elementHeaderLen ) ) {
-        returnNode =  CreateUnlinkedNode<XMLElement>( _elementPool );
-        returnNode->_parseLineNum = _parseCurLineNum;
-        p += elementHeaderLen;
-    }
-    else {
-        returnNode = CreateUnlinkedNode<XMLText>( _textPool );
-        returnNode->_parseLineNum = _parseCurLineNum; // Report line of first non-whitespace character
-        p = start;	// Back it up, all the text counts.
-        _parseCurLineNum = startLine;
-    }
+        output += *length;
 
-    TIXMLASSERT( returnNode );
-    TIXMLASSERT( p );
-    *node = returnNode;
-    return p;
-}
-
-
-bool XMLDocument::Accept( XMLVisitor* visitor ) const
-{
-    TIXMLASSERT( visitor );
-    if ( visitor->VisitEnter( *this ) ) {
-        for ( const XMLNode* node=FirstChild(); node; node=node->NextSibling() ) {
-            if ( !node->Accept( visitor ) ) {
+        // Scary scary fall throughs are annotated with carefully designed comments
+        // to suppress compiler warnings such as -Wimplicit-fallthrough in gcc
+        switch (*length)
+        {
+            case 4:
+                --output;
+                *output = static_cast<char>((input | BYTE_MARK) & BYTE_MASK);
+                input >>= 6;
+                // fall through
+            case 3:
+                --output;
+                *output = static_cast<char>((input | BYTE_MARK) & BYTE_MASK);
+                input >>= 6;
+                // fall through
+            case 2:
+                --output;
+                *output = static_cast<char>((input | BYTE_MARK) & BYTE_MASK);
+                input >>= 6;
+                // fall through
+            case 1:
+                --output;
+                *output = static_cast<char>(input | FIRST_BYTE_MARK[*length]);
                 break;
-            }
+            default:
+                TIXMLASSERT(false);
         }
     }
-    return visitor->VisitExit( *this );
-}
 
+    const char *XMLUtil::GetCharacterRef(const char *p, char *value, int *length)
+    {
+        // Presume an entity, and pull it out.
+        *length = 0;
 
-// --------- XMLNode ----------- //
+        if (*(p + 1) == '#' && *(p + 2))
+        {
+            unsigned long ucs = 0;
+            TIXMLASSERT(sizeof(ucs) >= 4);
+            ptrdiff_t delta = 0;
+            unsigned mult = 1;
+            static const char SEMICOLON = ';';
 
-XMLNode::XMLNode( XMLDocument* doc ) :
-    _document( doc ),
-    _parent( 0 ),
-    _value(),
-    _parseLineNum( 0 ),
-    _firstChild( 0 ), _lastChild( 0 ),
-    _prev( 0 ), _next( 0 ),
-	_userData( 0 ),
-    _memPool( 0 )
-{
-}
+            if (*(p + 2) == 'x')
+            {
+                // Hexadecimal.
+                const char *q = p + 3;
+                if (!(*q))
+                {
+                    return 0;
+                }
 
+                q = strchr(q, SEMICOLON);
 
-XMLNode::~XMLNode()
-{
-    DeleteChildren();
-    if ( _parent ) {
-        _parent->Unlink( this );
-    }
-}
+                if (!q)
+                {
+                    return 0;
+                }
+                TIXMLASSERT(*q == SEMICOLON);
 
-const char* XMLNode::Value() const
-{
-    // Edge case: XMLDocuments don't have a Value. Return null.
-    if ( this->ToDocument() )
-        return 0;
-    return _value.GetStr();
-}
+                delta = q - p;
+                --q;
 
-void XMLNode::SetValue( const char* str, bool staticMem )
-{
-    if ( staticMem ) {
-        _value.SetInternedStr( str );
-    }
-    else {
-        _value.SetStr( str );
-    }
-}
+                while (*q != 'x')
+                {
+                    unsigned int digit = 0;
 
-XMLNode* XMLNode::DeepClone(XMLDocument* target) const
-{
-	XMLNode* clone = this->ShallowClone(target);
-	if (!clone) return 0;
+                    if (*q >= '0' && *q <= '9')
+                    {
+                        digit = *q - '0';
+                    }
+                    else if (*q >= 'a' && *q <= 'f')
+                    {
+                        digit = *q - 'a' + 10;
+                    }
+                    else if (*q >= 'A' && *q <= 'F')
+                    {
+                        digit = *q - 'A' + 10;
+                    }
+                    else
+                    {
+                        return 0;
+                    }
+                    TIXMLASSERT(digit < 16);
+                    TIXMLASSERT(digit == 0 || mult <= UINT_MAX / digit);
+                    const unsigned int digitScaled = mult * digit;
+                    TIXMLASSERT(ucs <= ULONG_MAX - digitScaled);
+                    ucs += digitScaled;
+                    TIXMLASSERT(mult <= UINT_MAX / 16);
+                    mult *= 16;
+                    --q;
+                }
+            }
+            else
+            {
+                // Decimal.
+                const char *q = p + 2;
+                if (!(*q))
+                {
+                    return 0;
+                }
 
-	for (const XMLNode* child = this->FirstChild(); child; child = child->NextSibling()) {
-		XMLNode* childClone = child->DeepClone(target);
-		TIXMLASSERT(childClone);
-		clone->InsertEndChild(childClone);
-	}
-	return clone;
-}
+                q = strchr(q, SEMICOLON);
 
-void XMLNode::DeleteChildren()
-{
-    while( _firstChild ) {
-        TIXMLASSERT( _lastChild );
-        DeleteChild( _firstChild );
-    }
-    _firstChild = _lastChild = 0;
-}
+                if (!q)
+                {
+                    return 0;
+                }
+                TIXMLASSERT(*q == SEMICOLON);
 
+                delta = q - p;
+                --q;
 
-void XMLNode::Unlink( XMLNode* child )
-{
-    TIXMLASSERT( child );
-    TIXMLASSERT( child->_document == _document );
-    TIXMLASSERT( child->_parent == this );
-    if ( child == _firstChild ) {
-        _firstChild = _firstChild->_next;
-    }
-    if ( child == _lastChild ) {
-        _lastChild = _lastChild->_prev;
-    }
-
-    if ( child->_prev ) {
-        child->_prev->_next = child->_next;
-    }
-    if ( child->_next ) {
-        child->_next->_prev = child->_prev;
-    }
-	child->_next = 0;
-	child->_prev = 0;
-	child->_parent = 0;
-}
-
-
-void XMLNode::DeleteChild( XMLNode* node )
-{
-    TIXMLASSERT( node );
-    TIXMLASSERT( node->_document == _document );
-    TIXMLASSERT( node->_parent == this );
-    Unlink( node );
-	TIXMLASSERT(node->_prev == 0);
-	TIXMLASSERT(node->_next == 0);
-	TIXMLASSERT(node->_parent == 0);
-    DeleteNode( node );
-}
-
-
-XMLNode* XMLNode::InsertEndChild( XMLNode* addThis )
-{
-    TIXMLASSERT( addThis );
-    if ( addThis->_document != _document ) {
-        TIXMLASSERT( false );
-        return 0;
-    }
-    InsertChildPreamble( addThis );
-
-    if ( _lastChild ) {
-        TIXMLASSERT( _firstChild );
-        TIXMLASSERT( _lastChild->_next == 0 );
-        _lastChild->_next = addThis;
-        addThis->_prev = _lastChild;
-        _lastChild = addThis;
-
-        addThis->_next = 0;
-    }
-    else {
-        TIXMLASSERT( _firstChild == 0 );
-        _firstChild = _lastChild = addThis;
-
-        addThis->_prev = 0;
-        addThis->_next = 0;
-    }
-    addThis->_parent = this;
-    return addThis;
-}
-
-
-XMLNode* XMLNode::InsertFirstChild( XMLNode* addThis )
-{
-    TIXMLASSERT( addThis );
-    if ( addThis->_document != _document ) {
-        TIXMLASSERT( false );
-        return 0;
-    }
-    InsertChildPreamble( addThis );
-
-    if ( _firstChild ) {
-        TIXMLASSERT( _lastChild );
-        TIXMLASSERT( _firstChild->_prev == 0 );
-
-        _firstChild->_prev = addThis;
-        addThis->_next = _firstChild;
-        _firstChild = addThis;
-
-        addThis->_prev = 0;
-    }
-    else {
-        TIXMLASSERT( _lastChild == 0 );
-        _firstChild = _lastChild = addThis;
-
-        addThis->_prev = 0;
-        addThis->_next = 0;
-    }
-    addThis->_parent = this;
-    return addThis;
-}
-
-
-XMLNode* XMLNode::InsertAfterChild( XMLNode* afterThis, XMLNode* addThis )
-{
-    TIXMLASSERT( addThis );
-    if ( addThis->_document != _document ) {
-        TIXMLASSERT( false );
-        return 0;
+                while (*q != '#')
+                {
+                    if (*q >= '0' && *q <= '9')
+                    {
+                        const unsigned int digit = *q - '0';
+                        TIXMLASSERT(digit < 10);
+                        TIXMLASSERT(digit == 0 || mult <= UINT_MAX / digit);
+                        const unsigned int digitScaled = mult * digit;
+                        TIXMLASSERT(ucs <= ULONG_MAX - digitScaled);
+                        ucs += digitScaled;
+                    }
+                    else
+                    {
+                        return 0;
+                    }
+                    TIXMLASSERT(mult <= UINT_MAX / 10);
+                    mult *= 10;
+                    --q;
+                }
+            }
+            // convert the UCS to UTF-8
+            ConvertUTF32ToUTF8(ucs, value, length);
+            return p + delta + 1;
+        }
+        return p + 1;
     }
 
-    TIXMLASSERT( afterThis );
+    void XMLUtil::ToStr(int v, char *buffer, int bufferSize) { TIXML_SNPRINTF(buffer, bufferSize, "%d", v); }
 
-    if ( afterThis->_parent != this ) {
-        TIXMLASSERT( false );
-        return 0;
+    void XMLUtil::ToStr(unsigned v, char *buffer, int bufferSize) { TIXML_SNPRINTF(buffer, bufferSize, "%u", v); }
+
+    void XMLUtil::ToStr(bool v, char *buffer, int bufferSize)
+    {
+        TIXML_SNPRINTF(buffer, bufferSize, "%s", v ? writeBoolTrue : writeBoolFalse);
     }
-    if ( afterThis == addThis ) {
-        // Current state: BeforeThis -> AddThis -> OneAfterAddThis
-        // Now AddThis must disappear from it's location and then
-        // reappear between BeforeThis and OneAfterAddThis.
-        // So just leave it where it is.
+
+    /*
+        ToStr() of a number is a very tricky topic.
+        https://github.com/leethomason/tinyxml2/issues/106
+    */
+    void XMLUtil::ToStr(float v, char *buffer, int bufferSize) { TIXML_SNPRINTF(buffer, bufferSize, "%.8g", v); }
+
+    void XMLUtil::ToStr(double v, char *buffer, int bufferSize) { TIXML_SNPRINTF(buffer, bufferSize, "%.17g", v); }
+
+    void XMLUtil::ToStr(int64_t v, char *buffer, int bufferSize)
+    {
+        // horrible syntax trick to make the compiler happy about %lld
+        TIXML_SNPRINTF(buffer, bufferSize, "%lld", static_cast<long long>(v));
+    }
+
+    void XMLUtil::ToStr(uint64_t v, char *buffer, int bufferSize)
+    {
+        // horrible syntax trick to make the compiler happy about %llu
+        TIXML_SNPRINTF(buffer, bufferSize, "%llu", (long long)v);
+    }
+
+    bool XMLUtil::ToInt(const char *str, int *value)
+    {
+        if (TIXML_SSCANF(str, "%d", value) == 1)
+        {
+            return true;
+        }
+        return false;
+    }
+
+    bool XMLUtil::ToUnsigned(const char *str, unsigned *value)
+    {
+        if (TIXML_SSCANF(str, "%u", value) == 1)
+        {
+            return true;
+        }
+        return false;
+    }
+
+    bool XMLUtil::ToBool(const char *str, bool *value)
+    {
+        int ival = 0;
+        if (ToInt(str, &ival))
+        {
+            *value = (ival == 0) ? false : true;
+            return true;
+        }
+        static const char *TRUE[] = {"true", "True", "TRUE", 0};
+        static const char *FALSE[] = {"false", "False", "FALSE", 0};
+
+        for (int i = 0; TRUE[i]; ++i)
+        {
+            if (StringEqual(str, TRUE[i]))
+            {
+                *value = true;
+                return true;
+            }
+        }
+        for (int i = 0; FALSE[i]; ++i)
+        {
+            if (StringEqual(str, FALSE[i]))
+            {
+                *value = false;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool XMLUtil::ToFloat(const char *str, float *value)
+    {
+        if (TIXML_SSCANF(str, "%f", value) == 1)
+        {
+            return true;
+        }
+        return false;
+    }
+
+    bool XMLUtil::ToDouble(const char *str, double *value)
+    {
+        if (TIXML_SSCANF(str, "%lf", value) == 1)
+        {
+            return true;
+        }
+        return false;
+    }
+
+    bool XMLUtil::ToInt64(const char *str, int64_t *value)
+    {
+        long long v = 0; // horrible syntax trick to make the compiler happy about %lld
+        if (TIXML_SSCANF(str, "%lld", &v) == 1)
+        {
+            *value = static_cast<int64_t>(v);
+            return true;
+        }
+        return false;
+    }
+
+    bool XMLUtil::ToUnsigned64(const char *str, uint64_t *value)
+    {
+        unsigned long long v = 0; // horrible syntax trick to make the compiler happy about %llu
+        if (TIXML_SSCANF(str, "%llu", &v) == 1)
+        {
+            *value = (uint64_t)v;
+            return true;
+        }
+        return false;
+    }
+
+    char *XMLDocument::Identify(char *p, XMLNode **node)
+    {
+        TIXMLASSERT(node);
+        TIXMLASSERT(p);
+        char *const start = p;
+        int const startLine = _parseCurLineNum;
+        p = XMLUtil::SkipWhiteSpace(p, &_parseCurLineNum);
+        if (!*p)
+        {
+            *node = 0;
+            TIXMLASSERT(p);
+            return p;
+        }
+
+        // These strings define the matching patterns:
+        static const char *xmlHeader = {"<?"};
+        static const char *commentHeader = {"<!--"};
+        static const char *cdataHeader = {"<![CDATA["};
+        static const char *dtdHeader = {"<!"};
+        static const char *elementHeader = {"<"}; // and a header for everything else; check last.
+
+        static const int xmlHeaderLen = 2;
+        static const int commentHeaderLen = 4;
+        static const int cdataHeaderLen = 9;
+        static const int dtdHeaderLen = 2;
+        static const int elementHeaderLen = 1;
+
+        TIXMLASSERT(sizeof(XMLComment) == sizeof(XMLUnknown));     // use same memory pool
+        TIXMLASSERT(sizeof(XMLComment) == sizeof(XMLDeclaration)); // use same memory pool
+        XMLNode *returnNode = 0;
+        if (XMLUtil::StringEqual(p, xmlHeader, xmlHeaderLen))
+        {
+            returnNode = CreateUnlinkedNode<XMLDeclaration>(_commentPool);
+            returnNode->_parseLineNum = _parseCurLineNum;
+            p += xmlHeaderLen;
+        }
+        else if (XMLUtil::StringEqual(p, commentHeader, commentHeaderLen))
+        {
+            returnNode = CreateUnlinkedNode<XMLComment>(_commentPool);
+            returnNode->_parseLineNum = _parseCurLineNum;
+            p += commentHeaderLen;
+        }
+        else if (XMLUtil::StringEqual(p, cdataHeader, cdataHeaderLen))
+        {
+            XMLText *text = CreateUnlinkedNode<XMLText>(_textPool);
+            returnNode = text;
+            returnNode->_parseLineNum = _parseCurLineNum;
+            p += cdataHeaderLen;
+            text->SetCData(true);
+        }
+        else if (XMLUtil::StringEqual(p, dtdHeader, dtdHeaderLen))
+        {
+            returnNode = CreateUnlinkedNode<XMLUnknown>(_commentPool);
+            returnNode->_parseLineNum = _parseCurLineNum;
+            p += dtdHeaderLen;
+        }
+        else if (XMLUtil::StringEqual(p, elementHeader, elementHeaderLen))
+        {
+            returnNode = CreateUnlinkedNode<XMLElement>(_elementPool);
+            returnNode->_parseLineNum = _parseCurLineNum;
+            p += elementHeaderLen;
+        }
+        else
+        {
+            returnNode = CreateUnlinkedNode<XMLText>(_textPool);
+            returnNode->_parseLineNum = _parseCurLineNum; // Report line of first non-whitespace character
+            p = start;                                    // Back it up, all the text counts.
+            _parseCurLineNum = startLine;
+        }
+
+        TIXMLASSERT(returnNode);
+        TIXMLASSERT(p);
+        *node = returnNode;
+        return p;
+    }
+
+    bool XMLDocument::Accept(XMLVisitor *visitor) const
+    {
+        TIXMLASSERT(visitor);
+        if (visitor->VisitEnter(*this))
+        {
+            for (const XMLNode *node = FirstChild(); node; node = node->NextSibling())
+            {
+                if (!node->Accept(visitor))
+                {
+                    break;
+                }
+            }
+        }
+        return visitor->VisitExit(*this);
+    }
+
+    // --------- XMLNode ----------- //
+
+    XMLNode::XMLNode(XMLDocument *doc)
+        : _document(doc), _parent(0), _value(), _parseLineNum(0), _firstChild(0), _lastChild(0), _prev(0), _next(0),
+          _userData(0), _memPool(0)
+    {
+    }
+
+    XMLNode::~XMLNode()
+    {
+        DeleteChildren();
+        if (_parent)
+        {
+            _parent->Unlink(this);
+        }
+    }
+
+    const char *XMLNode::Value() const
+    {
+        // Edge case: XMLDocuments don't have a Value. Return null.
+        if (this->ToDocument())
+            return 0;
+        return _value.GetStr();
+    }
+
+    void XMLNode::SetValue(const char *str, bool staticMem)
+    {
+        if (staticMem)
+        {
+            _value.SetInternedStr(str);
+        }
+        else
+        {
+            _value.SetStr(str);
+        }
+    }
+
+    XMLNode *XMLNode::DeepClone(XMLDocument *target) const
+    {
+        XMLNode *clone = this->ShallowClone(target);
+        if (!clone)
+            return 0;
+
+        for (const XMLNode *child = this->FirstChild(); child; child = child->NextSibling())
+        {
+            XMLNode *childClone = child->DeepClone(target);
+            TIXMLASSERT(childClone);
+            clone->InsertEndChild(childClone);
+        }
+        return clone;
+    }
+
+    void XMLNode::DeleteChildren()
+    {
+        while (_firstChild)
+        {
+            TIXMLASSERT(_lastChild);
+            DeleteChild(_firstChild);
+        }
+        _firstChild = _lastChild = 0;
+    }
+
+    void XMLNode::Unlink(XMLNode *child)
+    {
+        TIXMLASSERT(child);
+        TIXMLASSERT(child->_document == _document);
+        TIXMLASSERT(child->_parent == this);
+        if (child == _firstChild)
+        {
+            _firstChild = _firstChild->_next;
+        }
+        if (child == _lastChild)
+        {
+            _lastChild = _lastChild->_prev;
+        }
+
+        if (child->_prev)
+        {
+            child->_prev->_next = child->_next;
+        }
+        if (child->_next)
+        {
+            child->_next->_prev = child->_prev;
+        }
+        child->_next = 0;
+        child->_prev = 0;
+        child->_parent = 0;
+    }
+
+    void XMLNode::DeleteChild(XMLNode *node)
+    {
+        TIXMLASSERT(node);
+        TIXMLASSERT(node->_document == _document);
+        TIXMLASSERT(node->_parent == this);
+        Unlink(node);
+        TIXMLASSERT(node->_prev == 0);
+        TIXMLASSERT(node->_next == 0);
+        TIXMLASSERT(node->_parent == 0);
+        DeleteNode(node);
+    }
+
+    XMLNode *XMLNode::InsertEndChild(XMLNode *addThis)
+    {
+        TIXMLASSERT(addThis);
+        if (addThis->_document != _document)
+        {
+            TIXMLASSERT(false);
+            return 0;
+        }
+        InsertChildPreamble(addThis);
+
+        if (_lastChild)
+        {
+            TIXMLASSERT(_firstChild);
+            TIXMLASSERT(_lastChild->_next == 0);
+            _lastChild->_next = addThis;
+            addThis->_prev = _lastChild;
+            _lastChild = addThis;
+
+            addThis->_next = 0;
+        }
+        else
+        {
+            TIXMLASSERT(_firstChild == 0);
+            _firstChild = _lastChild = addThis;
+
+            addThis->_prev = 0;
+            addThis->_next = 0;
+        }
+        addThis->_parent = this;
         return addThis;
     }
 
-    if ( afterThis->_next == 0 ) {
-        // The last node or the only node.
-        return InsertEndChild( addThis );
-    }
-    InsertChildPreamble( addThis );
-    addThis->_prev = afterThis;
-    addThis->_next = afterThis->_next;
-    afterThis->_next->_prev = addThis;
-    afterThis->_next = addThis;
-    addThis->_parent = this;
-    return addThis;
-}
-
-
-
-
-const XMLElement* XMLNode::FirstChildElement( const char* name ) const
-{
-    for( const XMLNode* node = _firstChild; node; node = node->_next ) {
-        const XMLElement* element = node->ToElementWithName( name );
-        if ( element ) {
-            return element;
+    XMLNode *XMLNode::InsertFirstChild(XMLNode *addThis)
+    {
+        TIXMLASSERT(addThis);
+        if (addThis->_document != _document)
+        {
+            TIXMLASSERT(false);
+            return 0;
         }
-    }
-    return 0;
-}
+        InsertChildPreamble(addThis);
 
+        if (_firstChild)
+        {
+            TIXMLASSERT(_lastChild);
+            TIXMLASSERT(_firstChild->_prev == 0);
 
-const XMLElement* XMLNode::LastChildElement( const char* name ) const
-{
-    for( const XMLNode* node = _lastChild; node; node = node->_prev ) {
-        const XMLElement* element = node->ToElementWithName( name );
-        if ( element ) {
-            return element;
+            _firstChild->_prev = addThis;
+            addThis->_next = _firstChild;
+            _firstChild = addThis;
+
+            addThis->_prev = 0;
         }
-    }
-    return 0;
-}
+        else
+        {
+            TIXMLASSERT(_lastChild == 0);
+            _firstChild = _lastChild = addThis;
 
-
-const XMLElement* XMLNode::NextSiblingElement( const char* name ) const
-{
-    for( const XMLNode* node = _next; node; node = node->_next ) {
-        const XMLElement* element = node->ToElementWithName( name );
-        if ( element ) {
-            return element;
+            addThis->_prev = 0;
+            addThis->_next = 0;
         }
-    }
-    return 0;
-}
-
-
-const XMLElement* XMLNode::PreviousSiblingElement( const char* name ) const
-{
-    for( const XMLNode* node = _prev; node; node = node->_prev ) {
-        const XMLElement* element = node->ToElementWithName( name );
-        if ( element ) {
-            return element;
-        }
-    }
-    return 0;
-}
-
-
-char* XMLNode::ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr )
-{
-    // This is a recursive method, but thinking about it "at the current level"
-    // it is a pretty simple flat list:
-    //		<foo/>
-    //		<!-- comment -->
-    //
-    // With a special case:
-    //		<foo>
-    //		</foo>
-    //		<!-- comment -->
-    //
-    // Where the closing element (/foo) *must* be the next thing after the opening
-    // element, and the names must match. BUT the tricky bit is that the closing
-    // element will be read by the child.
-    //
-    // 'endTag' is the end tag for this node, it is returned by a call to a child.
-    // 'parentEnd' is the end tag for the parent, which is filled in and returned.
-
-	XMLDocument::DepthTracker tracker(_document);
-	if (_document->Error())
-		return 0;
-
-	while( p && *p ) {
-        XMLNode* node = 0;
-
-        p = _document->Identify( p, &node );
-        TIXMLASSERT( p );
-        if ( node == 0 ) {
-            break;
-        }
-
-       const int initialLineNum = node->_parseLineNum;
-
-        StrPair endTag;
-        p = node->ParseDeep( p, &endTag, curLineNumPtr );
-        if ( !p ) {
-            DeleteNode( node );
-            if ( !_document->Error() ) {
-                _document->SetError( XML_ERROR_PARSING, initialLineNum, 0);
-            }
-            break;
-        }
-
-        const XMLDeclaration* const decl = node->ToDeclaration();
-        if ( decl ) {
-            // Declarations are only allowed at document level
-            //
-            // Multiple declarations are allowed but all declarations
-            // must occur before anything else. 
-            //
-            // Optimized due to a security test case. If the first node is 
-            // a declaration, and the last node is a declaration, then only 
-            // declarations have so far been added.
-            bool wellLocated = false;
-
-            if (ToDocument()) {
-                if (FirstChild()) {
-                    wellLocated =
-                        FirstChild() &&
-                        FirstChild()->ToDeclaration() &&
-                        LastChild() &&
-                        LastChild()->ToDeclaration();
-                }
-                else {
-                    wellLocated = true;
-                }
-            }
-            if ( !wellLocated ) {
-                _document->SetError( XML_ERROR_PARSING_DECLARATION, initialLineNum, "XMLDeclaration value=%s", decl->Value());
-                DeleteNode( node );
-                break;
-            }
-        }
-
-        XMLElement* ele = node->ToElement();
-        if ( ele ) {
-            // We read the end tag. Return it to the parent.
-            if ( ele->ClosingType() == XMLElement::CLOSING ) {
-                if ( parentEndTag ) {
-                    ele->_value.TransferTo( parentEndTag );
-                }
-                node->_memPool->SetTracked();   // created and then immediately deleted.
-                DeleteNode( node );
-                return p;
-            }
-
-            // Handle an end tag returned to this level.
-            // And handle a bunch of annoying errors.
-            bool mismatch = false;
-            if ( endTag.Empty() ) {
-                if ( ele->ClosingType() == XMLElement::OPEN ) {
-                    mismatch = true;
-                }
-            }
-            else {
-                if ( ele->ClosingType() != XMLElement::OPEN ) {
-                    mismatch = true;
-                }
-                else if ( !XMLUtil::StringEqual( endTag.GetStr(), ele->Name() ) ) {
-                    mismatch = true;
-                }
-            }
-            if ( mismatch ) {
-                _document->SetError( XML_ERROR_MISMATCHED_ELEMENT, initialLineNum, "XMLElement name=%s", ele->Name());
-                DeleteNode( node );
-                break;
-            }
-        }
-        InsertEndChild( node );
-    }
-    return 0;
-}
-
-/*static*/ void XMLNode::DeleteNode( XMLNode* node )
-{
-    if ( node == 0 ) {
-        return;
-    }
-	TIXMLASSERT(node->_document);
-	if (!node->ToDocument()) {
-		node->_document->MarkInUse(node);
-	}
-
-    MemPool* pool = node->_memPool;
-    node->~XMLNode();
-    pool->Free( node );
-}
-
-void XMLNode::InsertChildPreamble( XMLNode* insertThis ) const
-{
-    TIXMLASSERT( insertThis );
-    TIXMLASSERT( insertThis->_document == _document );
-
-	if (insertThis->_parent) {
-        insertThis->_parent->Unlink( insertThis );
-	}
-	else {
-		insertThis->_document->MarkInUse(insertThis);
-        insertThis->_memPool->SetTracked();
-	}
-}
-
-const XMLElement* XMLNode::ToElementWithName( const char* name ) const
-{
-    const XMLElement* element = this->ToElement();
-    if ( element == 0 ) {
-        return 0;
-    }
-    if ( name == 0 ) {
-        return element;
-    }
-    if ( XMLUtil::StringEqual( element->Name(), name ) ) {
-       return element;
-    }
-    return 0;
-}
-
-// --------- XMLText ---------- //
-char* XMLText::ParseDeep( char* p, StrPair*, int* curLineNumPtr )
-{
-    if ( this->CData() ) {
-        p = _value.ParseText( p, "]]>", StrPair::NEEDS_NEWLINE_NORMALIZATION, curLineNumPtr );
-        if ( !p ) {
-            _document->SetError( XML_ERROR_PARSING_CDATA, _parseLineNum, 0 );
-        }
-        return p;
-    }
-    else {
-        int flags = _document->ProcessEntities() ? StrPair::TEXT_ELEMENT : StrPair::TEXT_ELEMENT_LEAVE_ENTITIES;
-        if ( _document->WhitespaceMode() == COLLAPSE_WHITESPACE ) {
-            flags |= StrPair::NEEDS_WHITESPACE_COLLAPSING;
-        }
-
-        p = _value.ParseText( p, "<", flags, curLineNumPtr );
-        if ( p && *p ) {
-            return p-1;
-        }
-        if ( !p ) {
-            _document->SetError( XML_ERROR_PARSING_TEXT, _parseLineNum, 0 );
-        }
-    }
-    return 0;
-}
-
-
-XMLNode* XMLText::ShallowClone( XMLDocument* doc ) const
-{
-    if ( !doc ) {
-        doc = _document;
-    }
-    XMLText* text = doc->NewText( Value() );	// fixme: this will always allocate memory. Intern?
-    text->SetCData( this->CData() );
-    return text;
-}
-
-
-bool XMLText::ShallowEqual( const XMLNode* compare ) const
-{
-    TIXMLASSERT( compare );
-    const XMLText* text = compare->ToText();
-    return ( text && XMLUtil::StringEqual( text->Value(), Value() ) );
-}
-
-
-bool XMLText::Accept( XMLVisitor* visitor ) const
-{
-    TIXMLASSERT( visitor );
-    return visitor->Visit( *this );
-}
-
-
-// --------- XMLComment ---------- //
-
-XMLComment::XMLComment( XMLDocument* doc ) : XMLNode( doc )
-{
-}
-
-
-XMLComment::~XMLComment()
-{
-}
-
-
-char* XMLComment::ParseDeep( char* p, StrPair*, int* curLineNumPtr )
-{
-    // Comment parses as text.
-    p = _value.ParseText( p, "-->", StrPair::COMMENT, curLineNumPtr );
-    if ( p == 0 ) {
-        _document->SetError( XML_ERROR_PARSING_COMMENT, _parseLineNum, 0 );
-    }
-    return p;
-}
-
-
-XMLNode* XMLComment::ShallowClone( XMLDocument* doc ) const
-{
-    if ( !doc ) {
-        doc = _document;
-    }
-    XMLComment* comment = doc->NewComment( Value() );	// fixme: this will always allocate memory. Intern?
-    return comment;
-}
-
-
-bool XMLComment::ShallowEqual( const XMLNode* compare ) const
-{
-    TIXMLASSERT( compare );
-    const XMLComment* comment = compare->ToComment();
-    return ( comment && XMLUtil::StringEqual( comment->Value(), Value() ));
-}
-
-
-bool XMLComment::Accept( XMLVisitor* visitor ) const
-{
-    TIXMLASSERT( visitor );
-    return visitor->Visit( *this );
-}
-
-
-// --------- XMLDeclaration ---------- //
-
-XMLDeclaration::XMLDeclaration( XMLDocument* doc ) : XMLNode( doc )
-{
-}
-
-
-XMLDeclaration::~XMLDeclaration()
-{
-    //printf( "~XMLDeclaration\n" );
-}
-
-
-char* XMLDeclaration::ParseDeep( char* p, StrPair*, int* curLineNumPtr )
-{
-    // Declaration parses as text.
-    p = _value.ParseText( p, "?>", StrPair::NEEDS_NEWLINE_NORMALIZATION, curLineNumPtr );
-    if ( p == 0 ) {
-        _document->SetError( XML_ERROR_PARSING_DECLARATION, _parseLineNum, 0 );
-    }
-    return p;
-}
-
-
-XMLNode* XMLDeclaration::ShallowClone( XMLDocument* doc ) const
-{
-    if ( !doc ) {
-        doc = _document;
-    }
-    XMLDeclaration* dec = doc->NewDeclaration( Value() );	// fixme: this will always allocate memory. Intern?
-    return dec;
-}
-
-
-bool XMLDeclaration::ShallowEqual( const XMLNode* compare ) const
-{
-    TIXMLASSERT( compare );
-    const XMLDeclaration* declaration = compare->ToDeclaration();
-    return ( declaration && XMLUtil::StringEqual( declaration->Value(), Value() ));
-}
-
-
-
-bool XMLDeclaration::Accept( XMLVisitor* visitor ) const
-{
-    TIXMLASSERT( visitor );
-    return visitor->Visit( *this );
-}
-
-// --------- XMLUnknown ---------- //
-
-XMLUnknown::XMLUnknown( XMLDocument* doc ) : XMLNode( doc )
-{
-}
-
-
-XMLUnknown::~XMLUnknown()
-{
-}
-
-
-char* XMLUnknown::ParseDeep( char* p, StrPair*, int* curLineNumPtr )
-{
-    // Unknown parses as text.
-    p = _value.ParseText( p, ">", StrPair::NEEDS_NEWLINE_NORMALIZATION, curLineNumPtr );
-    if ( !p ) {
-        _document->SetError( XML_ERROR_PARSING_UNKNOWN, _parseLineNum, 0 );
-    }
-    return p;
-}
-
-
-XMLNode* XMLUnknown::ShallowClone( XMLDocument* doc ) const
-{
-    if ( !doc ) {
-        doc = _document;
-    }
-    XMLUnknown* text = doc->NewUnknown( Value() );	// fixme: this will always allocate memory. Intern?
-    return text;
-}
-
-
-bool XMLUnknown::ShallowEqual( const XMLNode* compare ) const
-{
-    TIXMLASSERT( compare );
-    const XMLUnknown* unknown = compare->ToUnknown();
-    return ( unknown && XMLUtil::StringEqual( unknown->Value(), Value() ));
-}
-
-
-bool XMLUnknown::Accept( XMLVisitor* visitor ) const
-{
-    TIXMLASSERT( visitor );
-    return visitor->Visit( *this );
-}
-
-// --------- XMLAttribute ---------- //
-
-const char* XMLAttribute::Name() const
-{
-    return _name.GetStr();
-}
-
-const char* XMLAttribute::Value() const
-{
-    return _value.GetStr();
-}
-
-char* XMLAttribute::ParseDeep( char* p, bool processEntities, int* curLineNumPtr )
-{
-    // Parse using the name rules: bug fix, was using ParseText before
-    p = _name.ParseName( p );
-    if ( !p || !*p ) {
-        return 0;
+        addThis->_parent = this;
+        return addThis;
     }
 
-    // Skip white space before =
-    p = XMLUtil::SkipWhiteSpace( p, curLineNumPtr );
-    if ( *p != '=' ) {
-        return 0;
-    }
-
-    ++p;	// move up to opening quote
-    p = XMLUtil::SkipWhiteSpace( p, curLineNumPtr );
-    if ( *p != '\"' && *p != '\'' ) {
-        return 0;
-    }
-
-    const char endTag[2] = { *p, 0 };
-    ++p;	// move past opening quote
-
-    p = _value.ParseText( p, endTag, processEntities ? StrPair::ATTRIBUTE_VALUE : StrPair::ATTRIBUTE_VALUE_LEAVE_ENTITIES, curLineNumPtr );
-    return p;
-}
-
-
-void XMLAttribute::SetName( const char* n )
-{
-    _name.SetStr( n );
-}
-
-
-XMLError XMLAttribute::QueryIntValue( int* value ) const
-{
-    if ( XMLUtil::ToInt( Value(), value )) {
-        return XML_SUCCESS;
-    }
-    return XML_WRONG_ATTRIBUTE_TYPE;
-}
-
-
-XMLError XMLAttribute::QueryUnsignedValue( unsigned int* value ) const
-{
-    if ( XMLUtil::ToUnsigned( Value(), value )) {
-        return XML_SUCCESS;
-    }
-    return XML_WRONG_ATTRIBUTE_TYPE;
-}
-
-
-XMLError XMLAttribute::QueryInt64Value(int64_t* value) const
-{
-	if (XMLUtil::ToInt64(Value(), value)) {
-		return XML_SUCCESS;
-	}
-	return XML_WRONG_ATTRIBUTE_TYPE;
-}
-
-
-XMLError XMLAttribute::QueryUnsigned64Value(uint64_t* value) const
-{
-    if(XMLUtil::ToUnsigned64(Value(), value)) {
-        return XML_SUCCESS;
-    }
-    return XML_WRONG_ATTRIBUTE_TYPE;
-}
-
-
-XMLError XMLAttribute::QueryBoolValue( bool* value ) const
-{
-    if ( XMLUtil::ToBool( Value(), value )) {
-        return XML_SUCCESS;
-    }
-    return XML_WRONG_ATTRIBUTE_TYPE;
-}
-
-
-XMLError XMLAttribute::QueryFloatValue( float* value ) const
-{
-    if ( XMLUtil::ToFloat( Value(), value )) {
-        return XML_SUCCESS;
-    }
-    return XML_WRONG_ATTRIBUTE_TYPE;
-}
-
-
-XMLError XMLAttribute::QueryDoubleValue( double* value ) const
-{
-    if ( XMLUtil::ToDouble( Value(), value )) {
-        return XML_SUCCESS;
-    }
-    return XML_WRONG_ATTRIBUTE_TYPE;
-}
-
-
-void XMLAttribute::SetAttribute( const char* v )
-{
-    _value.SetStr( v );
-}
-
-
-void XMLAttribute::SetAttribute( int v )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( v, buf, BUF_SIZE );
-    _value.SetStr( buf );
-}
-
-
-void XMLAttribute::SetAttribute( unsigned v )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( v, buf, BUF_SIZE );
-    _value.SetStr( buf );
-}
-
-
-void XMLAttribute::SetAttribute(int64_t v)
-{
-	char buf[BUF_SIZE];
-	XMLUtil::ToStr(v, buf, BUF_SIZE);
-	_value.SetStr(buf);
-}
-
-void XMLAttribute::SetAttribute(uint64_t v)
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr(v, buf, BUF_SIZE);
-    _value.SetStr(buf);
-}
-
-
-void XMLAttribute::SetAttribute( bool v )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( v, buf, BUF_SIZE );
-    _value.SetStr( buf );
-}
-
-void XMLAttribute::SetAttribute( double v )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( v, buf, BUF_SIZE );
-    _value.SetStr( buf );
-}
-
-void XMLAttribute::SetAttribute( float v )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( v, buf, BUF_SIZE );
-    _value.SetStr( buf );
-}
-
-
-// --------- XMLElement ---------- //
-XMLElement::XMLElement( XMLDocument* doc ) : XMLNode( doc ),
-    _closingType( OPEN ),
-    _rootAttribute( 0 )
-{
-}
-
-
-XMLElement::~XMLElement()
-{
-    while( _rootAttribute ) {
-        XMLAttribute* next = _rootAttribute->_next;
-        DeleteAttribute( _rootAttribute );
-        _rootAttribute = next;
-    }
-}
-
-
-const XMLAttribute* XMLElement::FindAttribute( const char* name ) const
-{
-    for( XMLAttribute* a = _rootAttribute; a; a = a->_next ) {
-        if ( XMLUtil::StringEqual( a->Name(), name ) ) {
-            return a;
-        }
-    }
-    return 0;
-}
-
-
-const char* XMLElement::Attribute( const char* name, const char* value ) const
-{
-    const XMLAttribute* a = FindAttribute( name );
-    if ( !a ) {
-        return 0;
-    }
-    if ( !value || XMLUtil::StringEqual( a->Value(), value )) {
-        return a->Value();
-    }
-    return 0;
-}
-
-int XMLElement::IntAttribute(const char* name, int defaultValue) const
-{
-	int i = defaultValue;
-	QueryIntAttribute(name, &i);
-	return i;
-}
-
-unsigned XMLElement::UnsignedAttribute(const char* name, unsigned defaultValue) const
-{
-	unsigned i = defaultValue;
-	QueryUnsignedAttribute(name, &i);
-	return i;
-}
-
-int64_t XMLElement::Int64Attribute(const char* name, int64_t defaultValue) const
-{
-	int64_t i = defaultValue;
-	QueryInt64Attribute(name, &i);
-	return i;
-}
-
-uint64_t XMLElement::Unsigned64Attribute(const char* name, uint64_t defaultValue) const
-{
-	uint64_t i = defaultValue;
-	QueryUnsigned64Attribute(name, &i);
-	return i;
-}
-
-bool XMLElement::BoolAttribute(const char* name, bool defaultValue) const
-{
-	bool b = defaultValue;
-	QueryBoolAttribute(name, &b);
-	return b;
-}
-
-double XMLElement::DoubleAttribute(const char* name, double defaultValue) const
-{
-	double d = defaultValue;
-	QueryDoubleAttribute(name, &d);
-	return d;
-}
-
-float XMLElement::FloatAttribute(const char* name, float defaultValue) const
-{
-	float f = defaultValue;
-	QueryFloatAttribute(name, &f);
-	return f;
-}
-
-const char* XMLElement::GetText() const
-{
-    if ( FirstChild() && FirstChild()->ToText() ) {
-        return FirstChild()->Value();
-    }
-    return 0;
-}
-
-
-void	XMLElement::SetText( const char* inText )
-{
-	if ( FirstChild() && FirstChild()->ToText() )
-		FirstChild()->SetValue( inText );
-	else {
-		XMLText*	theText = GetDocument()->NewText( inText );
-		InsertFirstChild( theText );
-	}
-}
-
-
-void XMLElement::SetText( int v )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( v, buf, BUF_SIZE );
-    SetText( buf );
-}
-
-
-void XMLElement::SetText( unsigned v )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( v, buf, BUF_SIZE );
-    SetText( buf );
-}
-
-
-void XMLElement::SetText(int64_t v)
-{
-	char buf[BUF_SIZE];
-	XMLUtil::ToStr(v, buf, BUF_SIZE);
-	SetText(buf);
-}
-
-void XMLElement::SetText(uint64_t v) {
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr(v, buf, BUF_SIZE);
-    SetText(buf);
-}
-
-
-void XMLElement::SetText( bool v )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( v, buf, BUF_SIZE );
-    SetText( buf );
-}
-
-
-void XMLElement::SetText( float v )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( v, buf, BUF_SIZE );
-    SetText( buf );
-}
-
-
-void XMLElement::SetText( double v )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( v, buf, BUF_SIZE );
-    SetText( buf );
-}
-
-
-XMLError XMLElement::QueryIntText( int* ival ) const
-{
-    if ( FirstChild() && FirstChild()->ToText() ) {
-        const char* t = FirstChild()->Value();
-        if ( XMLUtil::ToInt( t, ival ) ) {
-            return XML_SUCCESS;
-        }
-        return XML_CAN_NOT_CONVERT_TEXT;
-    }
-    return XML_NO_TEXT_NODE;
-}
-
-
-XMLError XMLElement::QueryUnsignedText( unsigned* uval ) const
-{
-    if ( FirstChild() && FirstChild()->ToText() ) {
-        const char* t = FirstChild()->Value();
-        if ( XMLUtil::ToUnsigned( t, uval ) ) {
-            return XML_SUCCESS;
-        }
-        return XML_CAN_NOT_CONVERT_TEXT;
-    }
-    return XML_NO_TEXT_NODE;
-}
-
-
-XMLError XMLElement::QueryInt64Text(int64_t* ival) const
-{
-	if (FirstChild() && FirstChild()->ToText()) {
-		const char* t = FirstChild()->Value();
-		if (XMLUtil::ToInt64(t, ival)) {
-			return XML_SUCCESS;
-		}
-		return XML_CAN_NOT_CONVERT_TEXT;
-	}
-	return XML_NO_TEXT_NODE;
-}
-
-
-XMLError XMLElement::QueryUnsigned64Text(uint64_t* ival) const
-{
-    if(FirstChild() && FirstChild()->ToText()) {
-        const char* t = FirstChild()->Value();
-        if(XMLUtil::ToUnsigned64(t, ival)) {
-            return XML_SUCCESS;
-        }
-        return XML_CAN_NOT_CONVERT_TEXT;
-    }
-    return XML_NO_TEXT_NODE;
-}
-
-
-XMLError XMLElement::QueryBoolText( bool* bval ) const
-{
-    if ( FirstChild() && FirstChild()->ToText() ) {
-        const char* t = FirstChild()->Value();
-        if ( XMLUtil::ToBool( t, bval ) ) {
-            return XML_SUCCESS;
-        }
-        return XML_CAN_NOT_CONVERT_TEXT;
-    }
-    return XML_NO_TEXT_NODE;
-}
-
-
-XMLError XMLElement::QueryDoubleText( double* dval ) const
-{
-    if ( FirstChild() && FirstChild()->ToText() ) {
-        const char* t = FirstChild()->Value();
-        if ( XMLUtil::ToDouble( t, dval ) ) {
-            return XML_SUCCESS;
-        }
-        return XML_CAN_NOT_CONVERT_TEXT;
-    }
-    return XML_NO_TEXT_NODE;
-}
-
-
-XMLError XMLElement::QueryFloatText( float* fval ) const
-{
-    if ( FirstChild() && FirstChild()->ToText() ) {
-        const char* t = FirstChild()->Value();
-        if ( XMLUtil::ToFloat( t, fval ) ) {
-            return XML_SUCCESS;
-        }
-        return XML_CAN_NOT_CONVERT_TEXT;
-    }
-    return XML_NO_TEXT_NODE;
-}
-
-int XMLElement::IntText(int defaultValue) const
-{
-	int i = defaultValue;
-	QueryIntText(&i);
-	return i;
-}
-
-unsigned XMLElement::UnsignedText(unsigned defaultValue) const
-{
-	unsigned i = defaultValue;
-	QueryUnsignedText(&i);
-	return i;
-}
-
-int64_t XMLElement::Int64Text(int64_t defaultValue) const
-{
-	int64_t i = defaultValue;
-	QueryInt64Text(&i);
-	return i;
-}
-
-uint64_t XMLElement::Unsigned64Text(uint64_t defaultValue) const
-{
-	uint64_t i = defaultValue;
-	QueryUnsigned64Text(&i);
-	return i;
-}
-
-bool XMLElement::BoolText(bool defaultValue) const
-{
-	bool b = defaultValue;
-	QueryBoolText(&b);
-	return b;
-}
-
-double XMLElement::DoubleText(double defaultValue) const
-{
-	double d = defaultValue;
-	QueryDoubleText(&d);
-	return d;
-}
-
-float XMLElement::FloatText(float defaultValue) const
-{
-	float f = defaultValue;
-	QueryFloatText(&f);
-	return f;
-}
-
-
-XMLAttribute* XMLElement::FindOrCreateAttribute( const char* name )
-{
-    XMLAttribute* last = 0;
-    XMLAttribute* attrib = 0;
-    for( attrib = _rootAttribute;
-            attrib;
-            last = attrib, attrib = attrib->_next ) {
-        if ( XMLUtil::StringEqual( attrib->Name(), name ) ) {
-            break;
-        }
-    }
-    if ( !attrib ) {
-        attrib = CreateAttribute();
-        TIXMLASSERT( attrib );
-        if ( last ) {
-            TIXMLASSERT( last->_next == 0 );
-            last->_next = attrib;
-        }
-        else {
-            TIXMLASSERT( _rootAttribute == 0 );
-            _rootAttribute = attrib;
-        }
-        attrib->SetName( name );
-    }
-    return attrib;
-}
-
-
-void XMLElement::DeleteAttribute( const char* name )
-{
-    XMLAttribute* prev = 0;
-    for( XMLAttribute* a=_rootAttribute; a; a=a->_next ) {
-        if ( XMLUtil::StringEqual( name, a->Name() ) ) {
-            if ( prev ) {
-                prev->_next = a->_next;
-            }
-            else {
-                _rootAttribute = a->_next;
-            }
-            DeleteAttribute( a );
-            break;
-        }
-        prev = a;
-    }
-}
-
-
-char* XMLElement::ParseAttributes( char* p, int* curLineNumPtr )
-{
-    XMLAttribute* prevAttribute = 0;
-
-    // Read the attributes.
-    while( p ) {
-        p = XMLUtil::SkipWhiteSpace( p, curLineNumPtr );
-        if ( !(*p) ) {
-            _document->SetError( XML_ERROR_PARSING_ELEMENT, _parseLineNum, "XMLElement name=%s", Name() );
+    XMLNode *XMLNode::InsertAfterChild(XMLNode *afterThis, XMLNode *addThis)
+    {
+        TIXMLASSERT(addThis);
+        if (addThis->_document != _document)
+        {
+            TIXMLASSERT(false);
             return 0;
         }
 
-        // attribute.
-        if (XMLUtil::IsNameStartChar( *p ) ) {
-            XMLAttribute* attrib = CreateAttribute();
-            TIXMLASSERT( attrib );
-            attrib->_parseLineNum = _document->_parseCurLineNum;
+        TIXMLASSERT(afterThis);
 
-            const int attrLineNum = attrib->_parseLineNum;
+        if (afterThis->_parent != this)
+        {
+            TIXMLASSERT(false);
+            return 0;
+        }
+        if (afterThis == addThis)
+        {
+            // Current state: BeforeThis -> AddThis -> OneAfterAddThis
+            // Now AddThis must disappear from it's location and then
+            // reappear between BeforeThis and OneAfterAddThis.
+            // So just leave it where it is.
+            return addThis;
+        }
 
-            p = attrib->ParseDeep( p, _document->ProcessEntities(), curLineNumPtr );
-            if ( !p || Attribute( attrib->Name() ) ) {
-                DeleteAttribute( attrib );
-                _document->SetError( XML_ERROR_PARSING_ATTRIBUTE, attrLineNum, "XMLElement name=%s", Name() );
-                return 0;
+        if (afterThis->_next == 0)
+        {
+            // The last node or the only node.
+            return InsertEndChild(addThis);
+        }
+        InsertChildPreamble(addThis);
+        addThis->_prev = afterThis;
+        addThis->_next = afterThis->_next;
+        afterThis->_next->_prev = addThis;
+        afterThis->_next = addThis;
+        addThis->_parent = this;
+        return addThis;
+    }
+
+    const XMLElement *XMLNode::FirstChildElement(const char *name) const
+    {
+        for (const XMLNode *node = _firstChild; node; node = node->_next)
+        {
+            const XMLElement *element = node->ToElementWithName(name);
+            if (element)
+            {
+                return element;
             }
-            // There is a minor bug here: if the attribute in the source xml
-            // document is duplicated, it will not be detected and the
-            // attribute will be doubly added. However, tracking the 'prevAttribute'
-            // avoids re-scanning the attribute list. Preferring performance for
-            // now, may reconsider in the future.
-            if ( prevAttribute ) {
-                TIXMLASSERT( prevAttribute->_next == 0 );
-                prevAttribute->_next = attrib;
+        }
+        return 0;
+    }
+
+    const XMLElement *XMLNode::LastChildElement(const char *name) const
+    {
+        for (const XMLNode *node = _lastChild; node; node = node->_prev)
+        {
+            const XMLElement *element = node->ToElementWithName(name);
+            if (element)
+            {
+                return element;
             }
-            else {
-                TIXMLASSERT( _rootAttribute == 0 );
+        }
+        return 0;
+    }
+
+    const XMLElement *XMLNode::NextSiblingElement(const char *name) const
+    {
+        for (const XMLNode *node = _next; node; node = node->_next)
+        {
+            const XMLElement *element = node->ToElementWithName(name);
+            if (element)
+            {
+                return element;
+            }
+        }
+        return 0;
+    }
+
+    const XMLElement *XMLNode::PreviousSiblingElement(const char *name) const
+    {
+        for (const XMLNode *node = _prev; node; node = node->_prev)
+        {
+            const XMLElement *element = node->ToElementWithName(name);
+            if (element)
+            {
+                return element;
+            }
+        }
+        return 0;
+    }
+
+    char *XMLNode::ParseDeep(char *p, StrPair *parentEndTag, int *curLineNumPtr)
+    {
+        // This is a recursive method, but thinking about it "at the current level"
+        // it is a pretty simple flat list:
+        //		<foo/>
+        //		<!-- comment -->
+        //
+        // With a special case:
+        //		<foo>
+        //		</foo>
+        //		<!-- comment -->
+        //
+        // Where the closing element (/foo) *must* be the next thing after the opening
+        // element, and the names must match. BUT the tricky bit is that the closing
+        // element will be read by the child.
+        //
+        // 'endTag' is the end tag for this node, it is returned by a call to a child.
+        // 'parentEnd' is the end tag for the parent, which is filled in and returned.
+
+        XMLDocument::DepthTracker tracker(_document);
+        if (_document->Error())
+            return 0;
+
+        while (p && *p)
+        {
+            XMLNode *node = 0;
+
+            p = _document->Identify(p, &node);
+            TIXMLASSERT(p);
+            if (node == 0)
+            {
+                break;
+            }
+
+            const int initialLineNum = node->_parseLineNum;
+
+            StrPair endTag;
+            p = node->ParseDeep(p, &endTag, curLineNumPtr);
+            if (!p)
+            {
+                DeleteNode(node);
+                if (!_document->Error())
+                {
+                    _document->SetError(XML_ERROR_PARSING, initialLineNum, 0);
+                }
+                break;
+            }
+
+            const XMLDeclaration *const decl = node->ToDeclaration();
+            if (decl)
+            {
+                // Declarations are only allowed at document level
+                //
+                // Multiple declarations are allowed but all declarations
+                // must occur before anything else.
+                //
+                // Optimized due to a security test case. If the first node is
+                // a declaration, and the last node is a declaration, then only
+                // declarations have so far been added.
+                bool wellLocated = false;
+
+                if (ToDocument())
+                {
+                    if (FirstChild())
+                    {
+                        wellLocated = FirstChild() && FirstChild()->ToDeclaration() && LastChild() &&
+                                      LastChild()->ToDeclaration();
+                    }
+                    else
+                    {
+                        wellLocated = true;
+                    }
+                }
+                if (!wellLocated)
+                {
+                    _document->SetError(
+                        XML_ERROR_PARSING_DECLARATION, initialLineNum, "XMLDeclaration value=%s", decl->Value());
+                    DeleteNode(node);
+                    break;
+                }
+            }
+
+            XMLElement *ele = node->ToElement();
+            if (ele)
+            {
+                // We read the end tag. Return it to the parent.
+                if (ele->ClosingType() == XMLElement::CLOSING)
+                {
+                    if (parentEndTag)
+                    {
+                        ele->_value.TransferTo(parentEndTag);
+                    }
+                    node->_memPool->SetTracked(); // created and then immediately deleted.
+                    DeleteNode(node);
+                    return p;
+                }
+
+                // Handle an end tag returned to this level.
+                // And handle a bunch of annoying errors.
+                bool mismatch = false;
+                if (endTag.Empty())
+                {
+                    if (ele->ClosingType() == XMLElement::OPEN)
+                    {
+                        mismatch = true;
+                    }
+                }
+                else
+                {
+                    if (ele->ClosingType() != XMLElement::OPEN)
+                    {
+                        mismatch = true;
+                    }
+                    else if (!XMLUtil::StringEqual(endTag.GetStr(), ele->Name()))
+                    {
+                        mismatch = true;
+                    }
+                }
+                if (mismatch)
+                {
+                    _document->SetError(
+                        XML_ERROR_MISMATCHED_ELEMENT, initialLineNum, "XMLElement name=%s", ele->Name());
+                    DeleteNode(node);
+                    break;
+                }
+            }
+            InsertEndChild(node);
+        }
+        return 0;
+    }
+
+    /*static*/ void XMLNode::DeleteNode(XMLNode *node)
+    {
+        if (node == 0)
+        {
+            return;
+        }
+        TIXMLASSERT(node->_document);
+        if (!node->ToDocument())
+        {
+            node->_document->MarkInUse(node);
+        }
+
+        MemPool *pool = node->_memPool;
+        node->~XMLNode();
+        pool->Free(node);
+    }
+
+    void XMLNode::InsertChildPreamble(XMLNode *insertThis) const
+    {
+        TIXMLASSERT(insertThis);
+        TIXMLASSERT(insertThis->_document == _document);
+
+        if (insertThis->_parent)
+        {
+            insertThis->_parent->Unlink(insertThis);
+        }
+        else
+        {
+            insertThis->_document->MarkInUse(insertThis);
+            insertThis->_memPool->SetTracked();
+        }
+    }
+
+    const XMLElement *XMLNode::ToElementWithName(const char *name) const
+    {
+        const XMLElement *element = this->ToElement();
+        if (element == 0)
+        {
+            return 0;
+        }
+        if (name == 0)
+        {
+            return element;
+        }
+        if (XMLUtil::StringEqual(element->Name(), name))
+        {
+            return element;
+        }
+        return 0;
+    }
+
+    // --------- XMLText ---------- //
+    char *XMLText::ParseDeep(char *p, StrPair *, int *curLineNumPtr)
+    {
+        if (this->CData())
+        {
+            p = _value.ParseText(p, "]]>", StrPair::NEEDS_NEWLINE_NORMALIZATION, curLineNumPtr);
+            if (!p)
+            {
+                _document->SetError(XML_ERROR_PARSING_CDATA, _parseLineNum, 0);
+            }
+            return p;
+        }
+        else
+        {
+            int flags = _document->ProcessEntities() ? StrPair::TEXT_ELEMENT : StrPair::TEXT_ELEMENT_LEAVE_ENTITIES;
+            if (_document->WhitespaceMode() == COLLAPSE_WHITESPACE)
+            {
+                flags |= StrPair::NEEDS_WHITESPACE_COLLAPSING;
+            }
+
+            p = _value.ParseText(p, "<", flags, curLineNumPtr);
+            if (p && *p)
+            {
+                return p - 1;
+            }
+            if (!p)
+            {
+                _document->SetError(XML_ERROR_PARSING_TEXT, _parseLineNum, 0);
+            }
+        }
+        return 0;
+    }
+
+    XMLNode *XMLText::ShallowClone(XMLDocument *doc) const
+    {
+        if (!doc)
+        {
+            doc = _document;
+        }
+        XMLText *text = doc->NewText(Value()); // fixme: this will always allocate memory. Intern?
+        text->SetCData(this->CData());
+        return text;
+    }
+
+    bool XMLText::ShallowEqual(const XMLNode *compare) const
+    {
+        TIXMLASSERT(compare);
+        const XMLText *text = compare->ToText();
+        return (text && XMLUtil::StringEqual(text->Value(), Value()));
+    }
+
+    bool XMLText::Accept(XMLVisitor *visitor) const
+    {
+        TIXMLASSERT(visitor);
+        return visitor->Visit(*this);
+    }
+
+    // --------- XMLComment ---------- //
+
+    XMLComment::XMLComment(XMLDocument *doc) : XMLNode(doc) {}
+
+    XMLComment::~XMLComment() {}
+
+    char *XMLComment::ParseDeep(char *p, StrPair *, int *curLineNumPtr)
+    {
+        // Comment parses as text.
+        p = _value.ParseText(p, "-->", StrPair::COMMENT, curLineNumPtr);
+        if (p == 0)
+        {
+            _document->SetError(XML_ERROR_PARSING_COMMENT, _parseLineNum, 0);
+        }
+        return p;
+    }
+
+    XMLNode *XMLComment::ShallowClone(XMLDocument *doc) const
+    {
+        if (!doc)
+        {
+            doc = _document;
+        }
+        XMLComment *comment = doc->NewComment(Value()); // fixme: this will always allocate memory. Intern?
+        return comment;
+    }
+
+    bool XMLComment::ShallowEqual(const XMLNode *compare) const
+    {
+        TIXMLASSERT(compare);
+        const XMLComment *comment = compare->ToComment();
+        return (comment && XMLUtil::StringEqual(comment->Value(), Value()));
+    }
+
+    bool XMLComment::Accept(XMLVisitor *visitor) const
+    {
+        TIXMLASSERT(visitor);
+        return visitor->Visit(*this);
+    }
+
+    // --------- XMLDeclaration ---------- //
+
+    XMLDeclaration::XMLDeclaration(XMLDocument *doc) : XMLNode(doc) {}
+
+    XMLDeclaration::~XMLDeclaration()
+    {
+        // printf( "~XMLDeclaration\n" );
+    }
+
+    char *XMLDeclaration::ParseDeep(char *p, StrPair *, int *curLineNumPtr)
+    {
+        // Declaration parses as text.
+        p = _value.ParseText(p, "?>", StrPair::NEEDS_NEWLINE_NORMALIZATION, curLineNumPtr);
+        if (p == 0)
+        {
+            _document->SetError(XML_ERROR_PARSING_DECLARATION, _parseLineNum, 0);
+        }
+        return p;
+    }
+
+    XMLNode *XMLDeclaration::ShallowClone(XMLDocument *doc) const
+    {
+        if (!doc)
+        {
+            doc = _document;
+        }
+        XMLDeclaration *dec = doc->NewDeclaration(Value()); // fixme: this will always allocate memory. Intern?
+        return dec;
+    }
+
+    bool XMLDeclaration::ShallowEqual(const XMLNode *compare) const
+    {
+        TIXMLASSERT(compare);
+        const XMLDeclaration *declaration = compare->ToDeclaration();
+        return (declaration && XMLUtil::StringEqual(declaration->Value(), Value()));
+    }
+
+    bool XMLDeclaration::Accept(XMLVisitor *visitor) const
+    {
+        TIXMLASSERT(visitor);
+        return visitor->Visit(*this);
+    }
+
+    // --------- XMLUnknown ---------- //
+
+    XMLUnknown::XMLUnknown(XMLDocument *doc) : XMLNode(doc) {}
+
+    XMLUnknown::~XMLUnknown() {}
+
+    char *XMLUnknown::ParseDeep(char *p, StrPair *, int *curLineNumPtr)
+    {
+        // Unknown parses as text.
+        p = _value.ParseText(p, ">", StrPair::NEEDS_NEWLINE_NORMALIZATION, curLineNumPtr);
+        if (!p)
+        {
+            _document->SetError(XML_ERROR_PARSING_UNKNOWN, _parseLineNum, 0);
+        }
+        return p;
+    }
+
+    XMLNode *XMLUnknown::ShallowClone(XMLDocument *doc) const
+    {
+        if (!doc)
+        {
+            doc = _document;
+        }
+        XMLUnknown *text = doc->NewUnknown(Value()); // fixme: this will always allocate memory. Intern?
+        return text;
+    }
+
+    bool XMLUnknown::ShallowEqual(const XMLNode *compare) const
+    {
+        TIXMLASSERT(compare);
+        const XMLUnknown *unknown = compare->ToUnknown();
+        return (unknown && XMLUtil::StringEqual(unknown->Value(), Value()));
+    }
+
+    bool XMLUnknown::Accept(XMLVisitor *visitor) const
+    {
+        TIXMLASSERT(visitor);
+        return visitor->Visit(*this);
+    }
+
+    // --------- XMLAttribute ---------- //
+
+    const char *XMLAttribute::Name() const { return _name.GetStr(); }
+
+    const char *XMLAttribute::Value() const { return _value.GetStr(); }
+
+    char *XMLAttribute::ParseDeep(char *p, bool processEntities, int *curLineNumPtr)
+    {
+        // Parse using the name rules: bug fix, was using ParseText before
+        p = _name.ParseName(p);
+        if (!p || !*p)
+        {
+            return 0;
+        }
+
+        // Skip white space before =
+        p = XMLUtil::SkipWhiteSpace(p, curLineNumPtr);
+        if (*p != '=')
+        {
+            return 0;
+        }
+
+        ++p; // move up to opening quote
+        p = XMLUtil::SkipWhiteSpace(p, curLineNumPtr);
+        if (*p != '\"' && *p != '\'')
+        {
+            return 0;
+        }
+
+        const char endTag[2] = {*p, 0};
+        ++p; // move past opening quote
+
+        p = _value.ParseText(
+            p,
+            endTag,
+            processEntities ? StrPair::ATTRIBUTE_VALUE : StrPair::ATTRIBUTE_VALUE_LEAVE_ENTITIES,
+            curLineNumPtr);
+        return p;
+    }
+
+    void XMLAttribute::SetName(const char *n) { _name.SetStr(n); }
+
+    XMLError XMLAttribute::QueryIntValue(int *value) const
+    {
+        if (XMLUtil::ToInt(Value(), value))
+        {
+            return XML_SUCCESS;
+        }
+        return XML_WRONG_ATTRIBUTE_TYPE;
+    }
+
+    XMLError XMLAttribute::QueryUnsignedValue(unsigned int *value) const
+    {
+        if (XMLUtil::ToUnsigned(Value(), value))
+        {
+            return XML_SUCCESS;
+        }
+        return XML_WRONG_ATTRIBUTE_TYPE;
+    }
+
+    XMLError XMLAttribute::QueryInt64Value(int64_t *value) const
+    {
+        if (XMLUtil::ToInt64(Value(), value))
+        {
+            return XML_SUCCESS;
+        }
+        return XML_WRONG_ATTRIBUTE_TYPE;
+    }
+
+    XMLError XMLAttribute::QueryUnsigned64Value(uint64_t *value) const
+    {
+        if (XMLUtil::ToUnsigned64(Value(), value))
+        {
+            return XML_SUCCESS;
+        }
+        return XML_WRONG_ATTRIBUTE_TYPE;
+    }
+
+    XMLError XMLAttribute::QueryBoolValue(bool *value) const
+    {
+        if (XMLUtil::ToBool(Value(), value))
+        {
+            return XML_SUCCESS;
+        }
+        return XML_WRONG_ATTRIBUTE_TYPE;
+    }
+
+    XMLError XMLAttribute::QueryFloatValue(float *value) const
+    {
+        if (XMLUtil::ToFloat(Value(), value))
+        {
+            return XML_SUCCESS;
+        }
+        return XML_WRONG_ATTRIBUTE_TYPE;
+    }
+
+    XMLError XMLAttribute::QueryDoubleValue(double *value) const
+    {
+        if (XMLUtil::ToDouble(Value(), value))
+        {
+            return XML_SUCCESS;
+        }
+        return XML_WRONG_ATTRIBUTE_TYPE;
+    }
+
+    void XMLAttribute::SetAttribute(const char *v) { _value.SetStr(v); }
+
+    void XMLAttribute::SetAttribute(int v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        _value.SetStr(buf);
+    }
+
+    void XMLAttribute::SetAttribute(unsigned v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        _value.SetStr(buf);
+    }
+
+    void XMLAttribute::SetAttribute(int64_t v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        _value.SetStr(buf);
+    }
+
+    void XMLAttribute::SetAttribute(uint64_t v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        _value.SetStr(buf);
+    }
+
+    void XMLAttribute::SetAttribute(bool v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        _value.SetStr(buf);
+    }
+
+    void XMLAttribute::SetAttribute(double v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        _value.SetStr(buf);
+    }
+
+    void XMLAttribute::SetAttribute(float v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        _value.SetStr(buf);
+    }
+
+    // --------- XMLElement ---------- //
+    XMLElement::XMLElement(XMLDocument *doc) : XMLNode(doc), _closingType(OPEN), _rootAttribute(0) {}
+
+    XMLElement::~XMLElement()
+    {
+        while (_rootAttribute)
+        {
+            XMLAttribute *next = _rootAttribute->_next;
+            DeleteAttribute(_rootAttribute);
+            _rootAttribute = next;
+        }
+    }
+
+    const XMLAttribute *XMLElement::FindAttribute(const char *name) const
+    {
+        for (XMLAttribute *a = _rootAttribute; a; a = a->_next)
+        {
+            if (XMLUtil::StringEqual(a->Name(), name))
+            {
+                return a;
+            }
+        }
+        return 0;
+    }
+
+    const char *XMLElement::Attribute(const char *name, const char *value) const
+    {
+        const XMLAttribute *a = FindAttribute(name);
+        if (!a)
+        {
+            return 0;
+        }
+        if (!value || XMLUtil::StringEqual(a->Value(), value))
+        {
+            return a->Value();
+        }
+        return 0;
+    }
+
+    int XMLElement::IntAttribute(const char *name, int defaultValue) const
+    {
+        int i = defaultValue;
+        QueryIntAttribute(name, &i);
+        return i;
+    }
+
+    unsigned XMLElement::UnsignedAttribute(const char *name, unsigned defaultValue) const
+    {
+        unsigned i = defaultValue;
+        QueryUnsignedAttribute(name, &i);
+        return i;
+    }
+
+    int64_t XMLElement::Int64Attribute(const char *name, int64_t defaultValue) const
+    {
+        int64_t i = defaultValue;
+        QueryInt64Attribute(name, &i);
+        return i;
+    }
+
+    uint64_t XMLElement::Unsigned64Attribute(const char *name, uint64_t defaultValue) const
+    {
+        uint64_t i = defaultValue;
+        QueryUnsigned64Attribute(name, &i);
+        return i;
+    }
+
+    bool XMLElement::BoolAttribute(const char *name, bool defaultValue) const
+    {
+        bool b = defaultValue;
+        QueryBoolAttribute(name, &b);
+        return b;
+    }
+
+    double XMLElement::DoubleAttribute(const char *name, double defaultValue) const
+    {
+        double d = defaultValue;
+        QueryDoubleAttribute(name, &d);
+        return d;
+    }
+
+    float XMLElement::FloatAttribute(const char *name, float defaultValue) const
+    {
+        float f = defaultValue;
+        QueryFloatAttribute(name, &f);
+        return f;
+    }
+
+    const char *XMLElement::GetText() const
+    {
+        if (FirstChild() && FirstChild()->ToText())
+        {
+            return FirstChild()->Value();
+        }
+        return 0;
+    }
+
+    void XMLElement::SetText(const char *inText)
+    {
+        if (FirstChild() && FirstChild()->ToText())
+            FirstChild()->SetValue(inText);
+        else
+        {
+            XMLText *theText = GetDocument()->NewText(inText);
+            InsertFirstChild(theText);
+        }
+    }
+
+    void XMLElement::SetText(int v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        SetText(buf);
+    }
+
+    void XMLElement::SetText(unsigned v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        SetText(buf);
+    }
+
+    void XMLElement::SetText(int64_t v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        SetText(buf);
+    }
+
+    void XMLElement::SetText(uint64_t v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        SetText(buf);
+    }
+
+    void XMLElement::SetText(bool v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        SetText(buf);
+    }
+
+    void XMLElement::SetText(float v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        SetText(buf);
+    }
+
+    void XMLElement::SetText(double v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        SetText(buf);
+    }
+
+    XMLError XMLElement::QueryIntText(int *ival) const
+    {
+        if (FirstChild() && FirstChild()->ToText())
+        {
+            const char *t = FirstChild()->Value();
+            if (XMLUtil::ToInt(t, ival))
+            {
+                return XML_SUCCESS;
+            }
+            return XML_CAN_NOT_CONVERT_TEXT;
+        }
+        return XML_NO_TEXT_NODE;
+    }
+
+    XMLError XMLElement::QueryUnsignedText(unsigned *uval) const
+    {
+        if (FirstChild() && FirstChild()->ToText())
+        {
+            const char *t = FirstChild()->Value();
+            if (XMLUtil::ToUnsigned(t, uval))
+            {
+                return XML_SUCCESS;
+            }
+            return XML_CAN_NOT_CONVERT_TEXT;
+        }
+        return XML_NO_TEXT_NODE;
+    }
+
+    XMLError XMLElement::QueryInt64Text(int64_t *ival) const
+    {
+        if (FirstChild() && FirstChild()->ToText())
+        {
+            const char *t = FirstChild()->Value();
+            if (XMLUtil::ToInt64(t, ival))
+            {
+                return XML_SUCCESS;
+            }
+            return XML_CAN_NOT_CONVERT_TEXT;
+        }
+        return XML_NO_TEXT_NODE;
+    }
+
+    XMLError XMLElement::QueryUnsigned64Text(uint64_t *ival) const
+    {
+        if (FirstChild() && FirstChild()->ToText())
+        {
+            const char *t = FirstChild()->Value();
+            if (XMLUtil::ToUnsigned64(t, ival))
+            {
+                return XML_SUCCESS;
+            }
+            return XML_CAN_NOT_CONVERT_TEXT;
+        }
+        return XML_NO_TEXT_NODE;
+    }
+
+    XMLError XMLElement::QueryBoolText(bool *bval) const
+    {
+        if (FirstChild() && FirstChild()->ToText())
+        {
+            const char *t = FirstChild()->Value();
+            if (XMLUtil::ToBool(t, bval))
+            {
+                return XML_SUCCESS;
+            }
+            return XML_CAN_NOT_CONVERT_TEXT;
+        }
+        return XML_NO_TEXT_NODE;
+    }
+
+    XMLError XMLElement::QueryDoubleText(double *dval) const
+    {
+        if (FirstChild() && FirstChild()->ToText())
+        {
+            const char *t = FirstChild()->Value();
+            if (XMLUtil::ToDouble(t, dval))
+            {
+                return XML_SUCCESS;
+            }
+            return XML_CAN_NOT_CONVERT_TEXT;
+        }
+        return XML_NO_TEXT_NODE;
+    }
+
+    XMLError XMLElement::QueryFloatText(float *fval) const
+    {
+        if (FirstChild() && FirstChild()->ToText())
+        {
+            const char *t = FirstChild()->Value();
+            if (XMLUtil::ToFloat(t, fval))
+            {
+                return XML_SUCCESS;
+            }
+            return XML_CAN_NOT_CONVERT_TEXT;
+        }
+        return XML_NO_TEXT_NODE;
+    }
+
+    int XMLElement::IntText(int defaultValue) const
+    {
+        int i = defaultValue;
+        QueryIntText(&i);
+        return i;
+    }
+
+    unsigned XMLElement::UnsignedText(unsigned defaultValue) const
+    {
+        unsigned i = defaultValue;
+        QueryUnsignedText(&i);
+        return i;
+    }
+
+    int64_t XMLElement::Int64Text(int64_t defaultValue) const
+    {
+        int64_t i = defaultValue;
+        QueryInt64Text(&i);
+        return i;
+    }
+
+    uint64_t XMLElement::Unsigned64Text(uint64_t defaultValue) const
+    {
+        uint64_t i = defaultValue;
+        QueryUnsigned64Text(&i);
+        return i;
+    }
+
+    bool XMLElement::BoolText(bool defaultValue) const
+    {
+        bool b = defaultValue;
+        QueryBoolText(&b);
+        return b;
+    }
+
+    double XMLElement::DoubleText(double defaultValue) const
+    {
+        double d = defaultValue;
+        QueryDoubleText(&d);
+        return d;
+    }
+
+    float XMLElement::FloatText(float defaultValue) const
+    {
+        float f = defaultValue;
+        QueryFloatText(&f);
+        return f;
+    }
+
+    XMLAttribute *XMLElement::FindOrCreateAttribute(const char *name)
+    {
+        XMLAttribute *last = 0;
+        XMLAttribute *attrib = 0;
+        for (attrib = _rootAttribute; attrib; last = attrib, attrib = attrib->_next)
+        {
+            if (XMLUtil::StringEqual(attrib->Name(), name))
+            {
+                break;
+            }
+        }
+        if (!attrib)
+        {
+            attrib = CreateAttribute();
+            TIXMLASSERT(attrib);
+            if (last)
+            {
+                TIXMLASSERT(last->_next == 0);
+                last->_next = attrib;
+            }
+            else
+            {
+                TIXMLASSERT(_rootAttribute == 0);
                 _rootAttribute = attrib;
             }
-            prevAttribute = attrib;
+            attrib->SetName(name);
         }
-        // end of the tag
-        else if ( *p == '>' ) {
-            ++p;
-            break;
-        }
-        // end of the tag
-        else if ( *p == '/' && *(p+1) == '>' ) {
-            _closingType = CLOSED;
-            return p+2;	// done; sealed element.
-        }
-        else {
-            _document->SetError( XML_ERROR_PARSING_ELEMENT, _parseLineNum, 0 );
-            return 0;
-        }
-    }
-    return p;
-}
-
-void XMLElement::DeleteAttribute( XMLAttribute* attribute )
-{
-    if ( attribute == 0 ) {
-        return;
-    }
-    MemPool* pool = attribute->_memPool;
-    attribute->~XMLAttribute();
-    pool->Free( attribute );
-}
-
-XMLAttribute* XMLElement::CreateAttribute()
-{
-    TIXMLASSERT( sizeof( XMLAttribute ) == _document->_attributePool.ItemSize() );
-    XMLAttribute* attrib = new (_document->_attributePool.Alloc() ) XMLAttribute();
-    TIXMLASSERT( attrib );
-    attrib->_memPool = &_document->_attributePool;
-    attrib->_memPool->SetTracked();
-    return attrib;
-}
-
-//
-//	<ele></ele>
-//	<ele>foo<b>bar</b></ele>
-//
-char* XMLElement::ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr )
-{
-    // Read the element name.
-    p = XMLUtil::SkipWhiteSpace( p, curLineNumPtr );
-
-    // The closing element is the </element> form. It is
-    // parsed just like a regular element then deleted from
-    // the DOM.
-    if ( *p == '/' ) {
-        _closingType = CLOSING;
-        ++p;
+        return attrib;
     }
 
-    p = _value.ParseName( p );
-    if ( _value.Empty() ) {
-        return 0;
+    void XMLElement::DeleteAttribute(const char *name)
+    {
+        XMLAttribute *prev = 0;
+        for (XMLAttribute *a = _rootAttribute; a; a = a->_next)
+        {
+            if (XMLUtil::StringEqual(name, a->Name()))
+            {
+                if (prev)
+                {
+                    prev->_next = a->_next;
+                }
+                else
+                {
+                    _rootAttribute = a->_next;
+                }
+                DeleteAttribute(a);
+                break;
+            }
+            prev = a;
+        }
     }
 
-    p = ParseAttributes( p, curLineNumPtr );
-    if ( !p || !*p || _closingType != OPEN ) {
+    char *XMLElement::ParseAttributes(char *p, int *curLineNumPtr)
+    {
+        XMLAttribute *prevAttribute = 0;
+
+        // Read the attributes.
+        while (p)
+        {
+            p = XMLUtil::SkipWhiteSpace(p, curLineNumPtr);
+            if (!(*p))
+            {
+                _document->SetError(XML_ERROR_PARSING_ELEMENT, _parseLineNum, "XMLElement name=%s", Name());
+                return 0;
+            }
+
+            // attribute.
+            if (XMLUtil::IsNameStartChar(*p))
+            {
+                XMLAttribute *attrib = CreateAttribute();
+                TIXMLASSERT(attrib);
+                attrib->_parseLineNum = _document->_parseCurLineNum;
+
+                const int attrLineNum = attrib->_parseLineNum;
+
+                p = attrib->ParseDeep(p, _document->ProcessEntities(), curLineNumPtr);
+                if (!p || Attribute(attrib->Name()))
+                {
+                    DeleteAttribute(attrib);
+                    _document->SetError(XML_ERROR_PARSING_ATTRIBUTE, attrLineNum, "XMLElement name=%s", Name());
+                    return 0;
+                }
+                // There is a minor bug here: if the attribute in the source xml
+                // document is duplicated, it will not be detected and the
+                // attribute will be doubly added. However, tracking the 'prevAttribute'
+                // avoids re-scanning the attribute list. Preferring performance for
+                // now, may reconsider in the future.
+                if (prevAttribute)
+                {
+                    TIXMLASSERT(prevAttribute->_next == 0);
+                    prevAttribute->_next = attrib;
+                }
+                else
+                {
+                    TIXMLASSERT(_rootAttribute == 0);
+                    _rootAttribute = attrib;
+                }
+                prevAttribute = attrib;
+            }
+            // end of the tag
+            else if (*p == '>')
+            {
+                ++p;
+                break;
+            }
+            // end of the tag
+            else if (*p == '/' && *(p + 1) == '>')
+            {
+                _closingType = CLOSED;
+                return p + 2; // done; sealed element.
+            }
+            else
+            {
+                _document->SetError(XML_ERROR_PARSING_ELEMENT, _parseLineNum, 0);
+                return 0;
+            }
+        }
         return p;
     }
 
-    p = XMLNode::ParseDeep( p, parentEndTag, curLineNumPtr );
-    return p;
-}
-
-
-
-XMLNode* XMLElement::ShallowClone( XMLDocument* doc ) const
-{
-    if ( !doc ) {
-        doc = _document;
+    void XMLElement::DeleteAttribute(XMLAttribute *attribute)
+    {
+        if (attribute == 0)
+        {
+            return;
+        }
+        MemPool *pool = attribute->_memPool;
+        attribute->~XMLAttribute();
+        pool->Free(attribute);
     }
-    XMLElement* element = doc->NewElement( Value() );					// fixme: this will always allocate memory. Intern?
-    for( const XMLAttribute* a=FirstAttribute(); a; a=a->Next() ) {
-        element->SetAttribute( a->Name(), a->Value() );					// fixme: this will always allocate memory. Intern?
+
+    XMLAttribute *XMLElement::CreateAttribute()
+    {
+        TIXMLASSERT(sizeof(XMLAttribute) == _document->_attributePool.ItemSize());
+        XMLAttribute *attrib = new (_document->_attributePool.Alloc()) XMLAttribute();
+        TIXMLASSERT(attrib);
+        attrib->_memPool = &_document->_attributePool;
+        attrib->_memPool->SetTracked();
+        return attrib;
     }
-    return element;
-}
 
+    //
+    //	<ele></ele>
+    //	<ele>foo<b>bar</b></ele>
+    //
+    char *XMLElement::ParseDeep(char *p, StrPair *parentEndTag, int *curLineNumPtr)
+    {
+        // Read the element name.
+        p = XMLUtil::SkipWhiteSpace(p, curLineNumPtr);
 
-bool XMLElement::ShallowEqual( const XMLNode* compare ) const
-{
-    TIXMLASSERT( compare );
-    const XMLElement* other = compare->ToElement();
-    if ( other && XMLUtil::StringEqual( other->Name(), Name() )) {
+        // The closing element is the </element> form. It is
+        // parsed just like a regular element then deleted from
+        // the DOM.
+        if (*p == '/')
+        {
+            _closingType = CLOSING;
+            ++p;
+        }
 
-        const XMLAttribute* a=FirstAttribute();
-        const XMLAttribute* b=other->FirstAttribute();
+        p = _value.ParseName(p);
+        if (_value.Empty())
+        {
+            return 0;
+        }
 
-        while ( a && b ) {
-            if ( !XMLUtil::StringEqual( a->Value(), b->Value() ) ) {
+        p = ParseAttributes(p, curLineNumPtr);
+        if (!p || !*p || _closingType != OPEN)
+        {
+            return p;
+        }
+
+        p = XMLNode::ParseDeep(p, parentEndTag, curLineNumPtr);
+        return p;
+    }
+
+    XMLNode *XMLElement::ShallowClone(XMLDocument *doc) const
+    {
+        if (!doc)
+        {
+            doc = _document;
+        }
+        XMLElement *element = doc->NewElement(Value()); // fixme: this will always allocate memory. Intern?
+        for (const XMLAttribute *a = FirstAttribute(); a; a = a->Next())
+        {
+            element->SetAttribute(a->Name(), a->Value()); // fixme: this will always allocate memory. Intern?
+        }
+        return element;
+    }
+
+    bool XMLElement::ShallowEqual(const XMLNode *compare) const
+    {
+        TIXMLASSERT(compare);
+        const XMLElement *other = compare->ToElement();
+        if (other && XMLUtil::StringEqual(other->Name(), Name()))
+        {
+
+            const XMLAttribute *a = FirstAttribute();
+            const XMLAttribute *b = other->FirstAttribute();
+
+            while (a && b)
+            {
+                if (!XMLUtil::StringEqual(a->Value(), b->Value()))
+                {
+                    return false;
+                }
+                a = a->Next();
+                b = b->Next();
+            }
+            if (a || b)
+            {
+                // different count
                 return false;
             }
-            a = a->Next();
-            b = b->Next();
+            return true;
         }
-        if ( a || b ) {
-            // different count
-            return false;
-        }
-        return true;
+        return false;
     }
-    return false;
-}
 
+    bool XMLElement::Accept(XMLVisitor *visitor) const
+    {
+        TIXMLASSERT(visitor);
+        if (visitor->VisitEnter(*this, _rootAttribute))
+        {
+            for (const XMLNode *node = FirstChild(); node; node = node->NextSibling())
+            {
+                if (!node->Accept(visitor))
+                {
+                    break;
+                }
+            }
+        }
+        return visitor->VisitExit(*this);
+    }
 
-bool XMLElement::Accept( XMLVisitor* visitor ) const
-{
-    TIXMLASSERT( visitor );
-    if ( visitor->VisitEnter( *this, _rootAttribute ) ) {
-        for ( const XMLNode* node=FirstChild(); node; node=node->NextSibling() ) {
-            if ( !node->Accept( visitor ) ) {
+    // --------- XMLDocument ----------- //
+
+    // Warning: List must match 'enum XMLError'
+    const char *XMLDocument::_errorNames[XML_ERROR_COUNT] = {"XML_SUCCESS",
+                                                             "XML_NO_ATTRIBUTE",
+                                                             "XML_WRONG_ATTRIBUTE_TYPE",
+                                                             "XML_ERROR_FILE_NOT_FOUND",
+                                                             "XML_ERROR_FILE_COULD_NOT_BE_OPENED",
+                                                             "XML_ERROR_FILE_READ_ERROR",
+                                                             "XML_ERROR_PARSING_ELEMENT",
+                                                             "XML_ERROR_PARSING_ATTRIBUTE",
+                                                             "XML_ERROR_PARSING_TEXT",
+                                                             "XML_ERROR_PARSING_CDATA",
+                                                             "XML_ERROR_PARSING_COMMENT",
+                                                             "XML_ERROR_PARSING_DECLARATION",
+                                                             "XML_ERROR_PARSING_UNKNOWN",
+                                                             "XML_ERROR_EMPTY_DOCUMENT",
+                                                             "XML_ERROR_MISMATCHED_ELEMENT",
+                                                             "XML_ERROR_PARSING",
+                                                             "XML_CAN_NOT_CONVERT_TEXT",
+                                                             "XML_NO_TEXT_NODE",
+                                                             "XML_ELEMENT_DEPTH_EXCEEDED"};
+
+    XMLDocument::XMLDocument(bool processEntities, Whitespace whitespaceMode)
+        : XMLNode(0), _writeBOM(false), _processEntities(processEntities), _errorID(XML_SUCCESS),
+          _whitespaceMode(whitespaceMode), _errorStr(), _errorLineNum(0), _charBuffer(0), _parseCurLineNum(0),
+          _parsingDepth(0), _unlinked(), _elementPool(), _attributePool(), _textPool(), _commentPool()
+    {
+        // avoid VC++ C4355 warning about 'this' in initializer list (C4355 is off by default in VS2012+)
+        _document = this;
+    }
+
+    XMLDocument::~XMLDocument() { Clear(); }
+
+    void XMLDocument::MarkInUse(XMLNode *node)
+    {
+        TIXMLASSERT(node);
+        TIXMLASSERT(node->_parent == 0);
+
+        for (int i = 0; i < _unlinked.Size(); ++i)
+        {
+            if (node == _unlinked[i])
+            {
+                _unlinked.SwapRemove(i);
                 break;
             }
         }
     }
-    return visitor->VisitExit( *this );
-}
 
-
-// --------- XMLDocument ----------- //
-
-// Warning: List must match 'enum XMLError'
-const char* XMLDocument::_errorNames[XML_ERROR_COUNT] = {
-    "XML_SUCCESS",
-    "XML_NO_ATTRIBUTE",
-    "XML_WRONG_ATTRIBUTE_TYPE",
-    "XML_ERROR_FILE_NOT_FOUND",
-    "XML_ERROR_FILE_COULD_NOT_BE_OPENED",
-    "XML_ERROR_FILE_READ_ERROR",
-    "XML_ERROR_PARSING_ELEMENT",
-    "XML_ERROR_PARSING_ATTRIBUTE",
-    "XML_ERROR_PARSING_TEXT",
-    "XML_ERROR_PARSING_CDATA",
-    "XML_ERROR_PARSING_COMMENT",
-    "XML_ERROR_PARSING_DECLARATION",
-    "XML_ERROR_PARSING_UNKNOWN",
-    "XML_ERROR_EMPTY_DOCUMENT",
-    "XML_ERROR_MISMATCHED_ELEMENT",
-    "XML_ERROR_PARSING",
-    "XML_CAN_NOT_CONVERT_TEXT",
-    "XML_NO_TEXT_NODE",
-	"XML_ELEMENT_DEPTH_EXCEEDED"
-};
-
-
-XMLDocument::XMLDocument( bool processEntities, Whitespace whitespaceMode ) :
-    XMLNode( 0 ),
-    _writeBOM( false ),
-    _processEntities( processEntities ),
-    _errorID(XML_SUCCESS),
-    _whitespaceMode( whitespaceMode ),
-    _errorStr(),
-    _errorLineNum( 0 ),
-    _charBuffer( 0 ),
-    _parseCurLineNum( 0 ),
-	_parsingDepth(0),
-    _unlinked(),
-    _elementPool(),
-    _attributePool(),
-    _textPool(),
-    _commentPool()
-{
-    // avoid VC++ C4355 warning about 'this' in initializer list (C4355 is off by default in VS2012+)
-    _document = this;
-}
-
-
-XMLDocument::~XMLDocument()
-{
-    Clear();
-}
-
-
-void XMLDocument::MarkInUse(XMLNode* node)
-{
-	TIXMLASSERT(node);
-	TIXMLASSERT(node->_parent == 0);
-
-	for (int i = 0; i < _unlinked.Size(); ++i) {
-		if (node == _unlinked[i]) {
-			_unlinked.SwapRemove(i);
-			break;
-		}
-	}
-}
-
-void XMLDocument::Clear()
-{
-    DeleteChildren();
-	while( _unlinked.Size()) {
-		DeleteNode(_unlinked[0]);	// Will remove from _unlinked as part of delete.
-	}
+    void XMLDocument::Clear()
+    {
+        DeleteChildren();
+        while (_unlinked.Size())
+        {
+            DeleteNode(_unlinked[0]); // Will remove from _unlinked as part of delete.
+        }
 
 #ifdef TINYXML2_DEBUG
-    const bool hadError = Error();
+        const bool hadError = Error();
 #endif
-    ClearError();
+        ClearError();
 
-    delete [] _charBuffer;
-    _charBuffer = 0;
-	_parsingDepth = 0;
+        delete[] _charBuffer;
+        _charBuffer = 0;
+        _parsingDepth = 0;
 
 #if 0
     _textPool.Trace( "text" );
@@ -2138,788 +2184,787 @@ void XMLDocument::Clear()
 #endif
 
 #ifdef TINYXML2_DEBUG
-    if ( !hadError ) {
-        TIXMLASSERT( _elementPool.CurrentAllocs()   == _elementPool.Untracked() );
-        TIXMLASSERT( _attributePool.CurrentAllocs() == _attributePool.Untracked() );
-        TIXMLASSERT( _textPool.CurrentAllocs()      == _textPool.Untracked() );
-        TIXMLASSERT( _commentPool.CurrentAllocs()   == _commentPool.Untracked() );
-    }
+        if (!hadError)
+        {
+            TIXMLASSERT(_elementPool.CurrentAllocs() == _elementPool.Untracked());
+            TIXMLASSERT(_attributePool.CurrentAllocs() == _attributePool.Untracked());
+            TIXMLASSERT(_textPool.CurrentAllocs() == _textPool.Untracked());
+            TIXMLASSERT(_commentPool.CurrentAllocs() == _commentPool.Untracked());
+        }
 #endif
-}
-
-
-void XMLDocument::DeepCopy(XMLDocument* target) const
-{
-	TIXMLASSERT(target);
-    if (target == this) {
-        return; // technically success - a no-op.
     }
 
-	target->Clear();
-	for (const XMLNode* node = this->FirstChild(); node; node = node->NextSibling()) {
-		target->InsertEndChild(node->DeepClone(target));
-	}
-}
+    void XMLDocument::DeepCopy(XMLDocument *target) const
+    {
+        TIXMLASSERT(target);
+        if (target == this)
+        {
+            return; // technically success - a no-op.
+        }
 
-XMLElement* XMLDocument::NewElement( const char* name )
-{
-    XMLElement* ele = CreateUnlinkedNode<XMLElement>( _elementPool );
-    ele->SetName( name );
-    return ele;
-}
-
-
-XMLComment* XMLDocument::NewComment( const char* str )
-{
-    XMLComment* comment = CreateUnlinkedNode<XMLComment>( _commentPool );
-    comment->SetValue( str );
-    return comment;
-}
-
-
-XMLText* XMLDocument::NewText( const char* str )
-{
-    XMLText* text = CreateUnlinkedNode<XMLText>( _textPool );
-    text->SetValue( str );
-    return text;
-}
-
-
-XMLDeclaration* XMLDocument::NewDeclaration( const char* str )
-{
-    XMLDeclaration* dec = CreateUnlinkedNode<XMLDeclaration>( _commentPool );
-    dec->SetValue( str ? str : "xml version=\"1.0\" encoding=\"UTF-8\"" );
-    return dec;
-}
-
-
-XMLUnknown* XMLDocument::NewUnknown( const char* str )
-{
-    XMLUnknown* unk = CreateUnlinkedNode<XMLUnknown>( _commentPool );
-    unk->SetValue( str );
-    return unk;
-}
-
-static FILE* callfopen( const char* filepath, const char* mode )
-{
-    TIXMLASSERT( filepath );
-    TIXMLASSERT( mode );
-#if defined(_MSC_VER) && (_MSC_VER >= 1400 ) && (!defined WINCE)
-    FILE* fp = 0;
-    const errno_t err = fopen_s( &fp, filepath, mode );
-    if ( err ) {
-        return 0;
+        target->Clear();
+        for (const XMLNode *node = this->FirstChild(); node; node = node->NextSibling())
+        {
+            target->InsertEndChild(node->DeepClone(target));
+        }
     }
+
+    XMLElement *XMLDocument::NewElement(const char *name)
+    {
+        XMLElement *ele = CreateUnlinkedNode<XMLElement>(_elementPool);
+        ele->SetName(name);
+        return ele;
+    }
+
+    XMLComment *XMLDocument::NewComment(const char *str)
+    {
+        XMLComment *comment = CreateUnlinkedNode<XMLComment>(_commentPool);
+        comment->SetValue(str);
+        return comment;
+    }
+
+    XMLText *XMLDocument::NewText(const char *str)
+    {
+        XMLText *text = CreateUnlinkedNode<XMLText>(_textPool);
+        text->SetValue(str);
+        return text;
+    }
+
+    XMLDeclaration *XMLDocument::NewDeclaration(const char *str)
+    {
+        XMLDeclaration *dec = CreateUnlinkedNode<XMLDeclaration>(_commentPool);
+        dec->SetValue(str ? str : "xml version=\"1.0\" encoding=\"UTF-8\"");
+        return dec;
+    }
+
+    XMLUnknown *XMLDocument::NewUnknown(const char *str)
+    {
+        XMLUnknown *unk = CreateUnlinkedNode<XMLUnknown>(_commentPool);
+        unk->SetValue(str);
+        return unk;
+    }
+
+    static FILE *callfopen(const char *filepath, const char *mode)
+    {
+        TIXMLASSERT(filepath);
+        TIXMLASSERT(mode);
+#if defined(_MSC_VER) && (_MSC_VER >= 1400) && (!defined WINCE)
+        FILE *fp = 0;
+        const errno_t err = fopen_s(&fp, filepath, mode);
+        if (err)
+        {
+            return 0;
+        }
 #else
-    FILE* fp = fopen( filepath, mode );
+        FILE *fp = fopen(filepath, mode);
 #endif
-    return fp;
-}
-
-void XMLDocument::DeleteNode( XMLNode* node )	{
-    TIXMLASSERT( node );
-    TIXMLASSERT(node->_document == this );
-    if (node->_parent) {
-        node->_parent->DeleteChild( node );
+        return fp;
     }
-    else {
-        // Isn't in the tree.
-        // Use the parent delete.
-        // Also, we need to mark it tracked: we 'know'
-        // it was never used.
-        node->_memPool->SetTracked();
-        // Call the static XMLNode version:
-        XMLNode::DeleteNode(node);
+
+    void XMLDocument::DeleteNode(XMLNode *node)
+    {
+        TIXMLASSERT(node);
+        TIXMLASSERT(node->_document == this);
+        if (node->_parent)
+        {
+            node->_parent->DeleteChild(node);
+        }
+        else
+        {
+            // Isn't in the tree.
+            // Use the parent delete.
+            // Also, we need to mark it tracked: we 'know'
+            // it was never used.
+            node->_memPool->SetTracked();
+            // Call the static XMLNode version:
+            XMLNode::DeleteNode(node);
+        }
     }
-}
 
+    XMLError XMLDocument::LoadFile(const char *filename)
+    {
+        if (!filename)
+        {
+            TIXMLASSERT(false);
+            SetError(XML_ERROR_FILE_COULD_NOT_BE_OPENED, 0, "filename=<null>");
+            return _errorID;
+        }
 
-XMLError XMLDocument::LoadFile( const char* filename )
-{
-    if ( !filename ) {
-        TIXMLASSERT( false );
-        SetError( XML_ERROR_FILE_COULD_NOT_BE_OPENED, 0, "filename=<null>" );
+        Clear();
+        FILE *fp = callfopen(filename, "rb");
+        if (!fp)
+        {
+            SetError(XML_ERROR_FILE_NOT_FOUND, 0, "filename=%s", filename);
+            return _errorID;
+        }
+        LoadFile(fp);
+        fclose(fp);
         return _errorID;
     }
 
-    Clear();
-    FILE* fp = callfopen( filename, "rb" );
-    if ( !fp ) {
-        SetError( XML_ERROR_FILE_NOT_FOUND, 0, "filename=%s", filename );
+    // This is likely overengineered template art to have a check that unsigned long value incremented
+    // by one still fits into size_t. If size_t type is larger than unsigned long type
+    // (x86_64-w64-mingw32 target) then the check is redundant and gcc and clang emit
+    // -Wtype-limits warning. This piece makes the compiler select code with a check when a check
+    // is useful and code with no check when a check is redundant depending on how size_t and unsigned long
+    // types sizes relate to each other.
+    template <bool = (sizeof(unsigned long) >= sizeof(size_t))> struct LongFitsIntoSizeTMinusOne
+    {
+        static bool Fits(unsigned long value) { return value < static_cast<size_t>(-1); }
+    };
+
+    template <> struct LongFitsIntoSizeTMinusOne<false>
+    {
+        static bool Fits(unsigned long) { return true; }
+    };
+
+    XMLError XMLDocument::LoadFile(FILE *fp)
+    {
+        Clear();
+
+        fseek(fp, 0, SEEK_SET);
+        if (fgetc(fp) == EOF && ferror(fp) != 0)
+        {
+            SetError(XML_ERROR_FILE_READ_ERROR, 0, 0);
+            return _errorID;
+        }
+
+        fseek(fp, 0, SEEK_END);
+        const long filelength = ftell(fp);
+        fseek(fp, 0, SEEK_SET);
+        if (filelength == -1L)
+        {
+            SetError(XML_ERROR_FILE_READ_ERROR, 0, 0);
+            return _errorID;
+        }
+        TIXMLASSERT(filelength >= 0);
+
+        if (!LongFitsIntoSizeTMinusOne<>::Fits(filelength))
+        {
+            // Cannot handle files which won't fit in buffer together with null terminator
+            SetError(XML_ERROR_FILE_READ_ERROR, 0, 0);
+            return _errorID;
+        }
+
+        if (filelength == 0)
+        {
+            SetError(XML_ERROR_EMPTY_DOCUMENT, 0, 0);
+            return _errorID;
+        }
+
+        const size_t size = filelength;
+        TIXMLASSERT(_charBuffer == 0);
+        _charBuffer = new char[size + 1];
+        const size_t read = fread(_charBuffer, 1, size, fp);
+        if (read != size)
+        {
+            SetError(XML_ERROR_FILE_READ_ERROR, 0, 0);
+            return _errorID;
+        }
+
+        _charBuffer[size] = 0;
+
+        Parse();
         return _errorID;
     }
-    LoadFile( fp );
-    fclose( fp );
-    return _errorID;
-}
 
-// This is likely overengineered template art to have a check that unsigned long value incremented
-// by one still fits into size_t. If size_t type is larger than unsigned long type
-// (x86_64-w64-mingw32 target) then the check is redundant and gcc and clang emit
-// -Wtype-limits warning. This piece makes the compiler select code with a check when a check
-// is useful and code with no check when a check is redundant depending on how size_t and unsigned long
-// types sizes relate to each other.
-template
-<bool = (sizeof(unsigned long) >= sizeof(size_t))>
-struct LongFitsIntoSizeTMinusOne {
-    static bool Fits( unsigned long value )
+    XMLError XMLDocument::SaveFile(const char *filename, bool compact)
     {
-        return value < static_cast<size_t>(-1);
+        if (!filename)
+        {
+            TIXMLASSERT(false);
+            SetError(XML_ERROR_FILE_COULD_NOT_BE_OPENED, 0, "filename=<null>");
+            return _errorID;
+        }
+
+        FILE *fp = callfopen(filename, "w");
+        if (!fp)
+        {
+            SetError(XML_ERROR_FILE_COULD_NOT_BE_OPENED, 0, "filename=%s", filename);
+            return _errorID;
+        }
+        SaveFile(fp, compact);
+        fclose(fp);
+        return _errorID;
     }
-};
 
-template <>
-struct LongFitsIntoSizeTMinusOne<false> {
-    static bool Fits( unsigned long )
+    XMLError XMLDocument::SaveFile(FILE *fp, bool compact)
     {
+        // Clear any error from the last save, otherwise it will get reported
+        // for *this* call.
+        ClearError();
+        XMLPrinter stream(fp, compact);
+        Print(&stream);
+        return _errorID;
+    }
+
+    XMLError XMLDocument::Parse(const char *p, size_t len)
+    {
+        Clear();
+
+        if (len == 0 || !p || !*p)
+        {
+            SetError(XML_ERROR_EMPTY_DOCUMENT, 0, 0);
+            return _errorID;
+        }
+        if (len == static_cast<size_t>(-1))
+        {
+            len = strlen(p);
+        }
+        TIXMLASSERT(_charBuffer == 0);
+        _charBuffer = new char[len + 1];
+        memcpy(_charBuffer, p, len);
+        _charBuffer[len] = 0;
+
+        Parse();
+        if (Error())
+        {
+            // clean up now essentially dangling memory.
+            // and the parse fail can put objects in the
+            // pools that are dead and inaccessible.
+            DeleteChildren();
+            _elementPool.Clear();
+            _attributePool.Clear();
+            _textPool.Clear();
+            _commentPool.Clear();
+        }
+        return _errorID;
+    }
+
+    void XMLDocument::Print(XMLPrinter *streamer) const
+    {
+        if (streamer)
+        {
+            Accept(streamer);
+        }
+        else
+        {
+            XMLPrinter stdoutStreamer(stdout);
+            Accept(&stdoutStreamer);
+        }
+    }
+
+    void XMLDocument::SetError(XMLError error, int lineNum, const char *format, ...)
+    {
+        TIXMLASSERT(error >= 0 && error < XML_ERROR_COUNT);
+        _errorID = error;
+        _errorLineNum = lineNum;
+        _errorStr.Reset();
+
+        const size_t BUFFER_SIZE = 1000;
+        char *buffer = new char[BUFFER_SIZE];
+
+        TIXMLASSERT(sizeof(error) <= sizeof(int));
+        TIXML_SNPRINTF(
+            buffer,
+            BUFFER_SIZE,
+            "Error=%s ErrorID=%d (0x%x) Line number=%d",
+            ErrorIDToName(error),
+            int(error),
+            int(error),
+            lineNum);
+
+        if (format)
+        {
+            size_t len = strlen(buffer);
+            TIXML_SNPRINTF(buffer + len, BUFFER_SIZE - len, ": ");
+            len = strlen(buffer);
+
+            va_list va;
+            va_start(va, format);
+            TIXML_VSNPRINTF(buffer + len, BUFFER_SIZE - len, format, va);
+            va_end(va);
+        }
+        _errorStr.SetStr(buffer);
+        delete[] buffer;
+    }
+
+    /*static*/ const char *XMLDocument::ErrorIDToName(XMLError errorID)
+    {
+        TIXMLASSERT(errorID >= 0 && errorID < XML_ERROR_COUNT);
+        const char *errorName = _errorNames[errorID];
+        TIXMLASSERT(errorName && errorName[0]);
+        return errorName;
+    }
+
+    const char *XMLDocument::ErrorStr() const { return _errorStr.Empty() ? "" : _errorStr.GetStr(); }
+
+    void XMLDocument::PrintError() const { printf("%s\n", ErrorStr()); }
+
+    const char *XMLDocument::ErrorName() const { return ErrorIDToName(_errorID); }
+
+    void XMLDocument::Parse()
+    {
+        TIXMLASSERT(NoChildren()); // Clear() must have been called previously
+        TIXMLASSERT(_charBuffer);
+        _parseCurLineNum = 1;
+        _parseLineNum = 1;
+        char *p = _charBuffer;
+        p = XMLUtil::SkipWhiteSpace(p, &_parseCurLineNum);
+        p = const_cast<char *>(XMLUtil::ReadBOM(p, &_writeBOM));
+        if (!*p)
+        {
+            SetError(XML_ERROR_EMPTY_DOCUMENT, 0, 0);
+            return;
+        }
+        ParseDeep(p, 0, &_parseCurLineNum);
+    }
+
+    void XMLDocument::PushDepth()
+    {
+        _parsingDepth++;
+        if (_parsingDepth == TINYXML2_MAX_ELEMENT_DEPTH)
+        {
+            SetError(XML_ELEMENT_DEPTH_EXCEEDED, _parseCurLineNum, "Element nesting is too deep.");
+        }
+    }
+
+    void XMLDocument::PopDepth()
+    {
+        TIXMLASSERT(_parsingDepth > 0);
+        --_parsingDepth;
+    }
+
+    XMLPrinter::XMLPrinter(FILE *file, bool compact, int depth)
+        : _elementJustOpened(false), _stack(), _firstElement(true), _fp(file), _depth(depth), _textDepth(-1),
+          _processEntities(true), _compactMode(compact), _buffer()
+    {
+        for (int i = 0; i < ENTITY_RANGE; ++i)
+        {
+            _entityFlag[i] = false;
+            _restrictedEntityFlag[i] = false;
+        }
+        for (int i = 0; i < NUM_ENTITIES; ++i)
+        {
+            const char entityValue = entities[i].value;
+            const unsigned char flagIndex = static_cast<unsigned char>(entityValue);
+            TIXMLASSERT(flagIndex < ENTITY_RANGE);
+            _entityFlag[flagIndex] = true;
+        }
+        _restrictedEntityFlag[static_cast<unsigned char>('&')] = true;
+        _restrictedEntityFlag[static_cast<unsigned char>('<')] = true;
+        _restrictedEntityFlag[static_cast<unsigned char>('>')] = true; // not required, but consistency is nice
+        _buffer.Push(0);
+    }
+
+    void XMLPrinter::Print(const char *format, ...)
+    {
+        va_list va;
+        va_start(va, format);
+
+        if (_fp)
+        {
+            vfprintf(_fp, format, va);
+        }
+        else
+        {
+            const int len = TIXML_VSCPRINTF(format, va);
+            // Close out and re-start the va-args
+            va_end(va);
+            TIXMLASSERT(len >= 0);
+            va_start(va, format);
+            TIXMLASSERT(_buffer.Size() > 0 && _buffer[_buffer.Size() - 1] == 0);
+            char *p = _buffer.PushArr(len) - 1; // back up over the null terminator.
+            TIXML_VSNPRINTF(p, len + 1, format, va);
+        }
+        va_end(va);
+    }
+
+    void XMLPrinter::Write(const char *data, size_t size)
+    {
+        if (_fp)
+        {
+            fwrite(data, sizeof(char), size, _fp);
+        }
+        else
+        {
+            char *p = _buffer.PushArr(static_cast<int>(size)) - 1; // back up over the null terminator.
+            memcpy(p, data, size);
+            p[size] = 0;
+        }
+    }
+
+    void XMLPrinter::Putc(char ch)
+    {
+        if (_fp)
+        {
+            fputc(ch, _fp);
+        }
+        else
+        {
+            char *p = _buffer.PushArr(sizeof(char)) - 1; // back up over the null terminator.
+            p[0] = ch;
+            p[1] = 0;
+        }
+    }
+
+    void XMLPrinter::PrintSpace(int depth)
+    {
+        for (int i = 0; i < depth; ++i)
+        {
+            Write("    ");
+        }
+    }
+
+    void XMLPrinter::PrintString(const char *p, bool restricted)
+    {
+        // Look for runs of bytes between entities to print.
+        const char *q = p;
+
+        if (_processEntities)
+        {
+            const bool *flag = restricted ? _restrictedEntityFlag : _entityFlag;
+            while (*q)
+            {
+                TIXMLASSERT(p <= q);
+                // Remember, char is sometimes signed. (How many times has that bitten me?)
+                if (*q > 0 && *q < ENTITY_RANGE)
+                {
+                    // Check for entities. If one is found, flush
+                    // the stream up until the entity, write the
+                    // entity, and keep looking.
+                    if (flag[static_cast<unsigned char>(*q)])
+                    {
+                        while (p < q)
+                        {
+                            const size_t delta = q - p;
+                            const int toPrint = (INT_MAX < delta) ? INT_MAX : static_cast<int>(delta);
+                            Write(p, toPrint);
+                            p += toPrint;
+                        }
+                        bool entityPatternPrinted = false;
+                        for (int i = 0; i < NUM_ENTITIES; ++i)
+                        {
+                            if (entities[i].value == *q)
+                            {
+                                Putc('&');
+                                Write(entities[i].pattern, entities[i].length);
+                                Putc(';');
+                                entityPatternPrinted = true;
+                                break;
+                            }
+                        }
+                        if (!entityPatternPrinted)
+                        {
+                            // TIXMLASSERT( entityPatternPrinted ) causes gcc -Wunused-but-set-variable in release
+                            TIXMLASSERT(false);
+                        }
+                        ++p;
+                    }
+                }
+                ++q;
+                TIXMLASSERT(p <= q);
+            }
+            // Flush the remaining string. This will be the entire
+            // string if an entity wasn't found.
+            if (p < q)
+            {
+                const size_t delta = q - p;
+                const int toPrint = (INT_MAX < delta) ? INT_MAX : static_cast<int>(delta);
+                Write(p, toPrint);
+            }
+        }
+        else
+        {
+            Write(p);
+        }
+    }
+
+    void XMLPrinter::PushHeader(bool writeBOM, bool writeDec)
+    {
+        if (writeBOM)
+        {
+            static const unsigned char bom[] = {TIXML_UTF_LEAD_0, TIXML_UTF_LEAD_1, TIXML_UTF_LEAD_2, 0};
+            Write(reinterpret_cast<const char *>(bom));
+        }
+        if (writeDec)
+        {
+            PushDeclaration("xml version=\"1.0\"");
+        }
+    }
+
+    void XMLPrinter::OpenElement(const char *name, bool compactMode)
+    {
+        SealElementIfJustOpened();
+        _stack.Push(name);
+
+        if (_textDepth < 0 && !_firstElement && !compactMode)
+        {
+            Putc('\n');
+        }
+        if (!compactMode)
+        {
+            PrintSpace(_depth);
+        }
+
+        Write("<");
+        Write(name);
+
+        _elementJustOpened = true;
+        _firstElement = false;
+        ++_depth;
+    }
+
+    void XMLPrinter::PushAttribute(const char *name, const char *value)
+    {
+        TIXMLASSERT(_elementJustOpened);
+        Putc(' ');
+        Write(name);
+        Write("=\"");
+        PrintString(value, false);
+        Putc('\"');
+    }
+
+    void XMLPrinter::PushAttribute(const char *name, int v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        PushAttribute(name, buf);
+    }
+
+    void XMLPrinter::PushAttribute(const char *name, unsigned v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        PushAttribute(name, buf);
+    }
+
+    void XMLPrinter::PushAttribute(const char *name, int64_t v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        PushAttribute(name, buf);
+    }
+
+    void XMLPrinter::PushAttribute(const char *name, uint64_t v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        PushAttribute(name, buf);
+    }
+
+    void XMLPrinter::PushAttribute(const char *name, bool v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        PushAttribute(name, buf);
+    }
+
+    void XMLPrinter::PushAttribute(const char *name, double v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        PushAttribute(name, buf);
+    }
+
+    void XMLPrinter::CloseElement(bool compactMode)
+    {
+        --_depth;
+        const char *name = _stack.Pop();
+
+        if (_elementJustOpened)
+        {
+            Write("/>");
+        }
+        else
+        {
+            if (_textDepth < 0 && !compactMode)
+            {
+                Putc('\n');
+                PrintSpace(_depth);
+            }
+            Write("</");
+            Write(name);
+            Write(">");
+        }
+
+        if (_textDepth == _depth)
+        {
+            _textDepth = -1;
+        }
+        if (_depth == 0 && !compactMode)
+        {
+            Putc('\n');
+        }
+        _elementJustOpened = false;
+    }
+
+    void XMLPrinter::SealElementIfJustOpened()
+    {
+        if (!_elementJustOpened)
+        {
+            return;
+        }
+        _elementJustOpened = false;
+        Putc('>');
+    }
+
+    void XMLPrinter::PushText(const char *text, bool cdata)
+    {
+        _textDepth = _depth - 1;
+
+        SealElementIfJustOpened();
+        if (cdata)
+        {
+            Write("<![CDATA[");
+            Write(text);
+            Write("]]>");
+        }
+        else
+        {
+            PrintString(text, true);
+        }
+    }
+
+    void XMLPrinter::PushText(int64_t value)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(value, buf, BUF_SIZE);
+        PushText(buf, false);
+    }
+
+    void XMLPrinter::PushText(uint64_t value)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(value, buf, BUF_SIZE);
+        PushText(buf, false);
+    }
+
+    void XMLPrinter::PushText(int value)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(value, buf, BUF_SIZE);
+        PushText(buf, false);
+    }
+
+    void XMLPrinter::PushText(unsigned value)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(value, buf, BUF_SIZE);
+        PushText(buf, false);
+    }
+
+    void XMLPrinter::PushText(bool value)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(value, buf, BUF_SIZE);
+        PushText(buf, false);
+    }
+
+    void XMLPrinter::PushText(float value)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(value, buf, BUF_SIZE);
+        PushText(buf, false);
+    }
+
+    void XMLPrinter::PushText(double value)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(value, buf, BUF_SIZE);
+        PushText(buf, false);
+    }
+
+    void XMLPrinter::PushComment(const char *comment)
+    {
+        SealElementIfJustOpened();
+        if (_textDepth < 0 && !_firstElement && !_compactMode)
+        {
+            Putc('\n');
+            PrintSpace(_depth);
+        }
+        _firstElement = false;
+
+        Write("<!--");
+        Write(comment);
+        Write("-->");
+    }
+
+    void XMLPrinter::PushDeclaration(const char *value)
+    {
+        SealElementIfJustOpened();
+        if (_textDepth < 0 && !_firstElement && !_compactMode)
+        {
+            Putc('\n');
+            PrintSpace(_depth);
+        }
+        _firstElement = false;
+
+        Write("<?");
+        Write(value);
+        Write("?>");
+    }
+
+    void XMLPrinter::PushUnknown(const char *value)
+    {
+        SealElementIfJustOpened();
+        if (_textDepth < 0 && !_firstElement && !_compactMode)
+        {
+            Putc('\n');
+            PrintSpace(_depth);
+        }
+        _firstElement = false;
+
+        Write("<!");
+        Write(value);
+        Putc('>');
+    }
+
+    bool XMLPrinter::VisitEnter(const XMLDocument &doc)
+    {
+        _processEntities = doc.ProcessEntities();
+        if (doc.HasBOM())
+        {
+            PushHeader(true, false);
+        }
         return true;
     }
-};
 
-XMLError XMLDocument::LoadFile( FILE* fp )
-{
-    Clear();
-
-    fseek( fp, 0, SEEK_SET );
-    if ( fgetc( fp ) == EOF && ferror( fp ) != 0 ) {
-        SetError( XML_ERROR_FILE_READ_ERROR, 0, 0 );
-        return _errorID;
-    }
-
-    fseek( fp, 0, SEEK_END );
-    const long filelength = ftell( fp );
-    fseek( fp, 0, SEEK_SET );
-    if ( filelength == -1L ) {
-        SetError( XML_ERROR_FILE_READ_ERROR, 0, 0 );
-        return _errorID;
-    }
-    TIXMLASSERT( filelength >= 0 );
-
-    if ( !LongFitsIntoSizeTMinusOne<>::Fits( filelength ) ) {
-        // Cannot handle files which won't fit in buffer together with null terminator
-        SetError( XML_ERROR_FILE_READ_ERROR, 0, 0 );
-        return _errorID;
-    }
-
-    if ( filelength == 0 ) {
-        SetError( XML_ERROR_EMPTY_DOCUMENT, 0, 0 );
-        return _errorID;
-    }
-
-    const size_t size = filelength;
-    TIXMLASSERT( _charBuffer == 0 );
-    _charBuffer = new char[size+1];
-    const size_t read = fread( _charBuffer, 1, size, fp );
-    if ( read != size ) {
-        SetError( XML_ERROR_FILE_READ_ERROR, 0, 0 );
-        return _errorID;
-    }
-
-    _charBuffer[size] = 0;
-
-    Parse();
-    return _errorID;
-}
-
-
-XMLError XMLDocument::SaveFile( const char* filename, bool compact )
-{
-    if ( !filename ) {
-        TIXMLASSERT( false );
-        SetError( XML_ERROR_FILE_COULD_NOT_BE_OPENED, 0, "filename=<null>" );
-        return _errorID;
-    }
-
-    FILE* fp = callfopen( filename, "w" );
-    if ( !fp ) {
-        SetError( XML_ERROR_FILE_COULD_NOT_BE_OPENED, 0, "filename=%s", filename );
-        return _errorID;
-    }
-    SaveFile(fp, compact);
-    fclose( fp );
-    return _errorID;
-}
-
-
-XMLError XMLDocument::SaveFile( FILE* fp, bool compact )
-{
-    // Clear any error from the last save, otherwise it will get reported
-    // for *this* call.
-    ClearError();
-    XMLPrinter stream( fp, compact );
-    Print( &stream );
-    return _errorID;
-}
-
-
-XMLError XMLDocument::Parse( const char* p, size_t len )
-{
-    Clear();
-
-    if ( len == 0 || !p || !*p ) {
-        SetError( XML_ERROR_EMPTY_DOCUMENT, 0, 0 );
-        return _errorID;
-    }
-    if ( len == static_cast<size_t>(-1) ) {
-        len = strlen( p );
-    }
-    TIXMLASSERT( _charBuffer == 0 );
-    _charBuffer = new char[ len+1 ];
-    memcpy( _charBuffer, p, len );
-    _charBuffer[len] = 0;
-
-    Parse();
-    if ( Error() ) {
-        // clean up now essentially dangling memory.
-        // and the parse fail can put objects in the
-        // pools that are dead and inaccessible.
-        DeleteChildren();
-        _elementPool.Clear();
-        _attributePool.Clear();
-        _textPool.Clear();
-        _commentPool.Clear();
-    }
-    return _errorID;
-}
-
-
-void XMLDocument::Print( XMLPrinter* streamer ) const
-{
-    if ( streamer ) {
-        Accept( streamer );
-    }
-    else {
-        XMLPrinter stdoutStreamer( stdout );
-        Accept( &stdoutStreamer );
-    }
-}
-
-
-void XMLDocument::SetError( XMLError error, int lineNum, const char* format, ... )
-{
-    TIXMLASSERT( error >= 0 && error < XML_ERROR_COUNT );
-    _errorID = error;
-    _errorLineNum = lineNum;
-	_errorStr.Reset();
-
-    const size_t BUFFER_SIZE = 1000;
-    char* buffer = new char[BUFFER_SIZE];
-
-    TIXMLASSERT(sizeof(error) <= sizeof(int));
-    TIXML_SNPRINTF(buffer, BUFFER_SIZE, "Error=%s ErrorID=%d (0x%x) Line number=%d", ErrorIDToName(error), int(error), int(error), lineNum);
-
-	if (format) {
-		size_t len = strlen(buffer);
-		TIXML_SNPRINTF(buffer + len, BUFFER_SIZE - len, ": ");
-		len = strlen(buffer);
-
-		va_list va;
-		va_start(va, format);
-		TIXML_VSNPRINTF(buffer + len, BUFFER_SIZE - len, format, va);
-		va_end(va);
-	}
-	_errorStr.SetStr(buffer);
-	delete[] buffer;
-}
-
-
-/*static*/ const char* XMLDocument::ErrorIDToName(XMLError errorID)
-{
-	TIXMLASSERT( errorID >= 0 && errorID < XML_ERROR_COUNT );
-    const char* errorName = _errorNames[errorID];
-    TIXMLASSERT( errorName && errorName[0] );
-    return errorName;
-}
-
-const char* XMLDocument::ErrorStr() const
-{
-	return _errorStr.Empty() ? "" : _errorStr.GetStr();
-}
-
-
-void XMLDocument::PrintError() const
-{
-    printf("%s\n", ErrorStr());
-}
-
-const char* XMLDocument::ErrorName() const
-{
-    return ErrorIDToName(_errorID);
-}
-
-void XMLDocument::Parse()
-{
-    TIXMLASSERT( NoChildren() ); // Clear() must have been called previously
-    TIXMLASSERT( _charBuffer );
-    _parseCurLineNum = 1;
-    _parseLineNum = 1;
-    char* p = _charBuffer;
-    p = XMLUtil::SkipWhiteSpace( p, &_parseCurLineNum );
-    p = const_cast<char*>( XMLUtil::ReadBOM( p, &_writeBOM ) );
-    if ( !*p ) {
-        SetError( XML_ERROR_EMPTY_DOCUMENT, 0, 0 );
-        return;
-    }
-    ParseDeep(p, 0, &_parseCurLineNum );
-}
-
-void XMLDocument::PushDepth()
-{
-	_parsingDepth++;
-	if (_parsingDepth == TINYXML2_MAX_ELEMENT_DEPTH) {
-		SetError(XML_ELEMENT_DEPTH_EXCEEDED, _parseCurLineNum, "Element nesting is too deep." );
-	}
-}
-
-void XMLDocument::PopDepth()
-{
-	TIXMLASSERT(_parsingDepth > 0);
-	--_parsingDepth;
-}
-
-XMLPrinter::XMLPrinter( FILE* file, bool compact, int depth ) :
-    _elementJustOpened( false ),
-    _stack(),
-    _firstElement( true ),
-    _fp( file ),
-    _depth( depth ),
-    _textDepth( -1 ),
-    _processEntities( true ),
-    _compactMode( compact ),
-    _buffer()
-{
-    for( int i=0; i<ENTITY_RANGE; ++i ) {
-        _entityFlag[i] = false;
-        _restrictedEntityFlag[i] = false;
-    }
-    for( int i=0; i<NUM_ENTITIES; ++i ) {
-        const char entityValue = entities[i].value;
-        const unsigned char flagIndex = static_cast<unsigned char>(entityValue);
-        TIXMLASSERT( flagIndex < ENTITY_RANGE );
-        _entityFlag[flagIndex] = true;
-    }
-    _restrictedEntityFlag[static_cast<unsigned char>('&')] = true;
-    _restrictedEntityFlag[static_cast<unsigned char>('<')] = true;
-    _restrictedEntityFlag[static_cast<unsigned char>('>')] = true;	// not required, but consistency is nice
-    _buffer.Push( 0 );
-}
-
-
-void XMLPrinter::Print( const char* format, ... )
-{
-    va_list     va;
-    va_start( va, format );
-
-    if ( _fp ) {
-        vfprintf( _fp, format, va );
-    }
-    else {
-        const int len = TIXML_VSCPRINTF( format, va );
-        // Close out and re-start the va-args
-        va_end( va );
-        TIXMLASSERT( len >= 0 );
-        va_start( va, format );
-        TIXMLASSERT( _buffer.Size() > 0 && _buffer[_buffer.Size() - 1] == 0 );
-        char* p = _buffer.PushArr( len ) - 1;	// back up over the null terminator.
-		TIXML_VSNPRINTF( p, len+1, format, va );
-    }
-    va_end( va );
-}
-
-
-void XMLPrinter::Write( const char* data, size_t size )
-{
-    if ( _fp ) {
-        fwrite ( data , sizeof(char), size, _fp);
-    }
-    else {
-        char* p = _buffer.PushArr( static_cast<int>(size) ) - 1;   // back up over the null terminator.
-        memcpy( p, data, size );
-        p[size] = 0;
-    }
-}
-
-
-void XMLPrinter::Putc( char ch )
-{
-    if ( _fp ) {
-        fputc ( ch, _fp);
-    }
-    else {
-        char* p = _buffer.PushArr( sizeof(char) ) - 1;   // back up over the null terminator.
-        p[0] = ch;
-        p[1] = 0;
-    }
-}
-
-
-void XMLPrinter::PrintSpace( int depth )
-{
-    for( int i=0; i<depth; ++i ) {
-        Write( "    " );
-    }
-}
-
-
-void XMLPrinter::PrintString( const char* p, bool restricted )
-{
-    // Look for runs of bytes between entities to print.
-    const char* q = p;
-
-    if ( _processEntities ) {
-        const bool* flag = restricted ? _restrictedEntityFlag : _entityFlag;
-        while ( *q ) {
-            TIXMLASSERT( p <= q );
-            // Remember, char is sometimes signed. (How many times has that bitten me?)
-            if ( *q > 0 && *q < ENTITY_RANGE ) {
-                // Check for entities. If one is found, flush
-                // the stream up until the entity, write the
-                // entity, and keep looking.
-                if ( flag[static_cast<unsigned char>(*q)] ) {
-                    while ( p < q ) {
-                        const size_t delta = q - p;
-                        const int toPrint = ( INT_MAX < delta ) ? INT_MAX : static_cast<int>(delta);
-                        Write( p, toPrint );
-                        p += toPrint;
-                    }
-                    bool entityPatternPrinted = false;
-                    for( int i=0; i<NUM_ENTITIES; ++i ) {
-                        if ( entities[i].value == *q ) {
-                            Putc( '&' );
-                            Write( entities[i].pattern, entities[i].length );
-                            Putc( ';' );
-                            entityPatternPrinted = true;
-                            break;
-                        }
-                    }
-                    if ( !entityPatternPrinted ) {
-                        // TIXMLASSERT( entityPatternPrinted ) causes gcc -Wunused-but-set-variable in release
-                        TIXMLASSERT( false );
-                    }
-                    ++p;
-                }
-            }
-            ++q;
-            TIXMLASSERT( p <= q );
+    bool XMLPrinter::VisitEnter(const XMLElement &element, const XMLAttribute *attribute)
+    {
+        const XMLElement *parentElem = 0;
+        if (element.Parent())
+        {
+            parentElem = element.Parent()->ToElement();
         }
-        // Flush the remaining string. This will be the entire
-        // string if an entity wasn't found.
-        if ( p < q ) {
-            const size_t delta = q - p;
-            const int toPrint = ( INT_MAX < delta ) ? INT_MAX : static_cast<int>(delta);
-            Write( p, toPrint );
+        const bool compactMode = parentElem ? CompactMode(*parentElem) : _compactMode;
+        OpenElement(element.Name(), compactMode);
+        while (attribute)
+        {
+            PushAttribute(attribute->Name(), attribute->Value());
+            attribute = attribute->Next();
         }
-    }
-    else {
-        Write( p );
-    }
-}
-
-
-void XMLPrinter::PushHeader( bool writeBOM, bool writeDec )
-{
-    if ( writeBOM ) {
-        static const unsigned char bom[] = { TIXML_UTF_LEAD_0, TIXML_UTF_LEAD_1, TIXML_UTF_LEAD_2, 0 };
-        Write( reinterpret_cast< const char* >( bom ) );
-    }
-    if ( writeDec ) {
-        PushDeclaration( "xml version=\"1.0\"" );
-    }
-}
-
-
-void XMLPrinter::OpenElement( const char* name, bool compactMode )
-{
-    SealElementIfJustOpened();
-    _stack.Push( name );
-
-    if ( _textDepth < 0 && !_firstElement && !compactMode ) {
-        Putc( '\n' );
-    }
-    if ( !compactMode ) {
-        PrintSpace( _depth );
+        return true;
     }
 
-    Write ( "<" );
-    Write ( name );
-
-    _elementJustOpened = true;
-    _firstElement = false;
-    ++_depth;
-}
-
-
-void XMLPrinter::PushAttribute( const char* name, const char* value )
-{
-    TIXMLASSERT( _elementJustOpened );
-    Putc ( ' ' );
-    Write( name );
-    Write( "=\"" );
-    PrintString( value, false );
-    Putc ( '\"' );
-}
-
-
-void XMLPrinter::PushAttribute( const char* name, int v )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( v, buf, BUF_SIZE );
-    PushAttribute( name, buf );
-}
-
-
-void XMLPrinter::PushAttribute( const char* name, unsigned v )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( v, buf, BUF_SIZE );
-    PushAttribute( name, buf );
-}
-
-
-void XMLPrinter::PushAttribute(const char* name, int64_t v)
-{
-	char buf[BUF_SIZE];
-	XMLUtil::ToStr(v, buf, BUF_SIZE);
-	PushAttribute(name, buf);
-}
-
-
-void XMLPrinter::PushAttribute(const char* name, uint64_t v)
-{
-	char buf[BUF_SIZE];
-	XMLUtil::ToStr(v, buf, BUF_SIZE);
-	PushAttribute(name, buf);
-}
-
-
-void XMLPrinter::PushAttribute( const char* name, bool v )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( v, buf, BUF_SIZE );
-    PushAttribute( name, buf );
-}
-
-
-void XMLPrinter::PushAttribute( const char* name, double v )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( v, buf, BUF_SIZE );
-    PushAttribute( name, buf );
-}
-
-
-void XMLPrinter::CloseElement( bool compactMode )
-{
-    --_depth;
-    const char* name = _stack.Pop();
-
-    if ( _elementJustOpened ) {
-        Write( "/>" );
-    }
-    else {
-        if ( _textDepth < 0 && !compactMode) {
-            Putc( '\n' );
-            PrintSpace( _depth );
-        }
-        Write ( "</" );
-        Write ( name );
-        Write ( ">" );
+    bool XMLPrinter::VisitExit(const XMLElement &element)
+    {
+        CloseElement(CompactMode(element));
+        return true;
     }
 
-    if ( _textDepth == _depth ) {
-        _textDepth = -1;
+    bool XMLPrinter::Visit(const XMLText &text)
+    {
+        PushText(text.Value(), text.CData());
+        return true;
     }
-    if ( _depth == 0 && !compactMode) {
-        Putc( '\n' );
+
+    bool XMLPrinter::Visit(const XMLComment &comment)
+    {
+        PushComment(comment.Value());
+        return true;
     }
-    _elementJustOpened = false;
-}
 
-
-void XMLPrinter::SealElementIfJustOpened()
-{
-    if ( !_elementJustOpened ) {
-        return;
+    bool XMLPrinter::Visit(const XMLDeclaration &declaration)
+    {
+        PushDeclaration(declaration.Value());
+        return true;
     }
-    _elementJustOpened = false;
-    Putc( '>' );
-}
 
-
-void XMLPrinter::PushText( const char* text, bool cdata )
-{
-    _textDepth = _depth-1;
-
-    SealElementIfJustOpened();
-    if ( cdata ) {
-        Write( "<![CDATA[" );
-        Write( text );
-        Write( "]]>" );
+    bool XMLPrinter::Visit(const XMLUnknown &unknown)
+    {
+        PushUnknown(unknown.Value());
+        return true;
     }
-    else {
-        PrintString( text, true );
-    }
-}
 
-
-void XMLPrinter::PushText( int64_t value )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( value, buf, BUF_SIZE );
-    PushText( buf, false );
-}
-
-
-void XMLPrinter::PushText( uint64_t value )
-{
-	char buf[BUF_SIZE];
-	XMLUtil::ToStr(value, buf, BUF_SIZE);
-	PushText(buf, false);
-}
-
-
-void XMLPrinter::PushText( int value )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( value, buf, BUF_SIZE );
-    PushText( buf, false );
-}
-
-
-void XMLPrinter::PushText( unsigned value )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( value, buf, BUF_SIZE );
-    PushText( buf, false );
-}
-
-
-void XMLPrinter::PushText( bool value )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( value, buf, BUF_SIZE );
-    PushText( buf, false );
-}
-
-
-void XMLPrinter::PushText( float value )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( value, buf, BUF_SIZE );
-    PushText( buf, false );
-}
-
-
-void XMLPrinter::PushText( double value )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( value, buf, BUF_SIZE );
-    PushText( buf, false );
-}
-
-
-void XMLPrinter::PushComment( const char* comment )
-{
-    SealElementIfJustOpened();
-    if ( _textDepth < 0 && !_firstElement && !_compactMode) {
-        Putc( '\n' );
-        PrintSpace( _depth );
-    }
-    _firstElement = false;
-
-    Write( "<!--" );
-    Write( comment );
-    Write( "-->" );
-}
-
-
-void XMLPrinter::PushDeclaration( const char* value )
-{
-    SealElementIfJustOpened();
-    if ( _textDepth < 0 && !_firstElement && !_compactMode) {
-        Putc( '\n' );
-        PrintSpace( _depth );
-    }
-    _firstElement = false;
-
-    Write( "<?" );
-    Write( value );
-    Write( "?>" );
-}
-
-
-void XMLPrinter::PushUnknown( const char* value )
-{
-    SealElementIfJustOpened();
-    if ( _textDepth < 0 && !_firstElement && !_compactMode) {
-        Putc( '\n' );
-        PrintSpace( _depth );
-    }
-    _firstElement = false;
-
-    Write( "<!" );
-    Write( value );
-    Putc( '>' );
-}
-
-
-bool XMLPrinter::VisitEnter( const XMLDocument& doc )
-{
-    _processEntities = doc.ProcessEntities();
-    if ( doc.HasBOM() ) {
-        PushHeader( true, false );
-    }
-    return true;
-}
-
-
-bool XMLPrinter::VisitEnter( const XMLElement& element, const XMLAttribute* attribute )
-{
-    const XMLElement* parentElem = 0;
-    if ( element.Parent() ) {
-        parentElem = element.Parent()->ToElement();
-    }
-    const bool compactMode = parentElem ? CompactMode( *parentElem ) : _compactMode;
-    OpenElement( element.Name(), compactMode );
-    while ( attribute ) {
-        PushAttribute( attribute->Name(), attribute->Value() );
-        attribute = attribute->Next();
-    }
-    return true;
-}
-
-
-bool XMLPrinter::VisitExit( const XMLElement& element )
-{
-    CloseElement( CompactMode(element) );
-    return true;
-}
-
-
-bool XMLPrinter::Visit( const XMLText& text )
-{
-    PushText( text.Value(), text.CData() );
-    return true;
-}
-
-
-bool XMLPrinter::Visit( const XMLComment& comment )
-{
-    PushComment( comment.Value() );
-    return true;
-}
-
-bool XMLPrinter::Visit( const XMLDeclaration& declaration )
-{
-    PushDeclaration( declaration.Value() );
-    return true;
-}
-
-
-bool XMLPrinter::Visit( const XMLUnknown& unknown )
-{
-    PushUnknown( unknown.Value() );
-    return true;
-}
-
-}   // namespace tinyxml2
+} // namespace tinyxml2

--- a/source/http/HttpConnection.cpp
+++ b/source/http/HttpConnection.cpp
@@ -154,9 +154,6 @@ namespace Aws
             std::shared_ptr<HttpClientStream> HttpClientConnection::NewClientStream(
                 const HttpRequestOptions &requestOptions) noexcept
             {
-                AWS_ASSERT(requestOptions.onIncomingHeaders);
-                AWS_ASSERT(requestOptions.onStreamComplete);
-
                 aws_http_make_request_options options;
                 AWS_ZERO_STRUCT(options);
                 options.self_size = sizeof(aws_http_make_request_options);
@@ -221,7 +218,11 @@ namespace Aws
                 void *userData) noexcept
             {
                 auto callbackData = static_cast<ClientStreamCallbackData *>(userData);
-                callbackData->stream->m_onIncomingHeaders(*callbackData->stream, headerBlock, headerArray, numHeaders);
+                if (callbackData->stream->m_onIncomingHeaders)
+                {
+                    callbackData->stream->m_onIncomingHeaders(
+                        *callbackData->stream, headerBlock, headerArray, numHeaders);
+                }
 
                 return AWS_OP_SUCCESS;
             }
@@ -259,7 +260,10 @@ namespace Aws
             void HttpStream::s_onStreamComplete(struct aws_http_stream *, int errorCode, void *userData) noexcept
             {
                 auto callbackData = static_cast<ClientStreamCallbackData *>(userData);
-                callbackData->stream->m_onStreamComplete(*callbackData->stream, errorCode);
+                if (callbackData->stream->m_onStreamComplete)
+                {
+                    callbackData->stream->m_onStreamComplete(*callbackData->stream, errorCode);
+                }
 
                 callbackData->stream = nullptr;
                 Delete(callbackData, callbackData->allocator);


### PR DESCRIPTION
Multipart Upload and Download

*Multipart Upload and Download Changes/Notes:*
* Adding support to the canary for uploading large objects.  PutObjectMultipart is the user-facing API method.
* Adding support to the canary for downloading large objects.  GetObjectMultipart is the user-facing API method.
* MultipartTransferState is a holder for the current state of a transfer.  Several of the members are meant to be only written during the creation of the state, and then immutable from then on.  Other members which can be mutated are meant to be thread safe and have an associated mutex.
* MultipartTransferProcessor manages a queue of MultipartTransferStates.  (S3ObjectTransport has two of these, one for uploading and one for downloading.)  It has an allotted amount of "streams" for processing object parts.  Streams are currently consumed at two possible times: when something is pushed into the queue, or when something finishes being processed (ie: a part finished uploading or downloading).  When the number of parts to be processed exceeds a threshold, it will divide the workload among multiple tasks. 
* Several of the constants (including S3ObjectTransport::MaxPartSizeBytes and S3ObjectTransport::MaxStreams) are currently set to test friendly values, and will later be changed to their real world values.
* Adding dimensions to CloudWatch metrics for OS Name, Tool Name, and EC2 Instance Type.  For Windows, OS name simply returns "windows".  There appear to be a couple of API's for getting more information than this (GetVersion, GetVersionEx), but they are deprecated.  Non-deprecated functionality seems to be more centered around validating if your OS is past a certain generation: https://docs.microsoft.com/en-us/windows/win32/sysinfo/version-helper-apis.  Because we are planning to actually collect all of our metrics in a Linux environment, I didn't want to rabbit hole too much on this right now.
* Hooking up measurement of large objects and restructuring the surrounding code.
* Adding some CLI arguments for changing various metric dimensions, as well as limiting the amount of run time of the canary.
* More could be done to clean up some of the main execution logic, such as placing a lot of the currently shared state into a singleton.  This felt like feature creep for this particular commit, and in the nice-to-have category, so I have not done this yet.

*Some Notes from Previous Review:*
* Retries aren't currently implemented, but should now be feasible.  Whenever uploading (S3ObjectTransport.cpp:290) or downloading a part (S3ObjectTransport.cpp:487) there is a finished-callback that we use to tell the processor that we are done with the current part.  We should be able to add an error argument to this callback that tells the processor to re-queue this part.
* Cancelling isn't user facing at the moment, but we could likely alter the MultipartTransferState to make sense as a user-facing class and add a Cancel method to it.  This could then be returned by PutObjectMultipart/GetObjectMultipart.  We could probably also add a similar class (or possibly repurpose "MultipartTransferState" to "TransferState") for normal PutObject/GetObject.
* For the memory leak concern of the input streams being passed into PutObject and returned by the callback for PutObjectMultipart: these are getting cleaned up in the HttpMessage destructor.  It's a little bit hidden, but they get set on a request via aws_http_message_set_body_stream, and the HttpRequest class inherits from HttpMessage.

*Other Important Changes/Notes:*
* Adding tinyxml2 to the aws-crt-cpp library.
* Added logging to the aws-crt-cpp library.  Please validate that I did so correctly!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
