### PR TITLE
Support /DELAYLOAD DLLs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,22 @@ jobs:
         python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
         python builder.pyz build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DBUILD_SHARED_LIBS=ON
 
+  # Ensure users can link with /DELAYLOAD:aws-crt-cpp.dll
+  # We test by building everything using those linker flags.
+  # This will cause linker errors in the tests if an API is built wrong (assuming the API is tested).
+  # Usually the problem is extern global variables, and the fix is offering getter functions instead.
+  windows-delayload-dll:
+    runs-on: windows-2022 # latest
+    env:
+      LDFLAGS: /DELAYLOAD:aws-crt-cpp.dll
+    steps:
+    - name: Build ${{ env.PACKAGE_NAME }} + consumers
+      run: |
+        md D:\a\work
+        cd D:\a\work
+        python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
+        python builder.pyz build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DBUILD_SHARED_LIBS=ON
+
   windows-no-cpu-extensions:
     runs-on: windows-2022 # latest
     steps:

--- a/include/aws/crt/Allocator.h
+++ b/include/aws/crt/Allocator.h
@@ -1,0 +1,47 @@
+#pragma once
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#include <aws/common/common.h>
+#include <aws/crt/Exports.h>
+
+namespace Aws
+{
+    namespace Crt
+    {
+        using Allocator = aws_allocator;
+
+        /**
+         * Each object from this library can use an explicit allocator.
+         * If you construct an object without specifying an allocator,
+         * then THIS allocator is used instead.
+         *
+         * You can customize this allocator when initializing
+         * \ref ApiHandle::ApiHandle(Allocator*) "ApiHandle".
+         */
+        AWS_CRT_CPP_API Allocator *ApiAllocator() noexcept;
+
+        /**
+         * Returns the default implementation of an Allocator.
+         *
+         * If you initialize \ref ApiHandle::ApiHandle(Allocator*) "ApiHandle"
+         * without specifying a custom allocator, then this implementation is used.
+         */
+        AWS_CRT_CPP_API Allocator *DefaultAllocatorImplementation() noexcept;
+
+        /**
+         * @deprecated Use DefaultAllocatorImplementation() instead.
+         * DefaultAllocator() is too easily confused with ApiAllocator().
+         */
+        AWS_CRT_CPP_API Allocator *DefaultAllocator() noexcept;
+
+        /**
+         * @deprecated Use ApiAllocator() instead, to avoid issues with delay-loaded DLLs.
+         * https://github.com/aws/aws-sdk-cpp/issues/1960
+         */
+        extern AWS_CRT_CPP_API Allocator *g_allocator;
+
+    } // namespace Crt
+} // namespace Aws

