### PR TITLE
Bootstrap shutdown

### DIFF
--- a/include/aws/crt/io/Bootstrap.h
+++ b/include/aws/crt/io/Bootstrap.h
@@ -22,6 +22,8 @@
 #include <aws/io/channel_bootstrap.h>
 #include <aws/io/host_resolver.h>
 
+#include <future>
+
 namespace Aws
 {
     namespace Crt
@@ -44,10 +46,17 @@ namespace Aws
                 operator bool() const noexcept;
                 int LastError() const noexcept;
 
+                /**
+                 * Returns a future that will be set after ClientBootstrap is destroyed,
+                 * and all of its behind-the-scenes resources finish shutting down.
+                 */
+                std::future<void> GetShutdownFuture();
+
                 aws_client_bootstrap *GetUnderlyingHandle() const noexcept;
 
               private:
                 aws_client_bootstrap *m_bootstrap;
+                struct ClientBootstrapCallbackData *m_callbackData;
                 int m_lastError;
             };
         } // namespace Io

--- a/tests/ChannelBootstrapTest.cpp
+++ b/tests/ChannelBootstrapTest.cpp
@@ -15,6 +15,7 @@
 #include <aws/crt/Api.h>
 #include <aws/testing/aws_test_harness.h>
 
+#include <future>
 #include <utility>
 
 static int s_TestClientBootstrapResourceSafety(struct aws_allocator *allocator, void *)
@@ -29,16 +30,17 @@ static int s_TestClientBootstrapResourceSafety(struct aws_allocator *allocator, 
     ASSERT_TRUE(defaultHostResolver);
     ASSERT_NOT_NULL(defaultHostResolver.GetUnderlyingHandle());
 
-    std::future<void> shutdownFuture;
+    std::promise<void> bootstrapShutdownPromise;
+    std::future<void> bootstrapShutdownFuture = bootstrapShutdownPromise.get_future();
     {
         Aws::Crt::Io::ClientBootstrap clientBootstrap(eventLoopGroup, defaultHostResolver, allocator);
         ASSERT_TRUE(clientBootstrap);
         ASSERT_NOT_NULL(clientBootstrap.GetUnderlyingHandle());
-        shutdownFuture = clientBootstrap.GetShutdownFuture();
+        clientBootstrap.EnableBlockingShutdown();
+        clientBootstrap.SetShutdownCompleteCallback([&]() { bootstrapShutdownPromise.set_value(); });
     }
 
-    // wait until shutdown completes
-    ASSERT_TRUE(std::future_status::ready == shutdownFuture.wait_for(std::chrono::seconds(10)));
+    ASSERT_TRUE(std::future_status::ready == bootstrapShutdownFuture.wait_for(std::chrono::seconds(10)));
 
     return AWS_ERROR_SUCCESS;
 }

--- a/tests/CredentialsTest.cpp
+++ b/tests/CredentialsTest.cpp
@@ -149,6 +149,7 @@ static int s_TestProviderImdsGet(struct aws_allocator *allocator, void *ctx)
 
         Aws::Crt::Io::ClientBootstrap clientBootstrap(eventLoopGroup, defaultHostResolver, allocator);
         ASSERT_TRUE(clientBootstrap);
+        clientBootstrap.EnableBlockingShutdown();
 
         CredentialsProviderImdsConfig config;
         config.Bootstrap = &clientBootstrap;
