### PR TITLE
Do not export cJSON symbols in DLLs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,8 @@ endif()
 
 add_library(${PROJECT_NAME} ${AWS_CRT_CPP_SRC})
 
+target_compile_definitions(${PROJECT_NAME} PRIVATE -DCJSON_HIDE_SYMBOLS)
+
 if (BUILD_SHARED_LIBS)
     target_compile_definitions(${PROJECT_NAME} PUBLIC -DAWS_CRT_CPP_USE_IMPORT_EXPORT)
     target_compile_definitions(${PROJECT_NAME} PRIVATE -DAWS_CRT_CPP_EXPORTS)


### PR DESCRIPTION
If you use aws-crt-cpp in your code which you compile into a DLL, it gets 148 exported internal aws-crt-cpp symbols.

```
>dumpbin.exe /exports foo.dll
[...]
    ordinal hint RVA      name

          1    0 00007860 ?cJSON_AddArrayToObject@Aws@@YGPAUcJSON@1@QAU21@QBD@Z = @ILT+26715(?cJSON_AddArrayToObject@Aws@@YGPAUcJSON@1@QAU21@QBD@Z)
[...]
        148   93 000047D2 _cJSON_malloc@4 = @ILT+14285(_cJSON_malloc@4)
```

Steps to reproduce:

   1. build aws-crt-cpp
   2. use aws-crt-cpp in your DLL
       ```
       find_package(aws-crt-cpp REQUIRED)
	   add_library(foo SHARED)
       ```

The reason for the problem is that cJSON by default exports all its symbols into any DLL it is used in.

This PR gets rid of half of the exported symbols by fixing the place in aws-crt-cpp where cJSON is used to suppress exporting its symbols. There is a [similar problem](https://github.com/awslabs/aws-c-auth/pull/57) in aws-c-auth.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