--- a/include/aws/crt/Api.h
+++ b/include/aws/crt/Api.h
@@ -46,6 +46,10 @@ namespace Aws
         class AWS_CRT_CPP_API ApiHandle
         {
           public:
+            /**
+             * Customize the ApiAllocator(), which is be used by any objects
+             * constructed without an explicit allocator.
+             */
             ApiHandle(Allocator *allocator) noexcept;
             ApiHandle() noexcept;
             ~ApiHandle();

--- a/include/aws/crt/ImdsClient.h
+++ b/include/aws/crt/ImdsClient.h
@@ -140,7 +140,7 @@ namespace Aws
             class AWS_CRT_CPP_API ImdsClient
             {
               public:
-                ImdsClient(const ImdsClientConfig &config, Allocator *allocator = g_allocator) noexcept;
+                ImdsClient(const ImdsClientConfig &config, Allocator *allocator = ApiAllocator()) noexcept;
 
                 ~ImdsClient();
 

--- a/include/aws/crt/StlAllocator.h
+++ b/include/aws/crt/StlAllocator.h
@@ -4,19 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-#include <memory>
+#include <aws/crt/Allocator.h>
 
-#include <aws/common/common.h>
-#include <aws/crt/Exports.h>
+#include <memory>
 #include <type_traits>
 
 namespace Aws
 {
     namespace Crt
     {
-        using Allocator = aws_allocator;
-        extern AWS_CRT_CPP_API Allocator *g_allocator;
-
         /**
          * Stateful allocator variant that uses an underlying CRT allocator
          * @tparam T type that allocator can allocate
@@ -26,7 +22,7 @@ namespace Aws
           public:
             using Base = std::allocator<T>;
 
-            StlAllocator() noexcept : Base() { m_allocator = g_allocator; }
+            StlAllocator() noexcept : Base() { m_allocator = ApiAllocator(); }
 
             StlAllocator(Allocator *allocator) noexcept : Base() { m_allocator = allocator; }
 

--- a/include/aws/crt/Types.h
+++ b/include/aws/crt/Types.h
@@ -19,7 +19,6 @@
 #include <utility>
 #include <vector>
 
-struct aws_allocator;
 struct aws_byte_buf;
 struct aws_byte_cursor;
 struct aws_socket_options;
@@ -28,7 +27,6 @@ namespace Aws
 {
     namespace Crt
     {
-        using Allocator = aws_allocator;
         using ByteBuf = aws_byte_buf;
         using ByteCursor = aws_byte_cursor;
 
@@ -55,7 +53,6 @@ namespace Aws
         template <typename T> using Vector = std::vector<T, StlAllocator<T>>;
         template <typename T> using List = std::list<T, StlAllocator<T>>;
 
-        AWS_CRT_CPP_API Allocator *DefaultAllocator() noexcept;
         AWS_CRT_CPP_API ByteBuf ByteBufFromCString(const char *str) noexcept;
         AWS_CRT_CPP_API ByteBuf ByteBufFromEmptyArray(const uint8_t *array, size_t len) noexcept;
         AWS_CRT_CPP_API ByteBuf ByteBufFromArray(const uint8_t *array, size_t capacity) noexcept;

--- a/include/aws/crt/auth/Credentials.h
+++ b/include/aws/crt/auth/Credentials.h
@@ -43,7 +43,7 @@ namespace Aws
                     ByteCursor secret_access_key,
                     ByteCursor session_token,
                     uint64_t expiration_timepoint_in_seconds,
-                    Allocator *allocator = g_allocator) noexcept;
+                    Allocator *allocator = ApiAllocator()) noexcept;
 
                 ~Credentials();
 
@@ -337,7 +337,7 @@ namespace Aws
             class AWS_CRT_CPP_API CredentialsProvider : public ICredentialsProvider
             {
               public:
-                CredentialsProvider(aws_credentials_provider *provider, Allocator *allocator = g_allocator) noexcept;
+                CredentialsProvider(aws_credentials_provider *provider, Allocator *allocator = ApiAllocator()) noexcept;
 
                 virtual ~CredentialsProvider();
 
@@ -370,27 +370,27 @@ namespace Aws
                  */
                 static std::shared_ptr<ICredentialsProvider> CreateCredentialsProviderStatic(
                     const CredentialsProviderStaticConfig &config,
-                    Allocator *allocator = g_allocator);
+                    Allocator *allocator = ApiAllocator());
 
                 /**
                  * Creates a provider that returns credentials sourced from environment variables
                  */
                 static std::shared_ptr<ICredentialsProvider> CreateCredentialsProviderEnvironment(
-                    Allocator *allocator = g_allocator);
+                    Allocator *allocator = ApiAllocator());
 
                 /**
                  * Creates a provider that returns credentials sourced from config files
                  */
                 static std::shared_ptr<ICredentialsProvider> CreateCredentialsProviderProfile(
                     const CredentialsProviderProfileConfig &config,
-                    Allocator *allocator = g_allocator);
+                    Allocator *allocator = ApiAllocator());
 
                 /**
                  * Creates a provider that returns credentials sourced from Ec2 instance metadata service
                  */
                 static std::shared_ptr<ICredentialsProvider> CreateCredentialsProviderImds(
                     const CredentialsProviderImdsConfig &config,
-                    Allocator *allocator = g_allocator);
+                    Allocator *allocator = ApiAllocator());
 
                 /**
                  * Creates a provider that sources credentials by querying a series of providers and
@@ -398,7 +398,7 @@ namespace Aws
                  */
                 static std::shared_ptr<ICredentialsProvider> CreateCredentialsProviderChain(
                     const CredentialsProviderChainConfig &config,
-                    Allocator *allocator = g_allocator);
+                    Allocator *allocator = ApiAllocator());
 
                 /*
                  * Creates a provider that puts a simple time-based cache in front of its queries
@@ -406,7 +406,7 @@ namespace Aws
                  */
                 static std::shared_ptr<ICredentialsProvider> CreateCredentialsProviderCached(
                     const CredentialsProviderCachedConfig &config,
-                    Allocator *allocator = g_allocator);
+                    Allocator *allocator = ApiAllocator());
 
                 /**
                  * Creates the SDK-standard default credentials provider which is a cache-fronted chain of:
@@ -416,7 +416,7 @@ namespace Aws
                  */
                 static std::shared_ptr<ICredentialsProvider> CreateCredentialsProviderChainDefault(
                     const CredentialsProviderChainDefaultConfig &config,
-                    Allocator *allocator = g_allocator);
+                    Allocator *allocator = ApiAllocator());
 
                 /**
                  * Creates a provider that sources credentials from the IoT X509 provider service
@@ -424,7 +424,7 @@ namespace Aws
                  */
                 static std::shared_ptr<ICredentialsProvider> CreateCredentialsProviderX509(
                     const CredentialsProviderX509Config &config,
-                    Allocator *allocator = g_allocator);
+                    Allocator *allocator = ApiAllocator());
 
                 /**
                  * Creates a provider that sources credentials from the provided function.
@@ -432,7 +432,7 @@ namespace Aws
                  */
                 static std::shared_ptr<ICredentialsProvider> CreateCredentialsProviderDelegate(
                     const CredentialsProviderDelegateConfig &config,
-                    Allocator *allocator = g_allocator);
+                    Allocator *allocator = ApiAllocator());
 
               private:
                 static void s_onCredentialsResolved(aws_credentials *credentials, int error_code, void *user_data);

