### PR TITLE
fix shadow paramater warning on old g++

### DIFF
--- a/include/aws/crt/StringView.h
+++ b/include/aws/crt/StringView.h
@@ -54,7 +54,7 @@ namespace Aws
 
             constexpr basic_string_view(const CharT *s) noexcept : m_size{traits_type::length(s)}, m_data{s} {}
 
-            constexpr basic_string_view(const CharT *s, size_type length) noexcept : m_size{length}, m_data{s} {}
+            constexpr basic_string_view(const CharT *s, size_type count) noexcept : m_size{count}, m_data{s} {}
 
             basic_string_view &operator=(const basic_string_view &) noexcept = default;
 
@@ -91,7 +91,7 @@ namespace Aws
 
             constexpr size_type size() const noexcept { return this->m_size; }
 
-            constexpr size_type length() const noexcept { return m_size; }
+            constexpr size_type length() const noexcept { return this->m_size; }
 
             constexpr size_type max_size() const noexcept { return (std::numeric_limits<size_type>::max)(); }
 


### PR DESCRIPTION
StringView.h has a constructor with a parameter length and a function with the same name. Old g++ (pre 5.0) flags it if -Wshadow is on.
Replace length parameter with count to make it consistent with c++17 std implementation and to avoid the shadow warning.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
