### PR TITLE
Fix crash when assigning tls options for x509 credentials provider

### DIFF
--- a/source/Api.cpp
+++ b/source/Api.cpp
@@ -7,8 +7,8 @@
 #include <aws/crt/external/cJSON.h>
 #include <aws/crt/io/TlsOptions.h>
 
-#include <aws/common/ref_count.h>
 #include <aws/auth/auth.h>
+#include <aws/common/ref_count.h>
 #include <aws/http/http.h>
 #include <aws/mqtt/mqtt.h>
 

--- a/source/auth/Credentials.cpp
+++ b/source/auth/Credentials.cpp
@@ -290,7 +290,10 @@ namespace Aws
 
                     proxy_options.host = aws_byte_cursor_from_c_str(proxy_config.HostName.c_str());
                     proxy_options.port = proxy_config.Port;
-                    proxy_options.tls_options = proxy_config.TlsOptions->GetUnderlyingHandle();
+                    if (proxy_config.TlsOptions.has_value())
+                    {
+                        proxy_options.tls_options = proxy_config.TlsOptions->GetUnderlyingHandle();
+                    }
                     proxy_options.auth_type = (enum aws_http_proxy_authentication_type)proxy_config.AuthType;
                     proxy_options.auth_username = aws_byte_cursor_from_c_str(proxy_config.BasicAuthUsername.c_str());
                     proxy_options.auth_password = aws_byte_cursor_from_c_str(proxy_config.BasicAuthPassword.c_str());


### PR DESCRIPTION
* Fixes a potential crash when assigning tls options for a proxied x509 credentials provider

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
