### PR TITLE
Add support to store and pass SDK Name & Version as a metric to IoT c…

### DIFF
--- a/include/aws/iot/MqttClient.h
+++ b/include/aws/iot/MqttClient.h
@@ -52,6 +52,28 @@ namespace Aws
                 const Crt::Optional<Crt::Http::HttpClientConnectionProxyOptions> &proxyOptions);
 
             /**
+             * Creates a client configuration for use with making new AWS Iot specific MQTT Connections with web
+             * sockets. interceptor: a callback invoked during web socket handshake giving you the opportunity to mutate
+             * the request for authorization/signing purposes. If not specified, it's assumed you don't need to sign the
+             * request. proxyOptions: optional, if you want to use a proxy with websockets, specify the configuration
+             * options here.
+             *
+             * If proxy options are used, the tlsContext is applied to the connection to the remote endpoint, NOT the
+             * proxy. To make a tls connection to the proxy itself, you'll want to specify tls options in proxyOptions.
+             *
+             * It also provides option to save SDK Name and its version which will be sent as an metric to IoT Cloud.
+             */
+            MqttClientConnectionConfig(
+                const Crt::String &endpoint,
+                uint16_t port,
+                const Crt::Io::SocketOptions &socketOptions,
+                Crt::Io::TlsContext &&tlsContext,
+                Crt::Mqtt::OnWebSocketHandshakeIntercept &&interceptor,
+                const Crt::String &sdkName,
+                const Crt::String &sdkVersion,
+                const Crt::Optional<Crt::Http::HttpClientConnectionProxyOptions> &proxyOptions);
+
+            /**
              * @return true if the instance is in a valid state, false otherwise.
              */
             explicit operator bool() const noexcept { return m_context ? true : false; }
@@ -70,11 +92,22 @@ namespace Aws
                 Crt::Io::TlsContext &&tlsContext,
                 const Crt::Optional<Crt::Http::HttpClientConnectionProxyOptions> &proxyOptions);
 
+            MqttClientConnectionConfig(
+                const Crt::String &endpoint,
+                uint16_t port,
+                const Crt::Io::SocketOptions &socketOptions,
+                Crt::Io::TlsContext &&tlsContext,
+                const Crt::String &sdkName,
+                const Crt::String &sdkVersion,
+                const Crt::Optional<Crt::Http::HttpClientConnectionProxyOptions> &proxyOptions);
+
             Crt::String m_endpoint;
             uint16_t m_port;
             Crt::Io::TlsContext m_context;
             Crt::Io::SocketOptions m_socketOptions;
             Crt::Mqtt::OnWebSocketHandshakeIntercept m_webSocketInterceptor;
+            Crt::String m_sdkName;
+            Crt::String m_sdkVersion;
             Crt::Optional<Crt::Http::HttpClientConnectionProxyOptions> m_proxyOptions;
             int m_lastError;
 
@@ -179,6 +212,16 @@ namespace Aws
             MqttClientConnectionConfigBuilder &WithEndpoint(Crt::String &&endpoint);
 
             /**
+             * Store SDK Name to send as a metric while creating MQTT connection
+             */
+            MqttClientConnectionConfigBuilder &WithSdkName(const Crt::String &sdkName);
+
+            /**
+             * Store SDK Version to send as a metric while creating MQTT connection
+             */
+            MqttClientConnectionConfigBuilder &WithSdkVersion(const Crt::String &sdkVersion);
+
+            /**
              * Overrides the default port. By default, if ALPN is supported, 443 will be used. Otherwise 8883 will be
              * used. If you specify 443 and ALPN is not supported, we will still attempt to connect over 443 without
              * ALPN.
@@ -248,6 +291,8 @@ namespace Aws
             Crt::Io::SocketOptions m_socketOptions;
             Crt::Io::TlsContextOptions m_contextOptions;
             Crt::Optional<WebsocketConfig> m_websocketConfig;
+            Crt::String m_sdkName;
+            Crt::String m_sdkVersion;
             Crt::Optional<Crt::Http::HttpClientConnectionProxyOptions> m_proxyOptions;
 
             bool m_isGood;

--- a/source/iot/MqttClient.cpp
+++ b/source/iot/MqttClient.cpp
@@ -403,8 +403,10 @@ namespace Aws
                 return nullptr;
             }
 
-            char username[100] = "";
-            sprintf(username, "%s%s%s%s", "?SDK=", config.m_sdkName.c_str(), "&Version=", config.m_sdkVersion.c_str());
+            size_t username_size = sizeof(config.m_sdkName.c_str()) + sizeof(config.m_sdkVersion.c_str()) + 15;
+            char *username = new char[username_size];
+            snprintf(
+                username, username_size, "%s%s%s%s", "?SDK=", config.m_sdkName.c_str(), "&Version=", config.m_sdkVersion.c_str());
 
             if (!(*newConnection) || !newConnection->SetLogin(username, nullptr))
             {
@@ -421,6 +423,8 @@ namespace Aws
             {
                 newConnection->SetHttpProxyOptions(config.m_proxyOptions.value());
             }
+
+            delete[] username;
 
             return newConnection;
         }

--- a/source/iot/MqttClient.cpp
+++ b/source/iot/MqttClient.cpp
@@ -403,10 +403,16 @@ namespace Aws
                 return nullptr;
             }
 
-            size_t username_size = sizeof(config.m_sdkName.c_str()) + sizeof(config.m_sdkVersion.c_str()) + 15;
+            size_t username_size = sizeof(config.m_sdkName.c_str()) + sizeof(config.m_sdkVersion.c_str()) + 16;
             char *username = new char[username_size];
             snprintf(
-                username, username_size, "%s%s%s%s", "?SDK=", config.m_sdkName.c_str(), "&Version=", config.m_sdkVersion.c_str());
+                username,
+                username_size,
+                "%s%s%s%s",
+                "?SDK=",
+                config.m_sdkName.c_str(),
+                "&Version=",
+                config.m_sdkVersion.c_str());
 
             if (!(*newConnection) || !newConnection->SetLogin(username, nullptr))
             {


### PR DESCRIPTION
…loud

*Issue #, if available:*

*Description of changes:*

With this change request, I am adding support to pass and store SDK Name and its Version so we can pass it to IoT Cloud while making mqtt connection. This will give ability to external software running CPPv2 to pass their own metric so we can effectively track them. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
