### PR TITLE
Try new way of tagging releases; currently stuck on a version 1.5 years old

### DIFF
--- a/update-version.sh
+++ b/update-version.sh
@@ -10,7 +10,7 @@ GITHUB_TOKEN=$1
 
 pushd $(dirname $0) > /dev/null
 
-version=$(git describe --tags --abbrev=0)
+version=$(git tag --sort=-creatordate | head -n1)
 sed --in-place -r -e "s/set\\(AWS_CRT_CPP_VERSION \".+\"\\)/set(AWS_CRT_CPP_VERSION \"${version}\")/" CMakeLists.txt
 echo "Updating AWS_CRT_CPP_VERSION default to ${version}"
 
@@ -21,8 +21,10 @@ else
     git config --local user.name "GitHub Actions"
     git add CMakeLists.txt
     git commit -m "Updated version to ${version}"
-    git tag -f ${version}
-    git push "https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/awslabs/aws-crt-cpp.git" --force --tags
+
+    git push "https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/awslabs/aws-crt-cpp.git" :refs/tags/${version}
+    git tag -fa ${version}
+    git push "https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/awslabs/aws-crt-cpp.git" main --force --tags
 fi
 
 popd > /dev/null

--- a/update-version.sh
+++ b/update-version.sh
@@ -22,8 +22,18 @@ else
     git add CMakeLists.txt
     git commit -m "Updated version to ${version}"
 
+    # awkward - we need to snip the old tag message and then force overwrite the tag with the new commit but
+    # preserving the old message
+    tag_message=$(git tag -l -n20 ${version} | sed -n "s/${version} \(.*\)/\1/p")
+    echo "Old tag message is: ${tag_message}"
+
+    # delete the old tag on github
     git push "https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/awslabs/aws-crt-cpp.git" :refs/tags/${version}
-    git tag -fa ${version}
+
+    # create new tag on latest commit with old message
+    git tag -f ${version} -m "${tag_message}"
+
+    # push new tag and commit to github
     git push "https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/awslabs/aws-crt-cpp.git" main --force --tags
 fi
 


### PR DESCRIPTION


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