@@ -178,6 +179,7 @@ static int s_TestProviderDefaultChainGet(struct aws_allocator *allocator, void *
 
         Aws::Crt::Io::ClientBootstrap clientBootstrap(eventLoopGroup, defaultHostResolver, allocator);
         ASSERT_TRUE(clientBootstrap);
+        clientBootstrap.EnableBlockingShutdown();
 
         CredentialsProviderChainDefaultConfig config;
         config.Bootstrap = &clientBootstrap;

--- a/tests/HttpClientTest.cpp
+++ b/tests/HttpClientTest.cpp
@@ -99,6 +99,7 @@ static int s_TestHttpDownloadNoBackPressure(struct aws_allocator *allocator, voi
 
     Aws::Crt::Io::ClientBootstrap clientBootstrap(eventLoopGroup, defaultHostResolver, allocator);
     ASSERT_TRUE(clientBootstrap);
+    clientBootstrap.EnableBlockingShutdown();
 
     std::shared_ptr<Http::HttpClientConnection> connection(nullptr);
     bool errorOccured = true;
@@ -232,6 +233,7 @@ static int s_TestHttpStreamUnActivated(struct aws_allocator *allocator, void *ct
 
     Aws::Crt::Io::ClientBootstrap clientBootstrap(eventLoopGroup, defaultHostResolver, allocator);
     ASSERT_TRUE(clientBootstrap);
+    clientBootstrap.EnableBlockingShutdown();
 
     std::shared_ptr<Http::HttpClientConnection> connection(nullptr);
     bool errorOccured = true;

--- a/tests/IotServiceTest.cpp
+++ b/tests/IotServiceTest.cpp
@@ -67,6 +67,7 @@ static int s_TestIotPublishSubscribe(Aws::Crt::Allocator *allocator, void *ctx)
 
     Aws::Crt::Io::ClientBootstrap clientBootstrap(eventLoopGroup, defaultHostResolver, allocator);
     ASSERT_TRUE(allocator);
+    clientBootstrap.EnableBlockingShutdown();
 
     Aws::Crt::Mqtt::MqttClient mqttClient(clientBootstrap, allocator);
     ASSERT_TRUE(mqttClient);

--- a/tests/MqttClientTest.cpp
+++ b/tests/MqttClientTest.cpp
@@ -37,6 +37,7 @@ static int s_TestMqttClientResourceSafety(Aws::Crt::Allocator *allocator, void *
 
     Aws::Crt::Io::ClientBootstrap clientBootstrap(eventLoopGroup, defaultHostResolver, allocator);
     ASSERT_TRUE(allocator);
+    clientBootstrap.EnableBlockingShutdown();
 
     Aws::Crt::Mqtt::MqttClient mqttClient(clientBootstrap, allocator);
     ASSERT_TRUE(mqttClient);

--- a/tests/Sigv4SigningTest.cpp
+++ b/tests/Sigv4SigningTest.cpp
@@ -136,6 +136,7 @@ static int s_Sigv4SigningTestCreateDestroy(struct aws_allocator *allocator, void
 
         Aws::Crt::Io::ClientBootstrap clientBootstrap(eventLoopGroup, defaultHostResolver, allocator);
         ASSERT_TRUE(clientBootstrap);
+        clientBootstrap.EnableBlockingShutdown();
 
         CredentialsProviderChainDefaultConfig config;
         config.Bootstrap = &clientBootstrap;
@@ -164,6 +165,7 @@ static int s_Sigv4SigningTestSimple(struct aws_allocator *allocator, void *ctx)
 
         Aws::Crt::Io::ClientBootstrap clientBootstrap(eventLoopGroup, defaultHostResolver, allocator);
         ASSERT_TRUE(clientBootstrap);
+        clientBootstrap.EnableBlockingShutdown();
 
         CredentialsProviderChainDefaultConfig config;
         config.Bootstrap = &clientBootstrap;


### PR DESCRIPTION
Allow user to know when `ClientBootstrap` is done shutting down its behind-the-scenes resources.

User may register a `std::function<void()>` that fires upon shutdown complete. I considered offering a `std::future` to users, but realized you can only do blocking wait()/get() operations on a c++ future, you can't register a callback to fire (a feature available in Python and Java's future primitives). So if a user wants to use `std::future` they can hook that up themselves with the callback (I did this in a test).

Also added an `EnableBlockingShutdown()` function. I was looking around at how async-shutdown was handled in other `aws-crt-cpp` classes and saw this feature on the `HttpClientConnectionManager`. It's simplifies things when the IO classes are created on the main thread's stack (all of our tests and samples).

I chose to make these functions you call on the constructed class, rather than constructor arguments, or fields in an "Options" struct for 2 reasons: 1) This class wasn't using an Options struct before, so it felt weird to add one now. 2) If these were overloaded constructor args, I feared a user would enable the "blocking shutdown" by copy/pasting a constructor with `..., true, ...` in it and later have no idea why they occasionally dead-locked.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
