### PR TITLE
Custom keychain support for macOS TLS (#204)

### DIFF
--- a/include/aws/crt/io/TlsOptions.h
+++ b/include/aws/crt/io/TlsOptions.h
@@ -88,6 +88,14 @@ namespace Aws
                     const char *pkcs12_path,
                     const char *pkcs12_pwd,
                     Allocator *allocator = g_allocator) noexcept;
+
+                /**
+                 * By default the certificates and private keys are stored in the default keychain
+                 * of the account of the process. If you instead wish to provide your own keychain
+                 * for storing them, this makes the TlsContext to use that instead.
+                 * NOTE: The password of your keychain must be empty.
+                 */
+                bool SetKeychainPath(ByteCursor &keychain_path) noexcept;
 #endif
 
 #ifdef _WIN32

--- a/source/io/TlsOptions.cpp
+++ b/source/io/TlsOptions.cpp
@@ -105,6 +105,12 @@ namespace Aws
                 }
                 return ctxOptions;
             }
+
+            bool TlsContextOptions::SetKeychainPath(ByteCursor &keychain_path) noexcept
+            {
+                AWS_ASSERT(m_isInit);
+                return aws_tls_ctx_options_set_keychain_path(&m_options, static_cast<ByteCursor>(keychain_path)) == 0;
+            }
 #endif /* AWS_OS_APPLE */
 
 #ifdef _WIN32


### PR DESCRIPTION
*Issue #204*

*Description of changes:*

An optional macos keychain path for macOS TLS connection was added in https://github.com/awslabs/aws-c-io/pull/368. This change provides the C++ method for changing that value for a `TlsContextOptions` object.

As an implementation note, I noticed that all the other `Set*` and `Override*` methods are using a `const ByteCursor &`, but this change uses a non-const `ByteCursor &` due to `aws_tls_ctx_options_set_keychain_path()` also using a non-const `struct aws_byte_cursor` (not a pointer!) as its argument. It actually looks like it should be `const struct aws_byte_cursor *` instead, as it's only copied with `aws_string_new_from_cursor()` that expects a `const struct aws_byte_cursor *`. I'm open to both merging this and fixing that later, or changing that first in aws-c-io before changing aws-crt-cpp.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