--- a/include/aws/crt/auth/Sigv4Signing.h
+++ b/include/aws/crt/auth/Sigv4Signing.h
@@ -123,7 +123,7 @@ namespace Aws
             class AWS_CRT_CPP_API AwsSigningConfig : public ISigningConfig
             {
               public:
-                AwsSigningConfig(Allocator *allocator = g_allocator);
+                AwsSigningConfig(Allocator *allocator = ApiAllocator());
                 virtual ~AwsSigningConfig();
 
                 virtual SigningConfigType GetType() const noexcept override { return SigningConfigType::Aws; }
@@ -320,7 +320,7 @@ namespace Aws
             class AWS_CRT_CPP_API Sigv4HttpRequestSigner : public IHttpRequestSigner
             {
               public:
-                Sigv4HttpRequestSigner(Allocator *allocator = g_allocator);
+                Sigv4HttpRequestSigner(Allocator *allocator = ApiAllocator());
                 virtual ~Sigv4HttpRequestSigner() = default;
 
                 bool IsValid() const override { return true; }

--- a/include/aws/crt/auth/Sigv4Signing.h
+++ b/include/aws/crt/auth/Sigv4Signing.h
@@ -80,21 +80,32 @@ namespace Aws
                  * 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
                  * For use with `Aws::Crt::Auth::AwsSigningConfig.SetSignedBodyValue()`.
                  */
-                AWS_CRT_CPP_API extern const char *EmptySha256;
+                AWS_CRT_CPP_API const char *EmptySha256Str();
+
                 /**
                  * 'UNSIGNED-PAYLOAD'
                  * For use with `Aws::Crt::Auth::AwsSigningConfig.SetSignedBodyValue()`.
                  */
-                AWS_CRT_CPP_API extern const char *UnsignedPayload;
+                AWS_CRT_CPP_API const char *UnsignedPayloadStr();
+
                 /**
                  * 'STREAMING-AWS4-HMAC-SHA256-PAYLOAD'
                  * For use with `Aws::Crt::Auth::AwsSigningConfig.SetSignedBodyValue()`.
                  */
-                AWS_CRT_CPP_API extern const char *StreamingAws4HmacSha256Payload;
+                AWS_CRT_CPP_API const char *StreamingAws4HmacSha256PayloadStr();
                 /**
                  * 'STREAMING-AWS4-HMAC-SHA256-EVENTS'
                  * For use with `Aws::Crt::Auth::AwsSigningConfig.SetSignedBodyValue()`.
                  */
+                AWS_CRT_CPP_API const char *StreamingAws4HmacSha256EventsStr();
+
+                /** @deprecated to avoid issues with /DELAYLOAD on Windows. */
+                AWS_CRT_CPP_API extern const char *UnsignedPayload;
+                /** @deprecated to avoid issues with /DELAYLOAD on Windows. */
+                AWS_CRT_CPP_API extern const char *EmptySha256;
+                /** @deprecated to avoid issues with /DELAYLOAD on Windows. */
+                AWS_CRT_CPP_API extern const char *StreamingAws4HmacSha256Payload;
+                /** @deprecated to avoid issues with /DELAYLOAD on Windows. */
                 AWS_CRT_CPP_API extern const char *StreamingAws4HmacSha256Events;
             } // namespace SignedBodyValue
 

--- a/include/aws/crt/crypto/HMAC.h
+++ b/include/aws/crt/crypto/HMAC.h
@@ -115,7 +115,7 @@ namespace Aws
                 aws_hmac *SeatForCInterop(const std::shared_ptr<ByoHMAC> &selfRef);
 
               protected:
-                ByoHMAC(size_t digestSize, const ByteCursor &secret, Allocator *allocator = g_allocator);
+                ByoHMAC(size_t digestSize, const ByteCursor &secret, Allocator *allocator = ApiAllocator());
 
                 /**
                  * Updates the running HMAC with to_hash.

--- a/include/aws/crt/crypto/Hash.h
+++ b/include/aws/crt/crypto/Hash.h
@@ -86,12 +86,12 @@ namespace Aws
                 /**
                  * Creates an instance of a Streaming SHA256 Hash.
                  */
-                static Hash CreateSHA256(Allocator *allocator = g_allocator) noexcept;
+                static Hash CreateSHA256(Allocator *allocator = ApiAllocator()) noexcept;
 
                 /**
                  * Creates an instance of a Streaming MD5 Hash.
                  */
-                static Hash CreateMD5(Allocator *allocator = g_allocator) noexcept;
+                static Hash CreateMD5(Allocator *allocator = ApiAllocator()) noexcept;
 
                 /**
                  * Updates the running hash object with data in toHash. Returns true on success. Call
@@ -134,7 +134,7 @@ namespace Aws
                 aws_hash *SeatForCInterop(const std::shared_ptr<ByoHash> &selfRef);
 
               protected:
-                ByoHash(size_t digestSize, Allocator *allocator = g_allocator);
+                ByoHash(size_t digestSize, Allocator *allocator = ApiAllocator());
 
                 /**
                  * Update the running hash with to_hash.

--- a/include/aws/crt/http/HttpConnectionManager.h
+++ b/include/aws/crt/http/HttpConnectionManager.h
@@ -98,12 +98,12 @@ namespace Aws
                  */
                 static std::shared_ptr<HttpClientConnectionManager> NewClientConnectionManager(
                     const HttpClientConnectionManagerOptions &connectionManagerOptions,
-                    Allocator *allocator = g_allocator) noexcept;
+                    Allocator *allocator = ApiAllocator()) noexcept;
 
               private:
                 HttpClientConnectionManager(
                     const HttpClientConnectionManagerOptions &options,
-                    Allocator *allocator = g_allocator) noexcept;
+                    Allocator *allocator = ApiAllocator()) noexcept;
 
                 Allocator *m_allocator;
 

--- a/include/aws/crt/http/HttpProxyStrategy.h
+++ b/include/aws/crt/http/HttpProxyStrategy.h
@@ -95,7 +95,7 @@ namespace Aws
                  */
                 static std::shared_ptr<HttpProxyStrategy> CreateBasicHttpProxyStrategy(
                     const HttpProxyStrategyBasicAuthConfig &config,
-                    Allocator *allocator = g_allocator);
+                    Allocator *allocator = ApiAllocator());
 
                 /**
                  * Creates a proxy strategy that, depending on configuration, can attempt kerberos and/or ntlm
@@ -106,7 +106,7 @@ namespace Aws
                  */
                 static std::shared_ptr<HttpProxyStrategy> CreateAdaptiveHttpProxyStrategy(
                     const HttpProxyStrategyAdaptiveConfig &config,
-                    Allocator *allocator = g_allocator);
+                    Allocator *allocator = ApiAllocator());
 
               protected:
                 struct aws_http_proxy_strategy *m_strategy;

