### PR TITLE
Clean out m_tls_connection_options in TlsConnectionOptions constructor

### DIFF
--- a/source/io/TlsOptions.cpp
+++ b/source/io/TlsOptions.cpp
@@ -264,10 +264,12 @@ namespace Aws
             TlsConnectionOptions::TlsConnectionOptions(const TlsConnectionOptions &options) noexcept
             {
                 m_isInit = false;
+                AWS_ZERO_STRUCT(m_tls_connection_options);
 
                 if (options.m_isInit)
                 {
                     m_allocator = options.m_allocator;
+
                     if (!aws_tls_connection_options_copy(&m_tls_connection_options, &options.m_tls_connection_options))
                     {
                         m_isInit = true;
@@ -289,6 +291,7 @@ namespace Aws
                     }
 
                     m_isInit = false;
+                    AWS_ZERO_STRUCT(m_tls_connection_options);
 
                     if (options.m_isInit)
                     {


### PR DESCRIPTION
*Issue
aws_tls_connection_options_copy from aws-c-io changed the behavior that it will release dest tls option before copy. Update the aws-c-io library. 

*Description of changes:*
Clean out uninitialized m_tls_connection_options in TlsConnectionOptions constructor

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
