### PR TITLE
add refcount for HttpMessage and remove ownMessage

### DIFF
--- a/include/aws/crt/http/HttpRequestResponse.h
+++ b/include/aws/crt/http/HttpRequestResponse.h
@@ -59,12 +59,11 @@ namespace Aws
                 struct aws_http_message *GetUnderlyingMessage() const noexcept { return m_message; }
 
               protected:
-                HttpMessage(Allocator *allocator, struct aws_http_message *message, bool ownsMessage = true) noexcept;
+                HttpMessage(Allocator *allocator, struct aws_http_message *message) noexcept;
 
                 Allocator *m_allocator;
                 struct aws_http_message *m_message;
                 std::shared_ptr<Aws::Crt::Io::InputStream> m_bodyStream;
-                bool m_ownsMessage;
             };
 
             /**

--- a/source/http/HttpRequestResponse.cpp
+++ b/source/http/HttpRequestResponse.cpp
@@ -16,14 +16,12 @@ namespace Aws
         namespace Http
         {
 
-            HttpMessage::HttpMessage(Allocator *allocator, struct aws_http_message *message, bool ownsMessage) noexcept
-                : m_allocator(allocator), m_message(message), m_bodyStream(nullptr), m_ownsMessage(ownsMessage)
+            HttpMessage::HttpMessage(Allocator *allocator, struct aws_http_message *message) noexcept
+                : m_allocator(allocator), m_message(message), m_bodyStream(nullptr)
             {
-                if (message && !ownsMessage)
+                if (message)
                 {
-                    // If the message is owned by this object, it means the refcount only accessed by this object. And
-                    // the initial refcount is created as the object created. If the message is not owned by this
-                    // object, acquire a refcount to keep the message alive until this object dies.
+                    // Acquire a refcount to keep the message alive until this object dies.
                     aws_http_message_acquire(this->m_message);
                 }
             }
@@ -97,12 +95,14 @@ namespace Aws
             }
 
             HttpRequest::HttpRequest(Allocator *allocator)
-                : HttpMessage(allocator, aws_http_message_new_request(allocator), true)
+                : HttpMessage(allocator, aws_http_message_new_request(allocator))
             {
+                // Releas the refcount as it created, since HttpMessage is taking the ownership
+                aws_http_message_release(this->m_message);
             }
 
             HttpRequest::HttpRequest(Allocator *allocator, struct aws_http_message *message)
-                : HttpMessage(allocator, message, false)
+                : HttpMessage(allocator, message)
             {
             }
 
@@ -141,6 +141,8 @@ namespace Aws
             HttpResponse::HttpResponse(Allocator *allocator)
                 : HttpMessage(allocator, aws_http_message_new_response(allocator))
             {
+                // Releas the refcount as it created, since HttpMessage is taking the ownership
+                aws_http_message_release(this->m_message);
             }
 
             Optional<int> HttpResponse::GetResponseCode() const noexcept


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-iot-device-sdk-cpp-v2/issues/146
If the underlying http_message get destroyed before the destructor of HttpMessage, it may crash when the destructor accesses the underlying http_message.

*Description of changes:*
- Keep the underlying http_message alive until the destructor called



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
