### PR TITLE
MQTT builder custom authorizer support

### DIFF
--- a/include/aws/iot/MqttClient.h
+++ b/include/aws/iot/MqttClient.h
@@ -465,9 +465,9 @@ namespace Aws
 
             // Helper function to add parameters to the username in the WithCustomAuthorizer function
             Crt::String AddToUsernameParameter(
-                Crt::String current_username,
-                Crt::String parameter_value,
-                Crt::String parameter_pre_text);
+                Crt::String currentUsername,
+                Crt::String parameterValue,
+                Crt::String parameterPreText);
 
             Crt::Allocator *m_allocator;
             Crt::String m_endpoint;

--- a/include/aws/iot/MqttClient.h
+++ b/include/aws/iot/MqttClient.h
@@ -254,6 +254,13 @@ namespace Aws
                 Crt::Allocator *allocator = Crt::g_allocator) noexcept;
 
             /**
+             * Creates a new builder with default Tls options. This requires setting the connection details manually.
+             *
+             * @return a new builder with default Tls options
+             */
+            static MqttClientConnectionConfigBuilder newDefaultBuilder() noexcept;
+
+            /**
              * Sets endpoint to connect to.
              *
              * @param endpoint endpoint to connect to
@@ -397,6 +404,45 @@ namespace Aws
             MqttClientConnectionConfigBuilder &WithSdkVersion(const Crt::String &sdkVersion);
 
             /**
+             * Sets the custom authorizer settings. This function will modify the username, port, and TLS options.
+             *
+             * @param username The username to use with the custom authorizer. If an empty string is passed, it will
+             *                 check to see if a username has already been set (via WithUsername function). If no
+             *                 username is set then no username will be passed with the MQTT connection.
+             * @param authorizerName The name of the custom authorizer. If an empty string is passed, then
+             *                       'x-amz-customauthorizer-name' will not be added with the MQTT connection.
+             * @param authorizerSignature The signature of the custom authorizer. If an empty string is passed, then
+             *                            'x-amz-customauthorizer-signature' will not be added with the MQTT connection.
+             * @param password The password to use with the custom authorizer. If null is passed, then no password will
+             *                 be set.
+             *
+             * @return this builder object
+             */
+            MqttClientConnectionConfigBuilder &WithCustomAuthorizer(
+                const Crt::String &username,
+                const Crt::String &authorizerName,
+                const Crt::String &authorizerSignature,
+                const Crt::String &password) noexcept;
+
+            /**
+             * Sets username for the connection
+             *
+             * @param username the username that will be passed with the MQTT connection
+             *
+             * @return this builder object
+             */
+            MqttClientConnectionConfigBuilder &WithUsername(const Crt::String &username) noexcept;
+
+            /**
+             * Sets password for the connection
+             *
+             * @param password the password that will be passed with the MQTT connection
+             *
+             * @return this builder object
+             */
+            MqttClientConnectionConfigBuilder &WithPassword(const Crt::String &password) noexcept;
+
+            /**
              * Builds a client configuration object from the set options.
              *
              * @return a new client connection config instance
@@ -417,6 +463,13 @@ namespace Aws
             // Common setup shared by all valid constructors
             MqttClientConnectionConfigBuilder(Crt::Allocator *allocator) noexcept;
 
+            // Helper function to add parameters to the username in the WithCustomAuthorizer function
+            Crt::String AddUsernameParameter(
+                Crt::String InputString,
+                Crt::String ParameterValue,
+                Crt::String ParameterPreText,
+                bool AddedStringToUsername);
+
             Crt::Allocator *m_allocator;
             Crt::String m_endpoint;
             uint16_t m_portOverride;
@@ -427,6 +480,9 @@ namespace Aws
             bool m_enableMetricsCollection = true;
             Crt::String m_sdkName = "CPPv2";
             Crt::String m_sdkVersion = AWS_CRT_CPP_VERSION;
+            Crt::String m_username = "";
+            Crt::String m_password = "";
+            bool m_isUsingCustomAuthorizer = false;
 
             int m_lastError;
         };

--- a/include/aws/iot/MqttClient.h
+++ b/include/aws/iot/MqttClient.h
@@ -258,7 +258,7 @@ namespace Aws
              *
              * @return a new builder with default Tls options
              */