--- a/include/aws/crt/http/HttpRequestResponse.h
+++ b/include/aws/crt/http/HttpRequestResponse.h
@@ -107,7 +107,7 @@ namespace Aws
                 friend class Mqtt::MqttConnection;
 
               public:
-                HttpRequest(Allocator *allocator = g_allocator);
+                HttpRequest(Allocator *allocator = ApiAllocator());
 
                 /**
                  * @return the value of the Http method associated with this request
@@ -139,7 +139,7 @@ namespace Aws
             class AWS_CRT_CPP_API HttpResponse : public HttpMessage
             {
               public:
-                HttpResponse(Allocator *allocator = g_allocator);
+                HttpResponse(Allocator *allocator = ApiAllocator());
 
                 /**
                  * @return the integral Http response code associated with this response

--- a/include/aws/crt/io/Bootstrap.h
+++ b/include/aws/crt/io/Bootstrap.h
@@ -42,14 +42,14 @@ namespace Aws
                 ClientBootstrap(
                     EventLoopGroup &elGroup,
                     HostResolver &resolver,
-                    Allocator *allocator = g_allocator) noexcept;
+                    Allocator *allocator = ApiAllocator()) noexcept;
 
                 /**
                  * Uses the default EventLoopGroup and HostResolver.
                  * See Aws::Crt::ApiHandle::GetOrCreateStaticDefaultEventLoopGroup
                  * and Aws::Crt::ApiHandle::GetOrCreateStaticDefaultHostResolver
                  */
-                ClientBootstrap(Allocator *allocator = g_allocator) noexcept;
+                ClientBootstrap(Allocator *allocator = ApiAllocator()) noexcept;
 
                 ~ClientBootstrap();
                 ClientBootstrap(const ClientBootstrap &) = delete;

--- a/include/aws/crt/io/ChannelHandler.h
+++ b/include/aws/crt/io/ChannelHandler.h
@@ -157,7 +157,7 @@ namespace Aws
                 void ScheduleTask(std::function<void(TaskStatus)> &&task, std::chrono::nanoseconds run_in);
 
               protected:
-                ChannelHandler(Allocator *allocator = g_allocator);
+                ChannelHandler(Allocator *allocator = ApiAllocator());
 
                 /**
                  * Acquire an aws_io_message from the channel's pool.

--- a/include/aws/crt/io/EventLoopGroup.h
+++ b/include/aws/crt/io/EventLoopGroup.h
@@ -37,14 +37,14 @@ namespace Aws
                  * each processor on the machine.
                  * @param allocator memory allocator to use.
                  */
-                EventLoopGroup(uint16_t threadCount = 0, Allocator *allocator = g_allocator) noexcept;
+                EventLoopGroup(uint16_t threadCount = 0, Allocator *allocator = ApiAllocator()) noexcept;
                 /**
                  * @param cpuGroup: The CPU group (e.g. NUMA nodes) that all hardware threads are pinned to.
                  * @param threadCount: The number of event-loops to create, default will be 0, which will create one for
                  * each processor on the machine.
                  * @param allocator memory allocator to use.
                  */
-                EventLoopGroup(uint16_t cpuGroup, uint16_t threadCount, Allocator *allocator = g_allocator) noexcept;
+                EventLoopGroup(uint16_t cpuGroup, uint16_t threadCount, Allocator *allocator = ApiAllocator()) noexcept;
                 ~EventLoopGroup();
                 EventLoopGroup(const EventLoopGroup &) = delete;
                 EventLoopGroup(EventLoopGroup &&) noexcept;

--- a/include/aws/crt/io/HostResolver.h
+++ b/include/aws/crt/io/HostResolver.h
@@ -62,7 +62,7 @@ namespace Aws
                     EventLoopGroup &elGroup,
                     size_t maxHosts,
                     size_t maxTTL,
-                    Allocator *allocator = g_allocator) noexcept;
+                    Allocator *allocator = ApiAllocator()) noexcept;
 
                 /**
                  * Resolves DNS addresses using the default EventLoopGroup.
@@ -74,7 +74,7 @@ namespace Aws
                  * @param maxTTL: how long to keep an address in the cache before evicting it.
                  * @param allocator memory allocator to use.
                  */
-                DefaultHostResolver(size_t maxHosts, size_t maxTTL, Allocator *allocator = g_allocator) noexcept;
+                DefaultHostResolver(size_t maxHosts, size_t maxTTL, Allocator *allocator = ApiAllocator()) noexcept;
 
                 ~DefaultHostResolver();
                 DefaultHostResolver(const DefaultHostResolver &) = delete;

--- a/include/aws/crt/io/Pkcs11.h
+++ b/include/aws/crt/io/Pkcs11.h
@@ -72,7 +72,7 @@ namespace Aws
                  *         If unsuccessful the `shared_ptr` will be empty, and Aws::Crt::LastError()
                  *         will contain the error that occurred.
                  */
