### PR TITLE
C++20 compile fixes

### DIFF
--- a/include/aws/crt/StlAllocator.h
+++ b/include/aws/crt/StlAllocator.h
@@ -41,14 +41,16 @@ namespace Aws
                 typedef StlAllocator<U> other;
             };
 
-            typename Base::pointer allocate(size_type n, const void *hint = nullptr)
+            using RawPointer = typename std::allocator_traits<std::allocator<T>>::pointer;
+
+            RawPointer allocate(size_type n, const void *hint = nullptr)
             {
                 (void)hint;
                 AWS_ASSERT(m_allocator);
-                return reinterpret_cast<typename Base::pointer>(aws_mem_acquire(m_allocator, n * sizeof(T)));
+                return reinterpret_cast<RawPointer>(aws_mem_acquire(m_allocator, n * sizeof(T)));
             }
 
-            void deallocate(typename Base::pointer p, size_type)
+            void deallocate(RawPointer p, size_type)
             {
                 AWS_ASSERT(m_allocator);
                 aws_mem_release(m_allocator, p);


### PR DESCRIPTION
Remove references to deprecated(17)/removed(20) std::allocator type members.  See http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0174r0.html#2.4

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
