### PR TITLE
Explicit permissions for update-docs-branch job

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   update-docs-branch:
     runs-on: ubuntu-20.04 # latest
+    permissions:
+      contents: write
+      contents-reason: to push changes
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,7 +5,7 @@ name: docs
 on:
   push:
     branches:
-      - 'ci-deleteme'
+      - 'main'
 
 jobs:
   update-docs-branch:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,7 +5,7 @@ name: docs
 on:
   push:
     branches:
-      - 'main'
+      - 'ci-deleteme'
 
 jobs:
   update-docs-branch:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,8 +11,7 @@ jobs:
   update-docs-branch:
     runs-on: ubuntu-20.04 # latest
     permissions:
-      contents: write
-      contents-reason: to push changes
+      contents: write # allow push
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Our Github workflows no longer have write permissions by default, so this job needs to be opted-in.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
