### PR TITLE
Adding default value for a flag to continue strict CI checking of com…

### DIFF
--- a/builder.json
+++ b/builder.json
@@ -2,7 +2,8 @@
     "name": "aws-crt-cpp",
     "!cmake_args": [
         "-DPERFORM_HEADER_CHECK_CXX=ON",
-        "-DS2N_NO_PQ_ASM=ON"
+        "-DS2N_NO_PQ_ASM=ON",
+        "-DAWS_WARNINGS_ARE_ERRORS=ON"
     ],
     "hosts": {
         "manylinux": {


### PR DESCRIPTION
…piler warnings.

*Description of changes:*
* enable CI builds to fail on compiler warnings by default. Anticipating future default value change of this flag for non CI builds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
