### PR TITLE
Catch error when TlsContext fails.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,26 @@ if (BUILD_DEPS)
         if (NOT USE_OPENSSL)
             set(DISABLE_PERL ON CACHE BOOL "Disable Perl for AWS-LC.")
             set(DISABLE_GO ON CACHE BOOL "Disable Go for AWS-LC.")
+
+            # temporarily disable certain warnings as errors for the aws-lc build
+            set(OLD_CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+            if (NOT MSVC)
+                check_c_compiler_flag(-Wno-stringop-overflow HAS_WNO_STRINGOP_OVERFLOW)
+                if (HAS_WNO_STRINGOP_OVERFLOW)
+                    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-stringop-overflow")
+                endif()
+
+                check_c_compiler_flag(-Wno-array-parameter HAS_WNO_ARRAY_PARAMETER)
+                if (HAS_WNO_ARRAY_PARAMETER)
+                    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-array-parameter")
+                endif()
+            endif()
+
             add_subdirectory(crt/aws-lc)
+
+            # restore previous build flags
+            set(CMAKE_C_FLAGS "${OLD_CMAKE_C_FLAGS}")
+
             set(SEARCH_LIBCRYPTO OFF CACHE BOOL "Let S2N use libcrypto from AWS-LC.")
         else()
             set(SEARCH_LIBCRYPTO ON CACHE BOOL "Let S2N search libcrypto in the system.")

--- a/include/aws/crt/io/TlsOptions.h
+++ b/include/aws/crt/io/TlsOptions.h
@@ -43,7 +43,7 @@ namespace Aws
                 /**
                  * @return the value of the last aws error encountered by operations on this instance.
                  */
-                int LastError() const noexcept { return aws_last_error(); }
+                int LastError() const noexcept;
 
                 /**
                  * Initializes TlsContextOptions with secure by default options, with

--- a/include/aws/iot/MqttClient.h
+++ b/include/aws/iot/MqttClient.h
@@ -254,11 +254,11 @@ namespace Aws
             /**
              * @return true if the instance is in a valid state, false otherwise.
              */
-            explicit operator bool() const noexcept { return m_isGood; }
+            explicit operator bool() const noexcept { return m_lastError == 0; }
             /**
              * @return the value of the last aws error encountered by operations on this instance.
              */
-            int LastError() const noexcept { return aws_last_error(); }
+            int LastError() const noexcept { return m_lastError ? m_lastError : AWS_ERROR_UNKNOWN; }
 
           private:
             Crt::Allocator *m_allocator;
@@ -272,7 +272,7 @@ namespace Aws
             Crt::String m_sdkName = "CPPv2";
             Crt::String m_sdkVersion = AWS_CRT_CPP_VERSION;
 
-            bool m_isGood;
+            int m_lastError;
         };
 
         /**

--- a/source/io/TlsOptions.cpp
+++ b/source/io/TlsOptions.cpp
@@ -125,6 +125,8 @@ namespace Aws
             }
 #endif /* _WIN32 */
 
+            int TlsContextOptions::LastError() const noexcept { return LastErrorOrUnknown(); }
+
             bool TlsContextOptions::IsAlpnSupported() noexcept { return aws_tls_is_alpn_available(); }
 
             bool TlsContextOptions::SetAlpnList(const char *alpn_list) noexcept


### PR DESCRIPTION
`MqttClientConnectionConfigBuilder` wasn't properly checking for errors when creating the `TlsContext`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
