### PR TITLE
Fix symbol import/export issues on Windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
+if (POLICY CMP0077)
+    cmake_policy(SET CMP0077 NEW)
+endif()
+
 project(aws-crt-cpp CXX C)
 option(BUILD_DEPS "Builds aws common runtime dependencies as part of build, only do this if you don't want to control your dependency chain." OFF)
 

--- a/include/aws/crt/Api.h
+++ b/include/aws/crt/Api.h
@@ -59,12 +59,6 @@ namespace Aws
             aws_logger logger;
         };
 
-        /**
-         * Method for tests to wait for all outstanding thread-based resources to fully destruct.  Must be called
-         * before a memory check.  We don't want this to be a part of normal (ApiHandle) destruction.
-         */
-        AWS_CRT_CPP_API void TestCleanupAndWait();
-
         AWS_CRT_CPP_API const char *ErrorDebugString(int error) noexcept;
         /**
          * @return the value of the last aws error on the current thread. Return 0 if no aws-error raised before.

--- a/include/aws/crt/Types.h
+++ b/include/aws/crt/Types.h
@@ -77,9 +77,7 @@ namespace Aws
          * A conversion function should be provided to do the type conversion
          */
         template <typename RawType, typename TargetType>
-        Vector<TargetType> ArrayListToVector(
-            const aws_array_list *array,
-            TypeConvertor<RawType, TargetType> conv)
+        Vector<TargetType> ArrayListToVector(const aws_array_list *array, TypeConvertor<RawType, TargetType> conv)
         {
             Vector<TargetType> v;
             size_t cnt = aws_array_list_length(array);

--- a/include/aws/crt/Types.h
+++ b/include/aws/crt/Types.h
@@ -77,7 +77,7 @@ namespace Aws
          * A conversion function should be provided to do the type conversion
          */
         template <typename RawType, typename TargetType>
-        AWS_CRT_CPP_API Vector<TargetType> ArrayListToVector(
+        Vector<TargetType> ArrayListToVector(
             const aws_array_list *array,
             TypeConvertor<RawType, TargetType> conv)
         {
@@ -97,7 +97,7 @@ namespace Aws
          * This template assumes a direct constructor: TargetType(RawType) is available
          */
         template <typename RawType, typename TargetType>
-        AWS_CRT_CPP_API Vector<TargetType> ArrayListToVector(const aws_array_list *array)
+        Vector<TargetType> ArrayListToVector(const aws_array_list *array)
         {
             Vector<TargetType> v;
             size_t cnt = aws_array_list_length(array);
@@ -113,7 +113,7 @@ namespace Aws
         /**
          * Template function to convert an aws_array_list of Type to a C++ like Vector of Type.
          */
-        template <typename Type> AWS_CRT_CPP_API Vector<Type> ArrayListToVector(const aws_array_list *array)
+        template <typename Type> Vector<Type> ArrayListToVector(const aws_array_list *array)
         {
             Vector<Type> v;
             size_t cnt = aws_array_list_length(array);

--- a/source/io/Stream.cpp
+++ b/source/io/Stream.cpp
@@ -114,7 +114,7 @@ namespace Aws
                 auto read = m_stream->gcount();
                 buffer.len += static_cast<size_t>(read);
 
-                if (read > 0)
+                if (read > 0 || (read == 0 && m_stream->eof()))
                 {
                     return true;
                 }

--- a/source/io/Stream.cpp
+++ b/source/io/Stream.cpp
@@ -114,7 +114,7 @@ namespace Aws
                 auto read = m_stream->gcount();
                 buffer.len += static_cast<size_t>(read);
 
-                if (read > 0 || (read == 0 && m_stream->eof()))
+                if (read > 0)
                 {
                     return true;
                 }

--- a/tests/ChannelBootstrapTest.cpp
+++ b/tests/ChannelBootstrapTest.cpp
@@ -5,6 +5,7 @@
 #include <aws/crt/Api.h>
 #include <aws/testing/aws_test_harness.h>
 
+#include <Utils.h>
 #include <future>
 #include <utility>
 

--- a/tests/CredentialsTest.cpp
+++ b/tests/CredentialsTest.cpp
@@ -9,6 +9,7 @@
 #include <aws/crt/auth/Credentials.h>
 #include <aws/testing/aws_test_harness.h>
 
+#include <Utils.h>
 #include <condition_variable>
 #include <mutex>
 

--- a/tests/EventLoopGroupTest.cpp
+++ b/tests/EventLoopGroupTest.cpp
@@ -5,6 +5,7 @@
 #include <aws/crt/Api.h>
 #include <aws/testing/aws_test_harness.h>
 
+#include <Utils.h>
 #include <utility>
 
 static int s_TestEventLoopResourceSafety(struct aws_allocator *allocator, void *ctx)

--- a/tests/HMACTest.cpp
+++ b/tests/HMACTest.cpp
@@ -5,6 +5,7 @@
 #include <aws/crt/Api.h>
 #include <aws/crt/crypto/HMAC.h>
 #include <aws/testing/aws_test_harness.h>
+#include <Utils.h>
 
 static int s_TestSHA256HMACResourceSafety(struct aws_allocator *allocator, void *)
 {

--- a/tests/HashTest.cpp
+++ b/tests/HashTest.cpp
@@ -5,6 +5,7 @@
 #include <aws/crt/Api.h>
 #include <aws/crt/crypto/Hash.h>
 #include <aws/testing/aws_test_harness.h>
+#include <Utils.h>
 
 static int s_TestSHA256ResourceSafety(struct aws_allocator *allocator, void *)
 {

--- a/tests/HostResolverTest.cpp
+++ b/tests/HostResolverTest.cpp
@@ -7,6 +7,7 @@
 #include <aws/crt/io/HostResolver.h>
 #include <aws/testing/aws_test_harness.h>
 
+#include <Utils.h>
 #include <condition_variable>
 #include <mutex>
 

--- a/tests/HttpClientConnectionManagerTest.cpp
+++ b/tests/HttpClientConnectionManagerTest.cpp
@@ -11,6 +11,7 @@
 
 #include <aws/io/logging.h>
 
+#include <Utils.h>
 #include <condition_variable>
 #include <mutex>
 

--- a/tests/HttpClientTest.cpp
+++ b/tests/HttpClientTest.cpp
@@ -10,6 +10,7 @@
 
 #include <aws/testing/aws_test_harness.h>
 
+#include <Utils.h>
 #include <condition_variable>
 #include <fstream>
 #include <iostream>

--- a/tests/HttpRequestTest.cpp
+++ b/tests/HttpRequestTest.cpp
@@ -10,6 +10,7 @@
 
 #include <aws/testing/aws_test_harness.h>
 
+#include <Utils.h>
 #include <sstream>
 
 using namespace Aws::Crt::Http;

--- a/tests/ImdsClientTest.cpp
+++ b/tests/ImdsClientTest.cpp
@@ -7,6 +7,7 @@
 #include <aws/crt/ImdsClient.h>
 #include <aws/crt/auth/Credentials.h>
 #include <aws/testing/aws_test_harness.h>
+#include <Utils.h>
 #include <condition_variable>
 #include <mutex>
 

--- a/tests/IotServiceTest.cpp
+++ b/tests/IotServiceTest.cpp
@@ -6,8 +6,9 @@
 #include <aws/crt/Api.h>
 
 #include <aws/testing/aws_test_harness.h>
-#include <utility>
 
+#include <Utils.h>
+#include <utility>
 #include <condition_variable>
 #include <fstream>
 #include <mutex>

--- a/tests/JsonParserTest.cpp
+++ b/tests/JsonParserTest.cpp
@@ -5,6 +5,7 @@
 #include <aws/crt/Api.h>
 #include <aws/crt/JsonObject.h>
 #include <aws/testing/aws_test_harness.h>
+#include <Utils.h>
 
 static int s_BasicJsonParsing(struct aws_allocator *allocator, void *ctx)
 {

--- a/tests/MqttClientTest.cpp
+++ b/tests/MqttClientTest.cpp
@@ -5,6 +5,7 @@
 #include <aws/crt/Api.h>
 
 #include <aws/testing/aws_test_harness.h>
+#include <Utils.h>
 #include <utility>
 
 static int s_TestMqttClientResourceSafety(Aws::Crt::Allocator *allocator, void *ctx)

--- a/tests/OptionalMemorySafetyTest.cpp
+++ b/tests/OptionalMemorySafetyTest.cpp
@@ -5,6 +5,7 @@
 #include <aws/crt/Api.h>
 #include <aws/crt/Optional.h>
 #include <aws/testing/aws_test_harness.h>
+#include <Utils.h>
 
 const char *s_test_str = "This is a string, that should be long enough to avoid small string optimizations";
 

--- a/tests/Sigv4SigningTest.cpp
+++ b/tests/Sigv4SigningTest.cpp
@@ -13,6 +13,7 @@
 
 #include <aws/testing/aws_test_harness.h>
 
+#include <Utils.h>
 #include <condition_variable>
 #include <mutex>
 

--- a/tests/StreamTest.cpp
+++ b/tests/StreamTest.cpp
@@ -11,6 +11,7 @@
 
 #include <aws/testing/aws_test_harness.h>
 
+#include <Utils.h>
 #include <sstream>
 
 static int s_StreamTestCreateDestroyWrapper(struct aws_allocator *allocator, void *ctx)

--- a/tests/StringViewTest.cpp
+++ b/tests/StringViewTest.cpp
@@ -5,6 +5,7 @@
 #include <aws/crt/Api.h>
 #include <aws/crt/Types.h>
 #include <aws/testing/aws_test_harness.h>
+#include <Utils.h>
 
 static int s_test_string_view(struct aws_allocator *allocator, void *ctx)
 {

--- a/tests/TLSContextTest.cpp
+++ b/tests/TLSContextTest.cpp
@@ -5,6 +5,7 @@
 #include <aws/crt/Api.h>
 
 #include <aws/testing/aws_test_harness.h>
+#include <Utils.h>
 #include <utility>
 
 static int s_TestTLSContextResourceSafety(Aws::Crt::Allocator *allocator, void *ctx)

--- a/tests/TypesTest.cpp
+++ b/tests/TypesTest.cpp
@@ -5,6 +5,7 @@
 #include <aws/crt/Api.h>
 #include <aws/crt/Types.h>
 #include <aws/testing/aws_test_harness.h>
+#include <Utils.h>
 
 using namespace Aws::Crt;
 

--- a/tests/UUIDTest.cpp
+++ b/tests/UUIDTest.cpp
@@ -7,6 +7,7 @@
 #include <aws/crt/UUID.h>
 
 #include <aws/testing/aws_test_harness.h>
+#include <Utils.h>
 #include <iostream>
 #include <utility>
 

--- a/tests/Utils.h
+++ b/tests/Utils.h
@@ -13,6 +13,6 @@ namespace Aws
          * Method for tests to wait for all outstanding thread-based resources to fully destruct.  Must be called
          * before a memory check.  We don't want this to be a part of normal (ApiHandle) destruction.
          */
-        AWS_CRT_CPP_API void TestCleanupAndWait();
+        void TestCleanupAndWait();
     } // namespace Crt
 } // namespace Aws


### PR DESCRIPTION
**Issue 1**:
> error C2491: 'Aws::Crt::ArrayListToVector': definition of dllimport function not allowed
```c++
// In include/aws/crt/Types.h
template <typename RawType, typename TargetType>
AWS_CRT_CPP_API Vector<TargetType> ArrayListToVector(const aws_array_list *array, TypeConvertor<RawType, TargetType> conv)
```
**Fix issue 1**:
Remove `AWS_CRT_CPP_API`

**Issue 2**:
> warning C4273: 'Aws::Crt::TestCleanupAndWait': inconsistent dll linkage
> warning LNK4217: locally defined symbol TestCleanupAndWait
```c++
// In both include/aws/crt/Api.h and tests/Utils.h
AWS_CRT_CPP_API void TestCleanupAndWait();
```
**Fix issue 2**:
1. Remove `TestCleanupAndWait` in `include/aws/crt/Api.h`
2. Remove `AWS_CRT_CPP_API` for `TestCleanupAndWait` in `tests/Utils.h`
3. `#include <Utils.h>` for all tests.

**Issue 3**:
>  Policy CMP0077 is not set: option() honors normal variables.

This warning happens when I use `aws-crt-cpp` as a submodule of `aws-sdk-cpp`. Starting from `CMake` version 3.13, If I set a normal variable `BUILD_TESTING` in `aws-sdk-cpp`'s `CMakeLists.txt`. This variable will be removed if `aws-crt-cpp`'s `CMakeLists.txt` has `include(CTest)` because `BUILD_TESTING` is a cache entry in `option`: https://github.com/Kitware/CMake/blob/ad478a4a398d6048c2cb9dbb05c1aecd8c31608e/Modules/CTest.cmake#L50
To summary, the issue is we set `BUILD_TESTING` as `OFF` in `aws-sdk-cpp`, but it's still `ON` in `aws-crt-cpp`.

**Fix issue 3**:
https://cmake.org/cmake/help/git-stage/policy/CMP0077.html
Set CMP0077 to `NEW`, then it will do nothing with `option(BUILD_TESTING)`. The normal variable `BUILD_TESTING` will not be changed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