-            static MqttClientConnectionConfigBuilder newDefaultBuilder() noexcept;
+            static MqttClientConnectionConfigBuilder NewDefaultBuilder() noexcept;
 
             /**
              * Sets endpoint to connect to.

--- a/include/aws/iot/MqttClient.h
+++ b/include/aws/iot/MqttClient.h
@@ -464,11 +464,10 @@ namespace Aws
             MqttClientConnectionConfigBuilder(Crt::Allocator *allocator) noexcept;
 
             // Helper function to add parameters to the username in the WithCustomAuthorizer function
-            Crt::String AddUsernameParameter(
-                Crt::String InputString,
-                Crt::String ParameterValue,
-                Crt::String ParameterPreText,
-                bool AddedStringToUsername);
+            Crt::String AddToUsernameParameter(
+                Crt::String current_username,
+                Crt::String parameter_value,
+                Crt::String parameter_pre_text);
 
             Crt::Allocator *m_allocator;
             Crt::String m_endpoint;

--- a/source/iot/MqttClient.cpp
+++ b/source/iot/MqttClient.cpp
@@ -323,29 +323,28 @@ namespace Aws
             return *this;
         }
 
-        Crt::String MqttClientConnectionConfigBuilder::AddUsernameParameter(
-            Crt::String InputString,
-            Crt::String ParameterValue,
-            Crt::String ParameterPreText,
-            bool AddedStringToUsername)
+        Crt::String MqttClientConnectionConfigBuilder::AddToUsernameParameter(
+            Crt::String current_username,
+            Crt::String parameter_value,
+            Crt::String parameter_pre_text)
         {
-            Crt::String ReturnString = InputString;
-            if (AddedStringToUsername == false)
+            Crt::String return_string = current_username;
+            if (return_string.find("?") != Crt::String::npos)
             {
-                ReturnString += "?";
+                return_string += "&";
             }
             else
             {
-                ReturnString += "&";
+                return_string += "?";
             }
 
-            if (ParameterValue.find(ParameterPreText) != Crt::String::npos)
+            if (parameter_value.find(parameter_pre_text) != Crt::String::npos)
             {
-                return ReturnString + ParameterValue;
+                return return_string + parameter_value;
             }
             else
             {
-                return ReturnString + ParameterPreText + ParameterValue;
+                return return_string + parameter_pre_text + parameter_value;
             }
         }
 
@@ -363,7 +362,6 @@ namespace Aws
 
             m_isUsingCustomAuthorizer = true;
             Crt::String usernameString = "";
-            bool addedStringToUsername = false;
 
             if (username.empty())
             {
@@ -379,14 +377,13 @@ namespace Aws
 
             if (!authorizerName.empty())
             {
-                usernameString = AddUsernameParameter(
-                    usernameString, authorizerName, "x-amz-customauthorizer-name=", addedStringToUsername);
-                addedStringToUsername = true;
+                usernameString = AddToUsernameParameter(
+                    usernameString, authorizerName, "x-amz-customauthorizer-name=");
             }
             if (!authorizerSignature.empty())
             {
-                usernameString = AddUsernameParameter(
-                    usernameString, authorizerSignature, "x-amz-customauthorizer-signature=", addedStringToUsername);
+                usernameString = AddToUsernameParameter(
+                    usernameString, authorizerSignature, "x-amz-customauthorizer-signature=");
             }
 
             m_username = usernameString;

--- a/source/iot/MqttClient.cpp
+++ b/source/iot/MqttClient.cpp
@@ -377,13 +377,12 @@ namespace Aws
 
             if (!authorizerName.empty())
             {
-                usernameString = AddToUsernameParameter(
-                    usernameString, authorizerName, "x-amz-customauthorizer-name=");
+                usernameString = AddToUsernameParameter(usernameString, authorizerName, "x-amz-customauthorizer-name=");
             }
             if (!authorizerSignature.empty())
             {
-                usernameString = AddToUsernameParameter(
-                    usernameString, authorizerSignature, "x-amz-customauthorizer-signature=");
+                usernameString =
+                    AddToUsernameParameter(usernameString, authorizerSignature, "x-amz-customauthorizer-signature=");
             }
 
             m_username = usernameString;

--- a/source/iot/MqttClient.cpp
+++ b/source/iot/MqttClient.cpp
@@ -205,7 +205,7 @@ namespace Aws
             m_websocketConfig = config;
         }
 
-        MqttClientConnectionConfigBuilder MqttClientConnectionConfigBuilder::newDefaultBuilder() noexcept
+        MqttClientConnectionConfigBuilder MqttClientConnectionConfigBuilder::NewDefaultBuilder() noexcept
         {
             MqttClientConnectionConfigBuilder return_value =
                 MqttClientConnectionConfigBuilder(Aws::Crt::DefaultAllocator());
@@ -436,15 +436,6 @@ namespace Aws
                 }
             }
 
-            if (port == 443 && !m_websocketConfig && Crt::Io::TlsContextOptions::IsAlpnSupported() &&
-                !m_isUsingCustomAuthorizer)
-            {
-                if (!m_contextOptions.SetAlpnList("x-amzn-mqtt-ca"))
-                {
-                    return MqttClientConnectionConfig::CreateInvalid(m_contextOptions.LastError());
-                }
-            }
-
             Crt::String username = m_username;
             Crt::String password = m_password;
 
@@ -460,6 +451,16 @@ namespace Aws
                     }
                 }
             }
+
+            if (port == 443 && !m_websocketConfig && Crt::Io::TlsContextOptions::IsAlpnSupported() &&
+                !m_isUsingCustomAuthorizer)
+            {
+                if (!m_contextOptions.SetAlpnList("x-amzn-mqtt-ca"))
+                {
+                    return MqttClientConnectionConfig::CreateInvalid(m_contextOptions.LastError());
+                }
+            }
+
             // Is the user trying to connect using a custom authorizer?
             if (m_isUsingCustomAuthorizer)
             {

--- a/source/iot/MqttClient.cpp
+++ b/source/iot/MqttClient.cpp
@@ -324,11 +324,11 @@ namespace Aws
         }
 
         Crt::String MqttClientConnectionConfigBuilder::AddToUsernameParameter(
-            Crt::String current_username,
-            Crt::String parameter_value,
-            Crt::String parameter_pre_text)
+            Crt::String currentUsername,
+            Crt::String parameterValue,
+            Crt::String parameterPreText)
         {
-            Crt::String return_string = current_username;
+            Crt::String return_string = currentUsername;
             if (return_string.find("?") != Crt::String::npos)
             {
                 return_string += "&";
@@ -338,13 +338,13 @@ namespace Aws
                 return_string += "?";
             }
 
-            if (parameter_value.find(parameter_pre_text) != Crt::String::npos)
+            if (parameterValue.find(parameterPreText) != Crt::String::npos)
             {
-                return return_string + parameter_value;
+                return return_string + parameterValue;
             }
             else
             {
-                return return_string + parameter_pre_text + parameter_value;
+                return return_string + parameterPreText + parameterValue;
             }
         }
 


### PR DESCRIPTION
*Description of changes:*

Modified MQTT connection builder to allow custom authorizer support. Added missing username and password options, and also added a function to make a default builder. All of these changes make MQTT connection builder closer to the Java V2 SDK in option parity, as well as adding custom authorizer support.

______________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
