### PR TITLE
Fixes cpp 20 builds for windows.

### DIFF
--- a/include/aws/crt/StringView.h
+++ b/include/aws/crt/StringView.h
@@ -15,7 +15,7 @@
 #include <stddef.h>
 #include <type_traits>
 
-#if __cplusplus >= 201703L || (defined(_MSC_LANG) && _MSC_LANG >= 201703L)
+#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
 #    include <string_view>
 #endif
 
@@ -58,7 +58,7 @@ namespace Aws
 
             basic_string_view &operator=(const basic_string_view &) noexcept = default;
 
-#if __cplusplus >= 201703L || (defined(_MSC_LANG) && _MSC_LANG >= 201703L)
+#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
             constexpr basic_string_view(const std::basic_string_view<CharT, Traits> &other) noexcept
                 : m_size(other.size()), m_data(other.data())
             {


### PR DESCRIPTION
*Issue #, if available:*
[aws-sdk-cpp-1858](https://github.com/aws/aws-sdk-cpp/issues/1858)

*Description of changes:*

Although cpp 20 remains not officially supported, there are a few changes we can make to build cpp 20 on windows. One of them being this typo where we are supposed to import `string_view` if cpp > 17. in this instance there was a typo where `_MSC_LANG` is mispelled and it should be `_MSVC_LANG` ([docs](https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170)). it only broke with cpp 20 because u8string hash was added in [cpp 20](https://en.cppreference.com/w/cpp/string/basic_string/hash)
```
template<> struct hash<[std::u8string](http://en.cppreference.com/w/cpp/string/basic_string)>;
template<> struct hash<[std::pmr::u8string](http://en.cppreference.com/w/cpp/string/basic_string)>;
(since C++20)
```

it works on other platforms because `__cplusplus` defined on other platforms.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
