### PR TITLE
Crash fix caused by passing null into a shared_ptr reset

### DIFF
--- a/source/io/TlsOptions.cpp
+++ b/source/io/TlsOptions.cpp
@@ -258,11 +258,21 @@ namespace Aws
             {
                 if (mode == TlsMode::CLIENT)
                 {
-                    m_ctx.reset(aws_tls_client_ctx_new(allocator, &options.m_options), aws_tls_ctx_destroy);
+                    aws_tls_ctx *underlying_tls_ctx = aws_tls_client_ctx_new(allocator, &options.m_options);
+
+                    if (underlying_tls_ctx != NULL)
+                    {
+                        m_ctx.reset(underlying_tls_ctx, aws_tls_ctx_destroy);
+                    }
                 }
                 else
                 {
-                    m_ctx.reset(aws_tls_server_ctx_new(allocator, &options.m_options), aws_tls_ctx_destroy);
+                    aws_tls_ctx *underlying_tls_ctx = aws_tls_server_ctx_new(allocator, &options.m_options);
+
+                    if (underlying_tls_ctx != NULL)
+                    {
+                        m_ctx.reset(underlying_tls_ctx, aws_tls_ctx_destroy);
+                    }
                 }
 
                 if (!m_ctx)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-iot-device-sdk-cpp-v2/issues/145

*Description of changes:*
In the case that a TLS-context-new function returns null, a null pointer passed into a shared_ptr via reset causes a strong reference to null pointer.  This gets passed into aws_tls_ctx_destroy on clean_up, where it is dereferenced, causing a crash.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
