### PR TITLE
Misc fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         # TODO: fix version 3. Changes to aws-crt-builder on 2021.03.11 changed docker container and now we get errors when including the std lib
-        version: [6, 8, 9]
+        version: [6, 8, 9, 10, 11]
     steps:
         # We can't use the `uses: docker://image` version yet, GitHub lacks authentication for actions -> packages
     - name: Build ${{ env.PACKAGE_NAME }}
@@ -87,7 +87,18 @@ jobs:
         docker pull $DOCKER_IMAGE
         docker run --env GITHUB_REF --env CXXFLAGS $DOCKER_IMAGE build -p ${{ env.PACKAGE_NAME }} --compiler=${{ matrix.compiler }}
 
-  windows-vs16:
+  linux-shared-libs:
+    runs-on: ubuntu-latest
+    steps:
+        # We can't use the `uses: docker://image` version yet, GitHub lacks authentication for actions -> packages
+    - name: Build ${{ env.PACKAGE_NAME }}
+      run: |
+        echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u awslabs --password-stdin
+        export DOCKER_IMAGE=docker.pkg.github.com/awslabs/aws-crt-builder/aws-crt-${{ env.LINUX_BASE_IMAGE }}:${{ env.BUILDER_VERSION }}
+        docker pull $DOCKER_IMAGE
+        docker run --env GITHUB_REF $DOCKER_IMAGE build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DBUILD_SHARED_LIBS=ON
+
+  windows-vc16:
     runs-on: windows-latest
     steps:
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
@@ -97,24 +108,41 @@ jobs:
         python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
         python builder.pyz build -p ${{ env.PACKAGE_NAME }} --spec=downstream
 
-  windows-vs14:
+  windows-vc15:
     runs-on: windows-latest
     strategy:
       matrix:
         arch: [x86, x64]
     steps:
-    - uses: ilammy/msvc-dev-cmd@v1
-      with:
-        toolset: 14.0
-        arch: ${{ matrix.arch }}
-        uwp: false
-        spectre: true
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
       run: |
         md D:\a\work
         cd D:\a\work
         python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
-        python builder.pyz build -p ${{ env.PACKAGE_NAME }} --spec=downstream
+        python builder.pyz build -p ${{ env.PACKAGE_NAME }} --target windows-${{ matrix.arch }} --compiler msvc-15
+
+  windows-vc14:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        arch: [x86, x64]
+    steps:
+    - name: Build ${{ env.PACKAGE_NAME }} + consumers
+      run: |
+        md D:\a\work
+        cd D:\a\work
+        python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
+        python builder.pyz build -p ${{ env.PACKAGE_NAME }} --target windows-${{ matrix.arch }} --compiler msvc-14
+
+  windows-shared-libs:
+    runs-on: windows-latest
+    steps:
+    - name: Build ${{ env.PACKAGE_NAME }} + consumers
+      run: |
+        md D:\a\work
+        cd D:\a\work
+        python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
+        python builder.pyz build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DBUILD_SHARED_LIBS=ON
 
   osx:
     runs-on: macos-latest

--- a/include/aws/crt/Optional.h
+++ b/include/aws/crt/Optional.h
@@ -3,21 +3,12 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0.
  */
-#if __cplusplus >= 201703L
-#    include <optional>
-#else
-#    include <cstdint>
-#    include <type_traits>
-#    include <utility>
-#endif
+#include <utility>
 
 namespace Aws
 {
     namespace Crt
     {
-#if __cplusplus >= 201703L
-        template <typename T> using Optional = std::optional<T>;
-#else
         template <typename T> class Optional
         {
           public:
@@ -195,6 +186,5 @@ namespace Aws
             typename std::aligned_storage<sizeof(T)>::type m_storage;
             T *m_value;
         };
-#endif
     } // namespace Crt
 } // namespace Aws


### PR DESCRIPTION
- additional CI runs: SHARED_LIBS=ON, Visual Studio versions
- Aws::Crt::Optional cannot alias std::optional. This library is always built with c++11, so always uses our definition of Optional. If a user's c++17 app includes this file, they'll think that instances created by our library are ACTUALLY std::optional, but these have different binary layout, so kaboom


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
