### PR TITLE
Verify TlsConnectionOptions (awslabs#223)

### DIFF
--- a/include/aws/crt/io/TlsOptions.h
+++ b/include/aws/crt/io/TlsOptions.h
@@ -166,7 +166,7 @@ namespace Aws
                 /**
                  * @return true if the instance is in a valid state, false otherwise.
                  */
-                explicit operator bool() const noexcept { return m_isInit; }
+                explicit operator bool() const noexcept { return isValid(); }
                 /**
                  * @return the value of the last aws error encountered by operations on this instance.
                  */
@@ -178,6 +178,8 @@ namespace Aws
                 }
 
               private:
+                bool isValid() const noexcept { return m_isInit; }
+
                 TlsConnectionOptions(aws_tls_ctx *ctx, Allocator *allocator) noexcept;
                 aws_tls_connection_options m_tls_connection_options;
                 aws_allocator *m_allocator;

--- a/source/io/TlsOptions.cpp
+++ b/source/io/TlsOptions.cpp
@@ -234,6 +234,12 @@ namespace Aws
 
             bool TlsConnectionOptions::SetServerName(ByteCursor &serverName) noexcept
             {
+                if (!isValid())
+                {
+                    m_lastError = LastErrorOrUnknown();
+                    return false;
+                }
+
                 if (aws_tls_connection_options_set_server_name(&m_tls_connection_options, m_allocator, &serverName))
                 {
                     m_lastError = LastErrorOrUnknown();
@@ -245,6 +251,12 @@ namespace Aws
 
             bool TlsConnectionOptions::SetAlpnList(const char *alpnList) noexcept
             {
+                if (!isValid())
+                {
+                    m_lastError = LastErrorOrUnknown();
+                    return false;
+                }
+
                 if (aws_tls_connection_options_set_alpn_list(&m_tls_connection_options, m_allocator, alpnList))
                 {
                     m_lastError = LastErrorOrUnknown();


### PR DESCRIPTION
*Issue #223*

*Description of changes:*

Before accessing possibly uninitialized members of `TlsConnectionOptions` check that it's been successfully initialized.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