-                static std::shared_ptr<Pkcs11Lib> Create(const String &filename, Allocator *allocator = g_allocator);
+                static std::shared_ptr<Pkcs11Lib> Create(const String &filename, Allocator *allocator = ApiAllocator());
 
                 /**
                  * Load a PKCS#11 library, specifying how `C_Initialize()` and `C_Finalize()` will be called.
@@ -92,7 +92,7 @@ namespace Aws
                 static std::shared_ptr<Pkcs11Lib> Create(
                     const String &filename,
                     InitializeFinalizeBehavior initializeFinalizeBehavior,
-                    Allocator *allocator = g_allocator);
+                    Allocator *allocator = ApiAllocator());
 
                 ~Pkcs11Lib();
 

--- a/include/aws/crt/io/Stream.h
+++ b/include/aws/crt/io/Stream.h
@@ -99,7 +99,7 @@ namespace Aws
                 Allocator *m_allocator;
                 aws_input_stream m_underlying_stream;
 
-                InputStream(Aws::Crt::Allocator *allocator = g_allocator);
+                InputStream(Aws::Crt::Allocator *allocator = ApiAllocator());
 
                 /***
                  * Read up-to buffer::capacity - buffer::len into buffer::buffer
@@ -152,7 +152,7 @@ namespace Aws
               public:
                 StdIOStreamInputStream(
                     std::shared_ptr<Aws::Crt::Io::IStream> stream,
-                    Aws::Crt::Allocator *allocator = g_allocator) noexcept;
+                    Aws::Crt::Allocator *allocator = ApiAllocator()) noexcept;
 
                 bool IsValid() const noexcept override;
 

--- a/include/aws/crt/io/TlsOptions.h
+++ b/include/aws/crt/io/TlsOptions.h
@@ -58,7 +58,7 @@ namespace Aws
                  * Initializes TlsContextOptions with secure by default options, with
                  * no client certificates.
                  */
-                static TlsContextOptions InitDefaultClient(Allocator *allocator = g_allocator) noexcept;
+                static TlsContextOptions InitDefaultClient(Allocator *allocator = ApiAllocator()) noexcept;
 
                 /**
                  * Initializes TlsContextOptions for mutual TLS (mTLS), with
@@ -74,7 +74,7 @@ namespace Aws
                 static TlsContextOptions InitClientWithMtls(
                     const char *cert_path,
                     const char *pkey_path,
-                    Allocator *allocator = g_allocator) noexcept;
+                    Allocator *allocator = ApiAllocator()) noexcept;
 
                 /**
                  * Initializes TlsContextOptions for mutual TLS (mTLS), with
@@ -90,7 +90,7 @@ namespace Aws
                 static TlsContextOptions InitClientWithMtls(
                     const ByteCursor &cert,
                     const ByteCursor &pkey,
-                    Allocator *allocator = g_allocator) noexcept;
+                    Allocator *allocator = ApiAllocator()) noexcept;
 
                 /**
                  * Initializes TlsContextOptions for mutual TLS (mTLS),
@@ -103,7 +103,7 @@ namespace Aws
                  */
                 static TlsContextOptions InitClientWithMtlsPkcs11(
                     const TlsContextPkcs11Options &pkcs11Options,
-                    Allocator *allocator = g_allocator) noexcept;
+                    Allocator *allocator = ApiAllocator()) noexcept;
 
                 /**
                  * Initializes TlsContextOptions for mutual TLS (mTLS), with
@@ -120,7 +120,7 @@ namespace Aws
                 static TlsContextOptions InitClientWithMtlsPkcs12(
                     const char *pkcs12_path,
                     const char *pkcs12_pwd,
-                    Allocator *allocator = g_allocator) noexcept;
+                    Allocator *allocator = ApiAllocator()) noexcept;
 
                 /**
                  * @deprecated Custom keychain management is deprecated.
@@ -147,7 +147,7 @@ namespace Aws
                  */
                 static TlsContextOptions InitClientWithMtlsSystemPath(
                     const char *windowsCertStorePath,
-                    Allocator *allocator = g_allocator) noexcept;
+                    Allocator *allocator = ApiAllocator()) noexcept;
 
                 /**
                  * @return true if alpn is supported by the underlying security provider, false
@@ -216,7 +216,7 @@ namespace Aws
                  */
                 TlsContextPkcs11Options(
                     const std::shared_ptr<Pkcs11Lib> &pkcs11Lib,
-                    Allocator *allocator = g_allocator) noexcept;
+                    Allocator *allocator = ApiAllocator()) noexcept;
 
                 /**
                  * Use this PIN to log the user into the PKCS#11 token.
@@ -344,7 +344,7 @@ namespace Aws
             {
               public:
                 TlsContext() noexcept;
-                TlsContext(TlsContextOptions &options, TlsMode mode, Allocator *allocator = g_allocator) noexcept;
+                TlsContext(TlsContextOptions &options, TlsMode mode, Allocator *allocator = ApiAllocator()) noexcept;
                 ~TlsContext() = default;
                 TlsContext(const TlsContext &) noexcept = default;
                 TlsContext &operator=(const TlsContext &) noexcept = default;
@@ -398,7 +398,7 @@ namespace Aws
                 TlsChannelHandler(
                     struct aws_channel_slot *slot,
                     const struct aws_tls_connection_options &options,
-                    Allocator *allocator = g_allocator);
+                    Allocator *allocator = ApiAllocator());
 
                 /**
                  * Invoke this function from inside your handler after TLS negotiation completes. errorCode ==
@@ -434,7 +434,7 @@ namespace Aws
                 ClientTlsChannelHandler(
                     struct aws_channel_slot *slot,
                     const struct aws_tls_connection_options &options,
-                    Allocator *allocator = g_allocator);
+                    Allocator *allocator = ApiAllocator());
             };
 
             using NewClientTlsHandlerCallback = std::function<std::shared_ptr<ClientTlsChannelHandler>(

--- a/include/aws/crt/io/Uri.h
+++ b/include/aws/crt/io/Uri.h
@@ -26,13 +26,13 @@ namespace Aws
                  * Parses `cursor` as a URI. Upon failure the bool() operator will return false and LastError()
                  * will contain the errorCode.
                  */
-                Uri(const ByteCursor &cursor, Allocator *allocator = g_allocator) noexcept;
+                Uri(const ByteCursor &cursor, Allocator *allocator = ApiAllocator()) noexcept;
 
                 /**
                  * Builds a URI from `builderOptions`. Upon failure the bool() operator will return false and
                  * LastError() will contain the errorCode.
                  */
