### PR TITLE
Deprecate macOS keychain path function.

### DIFF
--- a/include/aws/crt/io/TlsOptions.h
+++ b/include/aws/crt/io/TlsOptions.h
@@ -123,7 +123,7 @@ namespace Aws
                     Allocator *allocator = g_allocator) noexcept;
 
                 /**
-                 * @deprecated Custom keychain management marked deprecated starting in MacOS 12.
+                 * @deprecated Custom keychain management is deprecated.
                  *
                  * By default the certificates and private keys are stored in the default keychain
                  * of the account of the process. If you instead wish to provide your own keychain

--- a/include/aws/crt/io/TlsOptions.h
+++ b/include/aws/crt/io/TlsOptions.h
@@ -123,6 +123,8 @@ namespace Aws
                     Allocator *allocator = g_allocator) noexcept;
 
                 /**
+                 * @deprecated Custom keychain management marked deprecated starting in MacOS 12.
+                 *
                  * By default the certificates and private keys are stored in the default keychain
                  * of the account of the process. If you instead wish to provide your own keychain
                  * for storing them, this makes the TlsContext to use that instead.


### PR DESCRIPTION
Related: https://github.com/awslabs/aws-c-io/pull/476

Custom keychain management is being deprecated starting in macOS 12. This was causing compiler warnings.

Therefore, mark the `TlsContextOptions.SetKeychainPath()` function as deprecated, which leads to these deprecated mac keychain functions being invoked.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
