### PR TITLE
fix: make static build compiler flags public so they are inherited

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,9 +284,9 @@ aws_prepare_symbol_visibility_args(${PROJECT_NAME} "AWS_CRT_CPP")
 #set runtime library
 if (MSVC)
     if(STATIC_CRT)
-        target_compile_options(${PROJECT_NAME} PRIVATE "/MT$<$<CONFIG:Debug>:d>")
+        target_compile_options(${PROJECT_NAME} PUBLIC "/MT$<$<CONFIG:Debug>:d>")
     else()
-        target_compile_options(${PROJECT_NAME} PRIVATE "/MD$<$<CONFIG:Debug>:d>")
+        target_compile_options(${PROJECT_NAME} PUBLIC "/MD$<$<CONFIG:Debug>:d>")
     endif()
 endif ()
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Without this change, compiling with `-DSTATIC_CRT=ON` does not statically compile the subprojects (Greengrass IPC for example).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