-                Uri(aws_uri_builder_options &builderOptions, Allocator *allocator = g_allocator) noexcept;
+                Uri(aws_uri_builder_options &builderOptions, Allocator *allocator = ApiAllocator()) noexcept;
 
                 Uri(const Uri &);
                 Uri &operator=(const Uri &);

--- a/include/aws/crt/mqtt/MqttClient.h
+++ b/include/aws/crt/mqtt/MqttClient.h
@@ -425,7 +425,7 @@ namespace Aws
                 /**
                  * Initialize an MqttClient using bootstrap and allocator
                  */
-                MqttClient(Io::ClientBootstrap &bootstrap, Allocator *allocator = g_allocator) noexcept;
+                MqttClient(Io::ClientBootstrap &bootstrap, Allocator *allocator = ApiAllocator()) noexcept;
 
                 /**
                  * Initialize an MqttClient using a allocator and the default ClientBootstrap
@@ -433,7 +433,7 @@ namespace Aws
                  * For more information on the default ClientBootstrap see
                  * Aws::Crt::ApiHandle::GetOrCreateStaticDefaultClientBootstrap
                  */
-                MqttClient(Allocator *allocator = g_allocator) noexcept;
+                MqttClient(Allocator *allocator = ApiAllocator()) noexcept;
 
                 ~MqttClient();
                 MqttClient(const MqttClient &) = delete;

--- a/include/aws/iot/MqttClient.h
+++ b/include/aws/iot/MqttClient.h
@@ -119,7 +119,7 @@ namespace Aws
             WebsocketConfig(
                 const Crt::String &signingRegion,
                 Crt::Io::ClientBootstrap *bootstrap,
-                Crt::Allocator *allocator = Crt::g_allocator) noexcept;
+                Crt::Allocator *allocator = Crt::ApiAllocator()) noexcept;
 
             /**
              * Create a websocket configuration for use with the default credentials provider chain and default
@@ -132,7 +132,7 @@ namespace Aws
              * handshake upgrade request
              * @param allocator memory allocator to use
              */
-            WebsocketConfig(const Crt::String &signingRegion, Crt::Allocator *allocator = Crt::g_allocator) noexcept;
+            WebsocketConfig(const Crt::String &signingRegion, Crt::Allocator *allocator = Crt::ApiAllocator()) noexcept;
 
             /**
              * Create a websocket configuration for use with a custom credentials provider. Signing region will be used
@@ -146,7 +146,7 @@ namespace Aws
             WebsocketConfig(
                 const Crt::String &signingRegion,
                 const std::shared_ptr<Crt::Auth::ICredentialsProvider> &credentialsProvider,
-                Crt::Allocator *allocator = Crt::g_allocator) noexcept;
+                Crt::Allocator *allocator = Crt::ApiAllocator()) noexcept;
 
             /**
              * Create a websocket configuration for use with a custom credentials provider, and a custom signer.
@@ -202,7 +202,7 @@ namespace Aws
             MqttClientConnectionConfigBuilder(
                 const char *certPath,
                 const char *pkeyPath,
-                Crt::Allocator *allocator = Crt::g_allocator) noexcept;
+                Crt::Allocator *allocator = Crt::ApiAllocator()) noexcept;
 
             /**
              * Sets the builder up for MTLS using cert and pkey. These are in-memory buffers and must be in the PEM
@@ -215,7 +215,7 @@ namespace Aws
             MqttClientConnectionConfigBuilder(
                 const Crt::ByteCursor &cert,
                 const Crt::ByteCursor &pkey,
-                Crt::Allocator *allocator = Crt::g_allocator) noexcept;
+                Crt::Allocator *allocator = Crt::ApiAllocator()) noexcept;
 
             /**
              * Sets the builder up for MTLS, using a PKCS#11 library for private key operations.
@@ -227,7 +227,7 @@ namespace Aws
              */
             MqttClientConnectionConfigBuilder(
                 const Crt::Io::TlsContextPkcs11Options &pkcs11Options,
-                Crt::Allocator *allocator = Crt::g_allocator) noexcept;
+                Crt::Allocator *allocator = Crt::ApiAllocator()) noexcept;
 
             /**
              * Sets the builder up for MTLS, using a certificate in a Windows certificate store.
@@ -241,7 +241,7 @@ namespace Aws
              */
             MqttClientConnectionConfigBuilder(
                 const char *windowsCertStorePath,
-                Crt::Allocator *allocator = Crt::g_allocator) noexcept;
+                Crt::Allocator *allocator = Crt::ApiAllocator()) noexcept;
 
             /**
              * Sets the builder up for Websocket connection.
@@ -251,7 +251,7 @@ namespace Aws
              */
             MqttClientConnectionConfigBuilder(
                 const WebsocketConfig &config,
-                Crt::Allocator *allocator = Crt::g_allocator) noexcept;
+                Crt::Allocator *allocator = Crt::ApiAllocator()) noexcept;
 
             /**
              * Creates a new builder with default Tls options. This requires setting the connection details manually.
@@ -494,7 +494,7 @@ namespace Aws
         class AWS_CRT_CPP_API MqttClient final
         {
           public:
-            MqttClient(Crt::Io::ClientBootstrap &bootstrap, Crt::Allocator *allocator = Crt::g_allocator) noexcept;
+            MqttClient(Crt::Io::ClientBootstrap &bootstrap, Crt::Allocator *allocator = Crt::ApiAllocator()) noexcept;
 
             /**
              * Constructs a new Mqtt Client object using the static default ClientBootstrap.
@@ -502,7 +502,7 @@ namespace Aws
              * For more information on the default ClientBootstrap see
              * Aws::Crt::ApiHandle::GetOrCreateDefaultClientBootstrap
              */
