### PR TITLE
Support STATIC_CRT setting like aws-c-* libraries do

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,8 +194,13 @@ set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD ${CMAKE_CXX_STANDA
 
 aws_prepare_symbol_visibility_args(${PROJECT_NAME} "AWS_CRT_CPP")
 
-#set warnings
+#set warnings and runtime library
 if (MSVC)
+    if(STATIC_CRT)
+        target_compile_options(${PROJECT_NAME} PRIVATE "/MT$<$<CONFIG:Debug>:d>")
+    else()
+        target_compile_options(${PROJECT_NAME} PRIVATE "/MD$<$<CONFIG:Debug>:d>")
+    endif()
     target_compile_options(${PROJECT_NAME} PRIVATE /W4 /WX /wd4068)
 else ()
     target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wno-long-long -pedantic -Werror)

--- a/bin/elasticurl_cpp/CMakeLists.txt
+++ b/bin/elasticurl_cpp/CMakeLists.txt
@@ -12,8 +12,13 @@ add_executable(${ELASTICURL_CPP_PROJECT_NAME} ${ELASTICURL_CPP_SRC})
 set_target_properties(${ELASTICURL_CPP_PROJECT_NAME} PROPERTIES LINKER_LANGUAGE CXX)
 set_target_properties(${ELASTICURL_CPP_PROJECT_NAME} PROPERTIES CXX_STANDARD ${CMAKE_CXX_STANDARD})
 
-#set warnings
+#set warnings and runtime library
 if (MSVC)
+    if(STATIC_CRT)
+        target_compile_options(${PROJECT_NAME} PRIVATE "/MT$<$<CONFIG:Debug>:d>")
+    else()
+        target_compile_options(${PROJECT_NAME} PRIVATE "/MD$<$<CONFIG:Debug>:d>")
+    endif()
     target_compile_options(${ELASTICURL_CPP_PROJECT_NAME} PRIVATE /W4 /WX)
 else ()
     target_compile_options(${ELASTICURL_CPP_PROJECT_NAME} PRIVATE -Wall -Wno-long-long -pedantic -Werror)


### PR DESCRIPTION
Currently aws-crt-cpp links with the dynamic runtime library on Windows. Trying to use the option `-DSTATIC_CRT=TRUE` produces a library with mixed runtimes and causes errors when trying to link it into a program. This is because the C parts use the static runtime as expected, but the C++ parts still use the default dynamic runtime.

This commit adds support for `STATIC_CRT` setting to aws-crt-cpp. A complementary commit (awslabs/aws-c-common#638) into aws-c-common is needed to make also the tests compile properly after this change.

----
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
