### PR TITLE
fix cast compilation error

### DIFF
--- a/source/io/TlsOptions.cpp
+++ b/source/io/TlsOptions.cpp
@@ -216,7 +216,7 @@ namespace Aws
 
                 if (m_slotId)
                 {
-                    options.slot_id = &(*m_slotId);
+                    options.slot_id = const_cast<uint64_t*>(&(*m_slotId));
                 }
 
                 if (m_userPin)


### PR DESCRIPTION
*Description of changes:*

On g++ 11.2, explicit type conversion in `TlsOptions.cpp` is caused by compilation error.
So I want to use const_cast.
I hope that this change is in line with the repository policy.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
