### PR TITLE
Added missing limits include

### DIFF
--- a/include/aws/crt/StringView.h
+++ b/include/aws/crt/StringView.h
@@ -13,6 +13,7 @@
 #include <iterator>
 #include <stddef.h>
 #include <type_traits>
+#include <limits>
 
 #if __cplusplus >= 201703L || (defined(_MSC_LANG) && _MSC_LANG >= 201703L)
 #    include <string_view>


### PR DESCRIPTION
This was causing compilation errors on gcc 11.1 x86. I'm not sure why my x64 build was fine with it, but clearly the include should be there since numeric_limits is used.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
