### PR TITLE
OSX TLS ReadMe Change

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ C++ wrapper around the aws-c-* libraries. Provides Cross-Platform Transport Prot
 
 More protocols and utilities are coming soon, so stay tuned.
 
+### OSX-Only TLS Behavior
+
+Please note that on OSX, once a private key is used with a certificate, that certificate-key pair is imported into the OSX Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programatically.
+
 ## Building
 
 The C99 libraries are already included for your convenience as submodules. If you would like to have us build them

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ C++ wrapper around the aws-c-* libraries. Provides Cross-Platform Transport Prot
 
 More protocols and utilities are coming soon, so stay tuned.
 
-### OSX-Only TLS Behavior
+### OSX Only TLS Behavior
 
-Please note that on OSX, once a private key is used with a certificate, that certificate-key pair is imported into the OSX Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programatically.
+Please note that on OSX, once a private key is used with a certificate, that certificate-key pair is imported into the OSX Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ C++ wrapper around the aws-c-* libraries. Provides Cross-Platform Transport Prot
 
 More protocols and utilities are coming soon, so stay tuned.
 
-### OSX Only TLS Behavior
+### OSX-Only TLS Behavior
 
 Please note that on OSX, once a private key is used with a certificate, that certificate-key pair is imported into the OSX Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ C++ wrapper around the aws-c-* libraries. Provides Cross-Platform Transport Prot
 
 More protocols and utilities are coming soon, so stay tuned.
 
-### OSX-Only TLS Behavior
+### Mac-Only TLS Behavior
 
-Please note that on OSX, once a private key is used with a certificate, that certificate-key pair is imported into the OSX Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.
+Please note that on Mac, once a private key is used with a certificate, that certificate-key pair is imported into the Mac Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ More protocols and utilities are coming soon, so stay tuned.
 
 ### Mac-Only TLS Behavior
 
-Please note that on Mac, once a private key is used with a certificate, that certificate-key pair is imported into the Mac Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.
+Please note that on Mac, once a private key is used with a certificate, that certificate-key pair is imported into the Mac Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.  When a stored private key from the Keychain is used, the following will be logged at the "info" log level:
+
+```
+static: certificate has an existing certificate-key pair that was previously imported into the Keychain.  Using key from Keychain instead of the one provided.
+```
 
 ## Building
 


### PR DESCRIPTION
*Description of changes:*
Adding OSX TLS Keychain information to README.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