-            MqttClient(Crt::Allocator *allocator = Crt::g_allocator) noexcept;
+            MqttClient(Crt::Allocator *allocator = Crt::ApiAllocator()) noexcept;
 
             /**
              * Creates a new mqtt connection from a connection configuration object

--- a/source/Allocator.cpp
+++ b/source/Allocator.cpp
@@ -1,0 +1,21 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#include <aws/crt/Allocator.h>
+
+namespace Aws
+{
+    namespace Crt
+    {
+
+        Allocator *DefaultAllocatorImplementation() noexcept { return aws_default_allocator(); }
+
+        Allocator *DefaultAllocator() noexcept { return DefaultAllocatorImplementation(); }
+
+        Allocator *g_allocator = Aws::Crt::DefaultAllocatorImplementation();
+
+        Allocator *ApiAllocator() noexcept { return g_allocator; }
+
+    } // namespace Crt
+} // namespace Aws

--- a/source/Api.cpp
+++ b/source/Api.cpp
@@ -20,8 +20,6 @@ namespace Aws
 {
     namespace Crt
     {
-        Allocator *g_allocator = Aws::Crt::DefaultAllocator();
-
         static Crypto::CreateHashCallback s_BYOCryptoNewMD5Callback;
         static Crypto::CreateHashCallback s_BYOCryptoNewSHA256Callback;
         static Crypto::CreateHMACCallback s_BYOCryptoNewSHA256HMACCallback;
@@ -38,9 +36,9 @@ namespace Aws
         std::mutex ApiHandle::s_lock_event_loop_group;
         std::mutex ApiHandle::s_lock_default_host_resolver;
 
-        static void *s_cJSONAlloc(size_t sz) { return aws_mem_acquire(g_allocator, sz); }
+        static void *s_cJSONAlloc(size_t sz) { return aws_mem_acquire(ApiAllocator(), sz); }
 
-        static void s_cJSONFree(void *ptr) { return aws_mem_release(g_allocator, ptr); }
+        static void s_cJSONFree(void *ptr) { return aws_mem_release(ApiAllocator(), ptr); }
 
         static void s_initApi(Allocator *allocator)
         {
@@ -133,7 +131,7 @@ namespace Aws
                 }
             }
 
-            if (aws_logger_init_standard(&m_logger, g_allocator, &options))
+            if (aws_logger_init_standard(&m_logger, ApiAllocator(), &options))
             {
                 return;
             }
@@ -315,7 +313,7 @@ namespace Aws
             if (s_static_bootstrap == nullptr)
             {
                 s_static_bootstrap = Aws::Crt::New<Io::ClientBootstrap>(
-                    g_allocator, *GetOrCreateStaticDefaultEventLoopGroup(), *GetOrCreateStaticDefaultHostResolver());
+                    ApiAllocator(), *GetOrCreateStaticDefaultEventLoopGroup(), *GetOrCreateStaticDefaultHostResolver());
             }
             return s_static_bootstrap;
         }
@@ -325,7 +323,7 @@ namespace Aws
             std::lock_guard<std::mutex> lock(s_lock_event_loop_group);
             if (s_static_event_loop_group == nullptr)
             {
-                s_static_event_loop_group = Aws::Crt::New<Io::EventLoopGroup>(g_allocator, (uint16_t)0);
+                s_static_event_loop_group = Aws::Crt::New<Io::EventLoopGroup>(ApiAllocator(), (uint16_t)0);
             }
             return s_static_event_loop_group;
         }
@@ -336,7 +334,7 @@ namespace Aws
             if (s_static_default_host_resolver == nullptr)
             {
                 s_static_default_host_resolver = Aws::Crt::New<Io::DefaultHostResolver>(
-                    g_allocator, *GetOrCreateStaticDefaultEventLoopGroup(), 1, s_host_resolver_default_max_hosts);
+                    ApiAllocator(), *GetOrCreateStaticDefaultEventLoopGroup(), 1, s_host_resolver_default_max_hosts);
             }
             return s_static_default_host_resolver;
         }
@@ -346,7 +344,7 @@ namespace Aws
             std::lock_guard<std::mutex> lock(s_lock_client_bootstrap);
             if (s_static_bootstrap != nullptr)
             {
-                Aws::Crt::Delete(s_static_bootstrap, g_allocator);
+                Aws::Crt::Delete(s_static_bootstrap, ApiAllocator());
                 s_static_bootstrap = nullptr;
             }
         }
@@ -356,7 +354,7 @@ namespace Aws
             std::lock_guard<std::mutex> lock(s_lock_event_loop_group);
             if (s_static_event_loop_group != nullptr)
             {
-                Aws::Crt::Delete(s_static_event_loop_group, g_allocator);
+                Aws::Crt::Delete(s_static_event_loop_group, ApiAllocator());
                 s_static_event_loop_group = nullptr;
             }
         }
@@ -366,7 +364,7 @@ namespace Aws
             std::lock_guard<std::mutex> lock(s_lock_default_host_resolver);
             if (s_static_default_host_resolver != nullptr)
             {
-                Aws::Crt::Delete(s_static_default_host_resolver, g_allocator);
+                Aws::Crt::Delete(s_static_default_host_resolver, ApiAllocator());
                 s_static_default_host_resolver = nullptr;
             }
         }

--- a/source/Types.cpp
+++ b/source/Types.cpp
@@ -10,8 +10,6 @@ namespace Aws
 {
     namespace Crt
     {
-        Allocator *DefaultAllocator() noexcept { return aws_default_allocator(); }
-
         ByteBuf ByteBufFromCString(const char *str) noexcept { return aws_byte_buf_from_c_str(str); }
 
         ByteBuf ByteBufFromEmptyArray(const uint8_t *array, size_t len) noexcept

--- a/source/auth/Sigv4Signing.cpp
+++ b/source/auth/Sigv4Signing.cpp
@@ -21,9 +21,16 @@ namespace Aws
             namespace SignedBodyValue
             {
                 const char *EmptySha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+                const char *EmptySha256Str() { return EmptySha256; }
+
                 const char *UnsignedPayload = "UNSIGNED-PAYLOAD";
+                const char *UnsignedPayloadStr() { return UnsignedPayload; }
+
                 const char *StreamingAws4HmacSha256Payload = "STREAMING-AWS4-HMAC-SHA256-PAYLOAD";
+                const char *StreamingAws4HmacSha256PayloadStr() { return StreamingAws4HmacSha256Payload; }
+
                 const char *StreamingAws4HmacSha256Events = "STREAMING-AWS4-HMAC-SHA256-EVENTS";
+                const char *StreamingAws4HmacSha256EventsStr() { return StreamingAws4HmacSha256Events; }
             } // namespace SignedBodyValue
 
             AwsSigningConfig::AwsSigningConfig(Allocator *allocator)

--- a/source/crypto/HMAC.cpp
+++ b/source/crypto/HMAC.cpp
@@ -28,7 +28,7 @@ namespace Aws
                 ByteBuf &output,
                 size_t truncateTo) noexcept
             {
-                return aws_sha256_hmac_compute(g_allocator, &secret, &input, &output, truncateTo) == AWS_OP_SUCCESS;
+                return aws_sha256_hmac_compute(ApiAllocator(), &secret, &input, &output, truncateTo) == AWS_OP_SUCCESS;
             }
 
             HMAC::HMAC(aws_hmac *hmac) noexcept : m_hmac(hmac), m_good(false), m_lastError(0)
@@ -75,7 +75,7 @@ namespace Aws
 
             HMAC HMAC::CreateSHA256HMAC(const ByteCursor &secret) noexcept
             {
-                return HMAC(aws_sha256_hmac_new(g_allocator, &secret));
+                return HMAC(aws_sha256_hmac_new(ApiAllocator(), &secret));
             }
 
             bool HMAC::Update(const ByteCursor &toHMAC) noexcept

--- a/source/crypto/Hash.cpp
+++ b/source/crypto/Hash.cpp
@@ -23,7 +23,7 @@ namespace Aws
 
             bool ComputeSHA256(const ByteCursor &input, ByteBuf &output, size_t truncateTo) noexcept
             {
-                return aws_sha256_compute(DefaultAllocator(), &input, &output, truncateTo) == AWS_OP_SUCCESS;
+                return aws_sha256_compute(ApiAllocator(), &input, &output, truncateTo) == AWS_OP_SUCCESS;
             }
 
             bool ComputeMD5(Allocator *allocator, const ByteCursor &input, ByteBuf &output, size_t truncateTo) noexcept
@@ -33,7 +33,7 @@ namespace Aws
 
             bool ComputeMD5(const ByteCursor &input, ByteBuf &output, size_t truncateTo) noexcept
             {
-                return aws_md5_compute(DefaultAllocator(), &input, &output, truncateTo) == AWS_OP_SUCCESS;
+                return aws_md5_compute(ApiAllocator(), &input, &output, truncateTo) == AWS_OP_SUCCESS;
             }
 
             Hash::Hash(aws_hash *hash) noexcept : m_hash(hash), m_good(false), m_lastError(0)

--- a/source/iot/MqttClient.cpp
+++ b/source/iot/MqttClient.cpp
@@ -208,7 +208,7 @@ namespace Aws
         MqttClientConnectionConfigBuilder MqttClientConnectionConfigBuilder::NewDefaultBuilder() noexcept
         {
             MqttClientConnectionConfigBuilder return_value =
-                MqttClientConnectionConfigBuilder(Aws::Crt::DefaultAllocator());
+                MqttClientConnectionConfigBuilder(Aws::Crt::ApiAllocator());
             return_value.m_contextOptions = Crt::Io::TlsContextOptions::InitDefaultClient();
             return return_value;
         }

--- a/tests/Sigv4SigningTest.cpp
+++ b/tests/Sigv4SigningTest.cpp
@@ -273,7 +273,7 @@ static int s_Sigv4SigningTestUnsignedPayload(struct aws_allocator *allocator, vo
         signingConfig.SetRegion("test");
         signingConfig.SetService("service");
         signingConfig.SetCredentials(s_MakeDummyCredentials(allocator));
-        signingConfig.SetSignedBodyValue(Aws::Crt::Auth::SignedBodyValue::UnsignedPayload);
+        signingConfig.SetSignedBodyValue(Aws::Crt::Auth::SignedBodyValue::UnsignedPayloadStr());
         signingConfig.SetSignedBodyHeader(Aws::Crt::Auth::SignedBodyHeaderType::XAmzContentSha256);
 
         SignWaiter waiter;


### PR DESCRIPTION
**Issue:**
https://github.com/aws/aws-sdk-cpp/issues/1960

`extern` global variables do not play nice with [Delay Load DLLs](https://docs.microsoft.com/en-us/cpp/build/reference/delayload-delay-load-import) on Windows, leading to:
> fatal error LNK1194: cannot delay-load 'aws-crt-cpp.dll' due to import of data symbol '"__declspec(dllimport) struct aws_allocator * Aws::Crt::g_allocator

**Description of Changes:**

Offer getter functions for the 5 `extern` global variables, use the getters everywhere we can, and mark the variables `@deprecated`. We can't remove them entirely because that's an API-breaking change.

Add CI check to prove this is fixed, and ensure it stays fixed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
