### PR TITLE
Fix iOS Build

### DIFF
--- a/source/io/TlsOptions.cpp
+++ b/source/io/TlsOptions.cpp
@@ -111,7 +111,7 @@ namespace Aws
                 AWS_ASSERT(m_isInit);
                 return aws_tls_ctx_options_set_keychain_path(&m_options, &keychain_path) == 0;
             }
-#endif /* AWS_OS_APPLE */
+#endif /* AWS_OS_MACOS */
 
 #ifdef _WIN32
             TlsContextOptions TlsContextOptions::InitClientWithMtlsSystemPath(

--- a/source/io/TlsOptions.cpp
+++ b/source/io/TlsOptions.cpp
@@ -90,7 +90,7 @@ namespace Aws
                 return ctxOptions;
             }
 #endif /* !AWS_OS_IOS */
-#if defined(AWS_OS_APPLE)
+#if defined(AWS_OS_MACOS)
             TlsContextOptions TlsContextOptions::InitClientWithMtlsPkcs12(
                 const char *pkcs12Path,
                 const char *pkcs12Pwd,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Keychain methods are not available when building for iOS. They should be required only when building for MacOS and not for all Apple targets.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
