### PR TITLE
Fix memory leak from ApiHandle

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,16 +8,9 @@ file(GLOB TESTS ${TEST_HDRS} ${TEST_SRC})
 
 set(TEST_BINARY_NAME ${PROJECT_NAME}-tests)
 
-# TODO: Always run these tests once the following PR is merged/released:
-# https://github.com/awslabs/aws-c-io/pull/461
-# Currently, the MultiCreateDestroy tests fail due to leaks in s2n.
-# These leaks are only detected when using address-sanitizer.
-if (NOT ENABLE_SANITIZERS)
-    add_test_case(ApiMultiCreateDestroy)
-    add_test_case(ApiMultiDefaultCreateDestroy)
-    add_test_case(ApiStaticDefaultCreateDestroy)
-endif()
-
+add_test_case(ApiMultiCreateDestroy)
+add_test_case(ApiMultiDefaultCreateDestroy)
+add_test_case(ApiStaticDefaultCreateDestroy)
 add_test_case(EventLoopResourceSafety)
 add_test_case(ClientBootstrapResourceSafety)
 if (NOT BYO_CRYPTO)


### PR DESCRIPTION
Fix comes by updating aws-c-io submodule: https://github.com/awslabs/aws-c-io/pull/461

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
