### PR TITLE
Document building for Apple silicon (M1).

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,8 @@ jobs:
         python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
         chmod a+x builder
         ./builder build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DCMAKE_OSX_ARCHITECTURES=arm64 run_tests=false
-        test `lipo build/install/lib/libaws-crt-cpp.a -archs` = "arm64"
+        pwd
+        test `lipo aws-crt-cpp/build/install/lib/libaws-crt-cpp.a -archs` = "arm64"
 
   ios-cross-compile:
     runs-on: macos-11 # latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
 
   # cross-compile for Apple silicon
   # it would be better to run tests natively on one of these machines,
-  # but we don't have access to one in the cloud so for now just cross-compile
+  # but we don't have access to one in the cloud, so for now just cross-compile
   osx-arm64-cross-compile:
     runs-on: macos-11 # latest
     steps:
@@ -181,6 +181,7 @@ jobs:
         python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
         chmod a+x builder
         ./builder build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DCMAKE_OSX_ARCHITECTURES=arm64 run_tests=false
+        test `lipo build/install/lib/libaws-crt-cpp.a -archs` = "arm64"
 
   ios-cross-compile:
     runs-on: macos-11 # latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,18 @@ jobs:
         chmod a+x builder
         ./builder build -p ${{ env.PACKAGE_NAME }} --spec=downstream
 
+  # cross-compile for Apple silicon
+  # it would be better to run tests natively on one of these machines,
+  # but we don't have access to one in the cloud so for now just cross-compile
+  osx-arm64-cross-compile:
+    runs-on: macos-11 # latest
+    steps:
+    - name: Build ${{ env.PACKAGE_NAME }} + consumers
+      run: |
+        python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
+        chmod a+x builder
+        ./builder build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DCMAKE_OSX_ARCHITECTURES=arm64 run_tests=false
+
   ios-cross-compile:
     runs-on: macos-11 # latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,6 @@ jobs:
         python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
         chmod a+x builder
         ./builder build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DCMAKE_OSX_ARCHITECTURES=arm64 run_tests=false
-        pwd
         test `lipo aws-crt-cpp/build/install/lib/libaws-crt-cpp.a -archs` = "arm64"
 
   ios-cross-compile:

--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ If you want to manage these dependencies manually (e.g. you're using them in oth
 ### MSVC
 If you want to use a statically linked MSVCRT (/MT, /MTd), you can add `-DSTATIC_CRT=ON` to your cmake configuration.
 
+### Apple Silicon (aka M1) and Universal Binaries
+
+aws-crt-cpp supports both `arm64` and `x86_64` architectures.
+Configure cmake with `-DCMAKE_OSX_ARCHITECTURES=arm64` to target Apple silicon,
+or `-DCMAKE_OSX_ARCHITECTURES=x86_64` to target Intel.
+If you wish to create a [universal binary](https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary),
+you should use `lipo` to combine the `x86_64` and `arm64` binaries.
+For example: `lipo -create -output universal_app x86_app arm_app`
+
+You SHOULD NOT build for both architectures simultaneously via `-DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"`.
+aws-crt-cpp has not been tested in this configuration.
+aws-crt-cpp's cmake configuration scripts are known to get confused by this,
+and will not enable optimizations that would benefit an independent `arm64` or `x86_64` build.
+
 ## Dependencies?
 
 There are no non-OS dependencies that AWS does not own, maintain, and ship.


### PR DESCRIPTION
* Document how to build.
* Add CI job to ensure it builds.
  * Unfortunately can't run tests in CI because we don't have access to an M1 cloud machine.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
