### PR TITLE
shorter "logical" submodule paths

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,30 +1,30 @@
-[submodule "aws-common-runtime/aws-c-common"]
+[submodule "aws-c-common"]
 	path = crt/aws-c-common
 	url = https://github.com/awslabs/aws-c-common.git
-[submodule "aws-common-runtime/aws-c-io"]
+[submodule "aws-c-io"]
 	path = crt/aws-c-io
 	url = https://github.com/awslabs/aws-c-io.git
-[submodule "aws-common-runtime/aws-c-compression"]
+[submodule "aws-c-compression"]
 	path = crt/aws-c-compression
 	url = https://github.com/awslabs/aws-c-compression.git
-[submodule "aws-common-runtime/aws-c-cal"]
+[submodule "aws-c-cal"]
 	path = crt/aws-c-cal
 	url = https://github.com/awslabs/aws-c-cal.git
-[submodule "aws-common-runtime/aws-c-auth"]
+[submodule "aws-c-auth"]
 	path = crt/aws-c-auth
 	url = https://github.com/awslabs/aws-c-auth.git
-[submodule "aws-common-runtime/aws-c-http"]
+[submodule "aws-c-http"]
 	path = crt/aws-c-http
 	url = https://github.com/awslabs/aws-c-http.git
-[submodule "aws-common-runtime/aws-c-mqtt"]
+[submodule "aws-c-mqtt"]
 	path = crt/aws-c-mqtt
 	url = https://github.com/awslabs/aws-c-mqtt.git
-[submodule "aws-common-runtime/s2n"]
+[submodule "s2n"]
 	path = crt/s2n
 	url = https://github.com/awslabs/s2n.git
-[submodule "aws-common-runtime/aws-checksums"]
+[submodule "aws-checksums"]
 	path = crt/aws-checksums
 	url = https://github.com/awslabs/aws-checksums.git
-[submodule "aws-common-runtime/aws-c-event-stream"]
+[submodule "aws-c-event-stream"]
 	path = crt/aws-c-event-stream
 	url = https://github.com/awslabs/aws-c-event-stream.git


### PR DESCRIPTION
Shorten "logical path" in .gitmodules file. This is to aid with pain on windows when paths exceed 260 characters. We do a lot of recursive submodules, and these things do add up.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
