### PR TITLE
Custom keychain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ if (NOT CMAKE_BUILD_TYPE)
 endif()
 
 if (NOT DEFINED AWS_CRT_CPP_VERSION)
-    set(AWS_CRT_CPP_VERSION "v1.0.0-dev")
+    set(AWS_CRT_CPP_VERSION "v0.11.1")
     # Try to determine the current git tag and use that as the version
     execute_process(COMMAND git describe --tags
         RESULT_VARIABLE GIT_EXIT_CODE

--- a/include/aws/crt/io/TlsOptions.h
+++ b/include/aws/crt/io/TlsOptions.h
@@ -54,6 +54,7 @@ namespace Aws
                  * @param cert_path: Path to certificate file.
                  * @param pkey_path: Path to private key file.
                  */
+#if !defined(AWS_OS_IOS)
                 static TlsContextOptions InitClientWithMtls(
                     const char *cert_path,
                     const char *pkey_path,
@@ -70,8 +71,9 @@ namespace Aws
                     const ByteCursor &cert,
                     const ByteCursor &pkey,
                     Allocator *allocator = g_allocator) noexcept;
+#endif /* !AWS_OS_IOS */
 
-#ifdef __APPLE__
+#if defined(AWS_OS_APPLE)
                 /**
                  * Initializes TlsContextOptions with secure by default options, with
                  * client certificateand private key in the PKCS#12 format.
@@ -85,7 +87,7 @@ namespace Aws
                     const char *pkcs12_path,
                     const char *pkcs12_pwd,
                     Allocator *allocator = g_allocator) noexcept;
-#endif
+#endif /* AWS_OS_APPLE */
 
                 /**
                  * @return true if alpn is supported by the underlying security provider, false

--- a/include/aws/crt/io/TlsOptions.h
+++ b/include/aws/crt/io/TlsOptions.h
@@ -71,7 +71,36 @@ namespace Aws
                     const ByteCursor &cert,
                     const ByteCursor &pkey,
                     Allocator *allocator = g_allocator) noexcept;
-#endif /* !AWS_OS_IOS */
+#    if defined(AWS_OS_APPLE)
+                /**
+                 * Initializes TlsContextOptions with secure by default options, with
+                 * client certificate and private key. These are paths to a file on disk. These files
+                 * must be in the PEM format. The certificate and the key are stored in the custom keychain.
+                 * @param cert_path: Path to certificate file.
+                 * @param pkey_path: Path to private key file.
+                 * @param keychain_path: Path to custom keychain.
+                 */
+                static TlsContextOptions InitClientWithMtls(
+                    const char *cert_path,
+                    const char *pkey_path,
+                    const char *keychain_path,
+                    Allocator *allocator = g_allocator) noexcept;
+
+                /**
+                 * Initializes TlsContextOptions with secure by default options, with
+                 * client certificate and private key. These are in memory buffers. These buffers
+                 * must be in the PEM format. The certificate and the key are stored in the custom keychain.
+                 * @param cert: Certificate contents in memory.
+                 * @param pkey: Private key contents in memory.
+                 * @param keychain_path: Path to custom keychain.
+                 */
+                static TlsContextOptions InitClientWithMtls(
+                    const ByteCursor &cert,
+                    const ByteCursor &pkey,
+                    const char *keychain_path,
+                    Allocator *allocator = g_allocator) noexcept;
+#    endif /* AWS_OS_APPLE */
+#endif     /* !AWS_OS_IOS */
 
 #if defined(AWS_OS_APPLE)
                 /**

--- a/source/io/TlsOptions.cpp
+++ b/source/io/TlsOptions.cpp
@@ -89,7 +89,43 @@ namespace Aws
                 }
                 return ctxOptions;
             }
-#endif /* !AWS_OS_IOS */
+#    if defined(AWS_OS_APPLE)
+            TlsContextOptions TlsContextOptions::InitClientWithMtls(
+                const char *certPath,
+                const char *pKeyPath,
+                const char *keychainPath,
+                Allocator *allocator) noexcept
+            {
+                TlsContextOptions ctxOptions;
+                if (!aws_tls_ctx_options_init_client_mtls_from_path_custom_keychain(
+                        &ctxOptions.m_options, allocator, certPath, pKeyPath, keychainPath))
+                {
+                    ctxOptions.m_isInit = true;
+                }
+                return ctxOptions;
+            }
+
+            TlsContextOptions TlsContextOptions::InitClientWithMtls(
+                const ByteCursor &cert,
+                const ByteCursor &pkey,
+                const char *keychainPath,
+                Allocator *allocator) noexcept
+            {
+                TlsContextOptions ctxOptions;
+                if (!aws_tls_ctx_options_init_client_mtls_custom_keychain(
+                        &ctxOptions.m_options,
+                        allocator,
+                        const_cast<ByteCursor *>(&cert),
+                        const_cast<ByteCursor *>(&pkey),
+                        keychainPath))
+                {
+                    ctxOptions.m_isInit = true;
+                }
+                return ctxOptions;
+            }
+#    endif /* AWS_OS_APPLE */
+#endif     /* !AWS_OS_IOS */
+
 #if defined(AWS_OS_APPLE)
             TlsContextOptions TlsContextOptions::InitClientWithMtlsPkcs12(
                 const char *pkcs12Path,


### PR DESCRIPTION
*Issue #, if available:* #204 

*Description of changes:*

Introduces two overloaded `InitClientWithMtls` functions which call the functions `aws_tls_ctx_options_init_client_mtls_custom_keychain` and `aws_tls_ctx_options_init_client_mtls_from_path_custom_keychain` introduced to aws-c-io issue https://github.com/awslabs/aws-c-io/issues/340 and pull request https://github.com/awslabs/aws-c-io/pull/341 to use a custom keychain in macOS.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
