### PR TITLE
Exposing set minimum TLS version

### DIFF
--- a/include/aws/crt/io/TlsOptions.h
+++ b/include/aws/crt/io/TlsOptions.h
@@ -121,6 +121,12 @@ namespace Aws
                 void SetVerifyPeer(bool verifyPeer) noexcept;
 
                 /**
+                 * Sets the minimum TLS version allowed.
+                 * @param minimumTlsVersion: The minimum TLS version.
+                 */
+                void SetMinimumTlsVersion(aws_tls_versions minimumTlsVersion);
+
+                /**
                  * Overrides the default system trust store.
                  * @param caPath: Path to directory containing trusted certificates, which will overrides the
                  * default trust store. Only useful on Unix style systems where all anchors are stored in a directory

--- a/include/aws/iot/MqttClient.h
+++ b/include/aws/iot/MqttClient.h
@@ -214,6 +214,8 @@ namespace Aws
              */
             MqttClientConnectionConfigBuilder &WithTcpKeepAliveMaxProbes(uint16_t maxProbes) noexcept;
 
+            MqttClientConnectionConfigBuilder &WithMinimumTlsVersion(aws_tls_versions minimumTlsVersion) noexcept;
+
             /**
              * Builds a client configuration object from the set options.
              */

--- a/source/io/TlsOptions.cpp
+++ b/source/io/TlsOptions.cpp
@@ -128,6 +128,12 @@ namespace Aws
                 aws_tls_ctx_options_set_verify_peer(&m_options, verify_peer);
             }
 
+            void TlsContextOptions::SetMinimumTlsVersion(aws_tls_versions minimumTlsVersion)
+            {
+                AWS_ASSERT(m_isInit);
+                aws_tls_ctx_options_set_minimum_tls_version(&m_options, minimumTlsVersion);
+            }
+
             bool TlsContextOptions::OverrideDefaultTrustStore(const char *caPath, const char *caFile) noexcept
             {
                 AWS_ASSERT(m_isInit);

--- a/source/iot/MqttClient.cpp
+++ b/source/iot/MqttClient.cpp
@@ -250,6 +250,12 @@ namespace Aws
             return *this;
         }
 
+        MqttClientConnectionConfigBuilder &MqttClientConnectionConfigBuilder::WithMinimumTlsVersion(aws_tls_versions minimumTlsVersion) noexcept
+        {
+            m_contextOptions.SetMinimumTlsVersion(minimumTlsVersion);
+            return *this;
+        }
+
         MqttClientConnectionConfig MqttClientConnectionConfigBuilder::Build() noexcept
         {
             if (!m_isGood)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-iot-device-sdk-cpp-v2/issues/118

*Description of changes:*
Hooking up functionality to set minimum TLS version in a couple of places.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
