### PR TITLE
[ClientBootstrap] await thread shutdown (#388)

### DIFF
--- a/include/aws/crt/io/Bootstrap.h
+++ b/include/aws/crt/io/Bootstrap.h
@@ -50,11 +50,20 @@ namespace Aws
                 /**
                  * @param elGroup: EventLoopGroup to use.
                  * @param resolver: DNS host resolver to use.
+                 * @param allocator memory allocator to use
                  */
                 ClientBootstrap(
                     EventLoopGroup &elGroup,
                     HostResolver &resolver,
-                    Allocator *allocator = g_allocator) noexcept;
+                    Allocator *allocator = ApiAllocator()) noexcept;
+
+                /**
+                 * Uses the default EventLoopGroup and HostResolver.
+                 * See Aws::Crt::ApiHandle::GetOrCreateStaticDefaultEventLoopGroup
+                 * and Aws::Crt::ApiHandle::GetOrCreateStaticDefaultHostResolver
+                 */
+                ClientBootstrap(Allocator *allocator = ApiAllocator()) noexcept;
+
                 ~ClientBootstrap();
                 ClientBootstrap(const ClientBootstrap &) = delete;
                 ClientBootstrap &operator=(const ClientBootstrap &) = delete;

--- a/source/io/Bootstrap.cpp
+++ b/source/io/Bootstrap.cpp
@@ -2,8 +2,13 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0.
  */
-#include <aws/crt/Api.h>
+#include <aws/common/clock.h>
+
 #include <aws/crt/io/Bootstrap.h>
+
+// Maximum time to wait (in seconds) for the blocking shutdown sequence.
+// This is to avoid hanging at program exit due to unexpected conditions.
+#define FINAL_TIMEOUT_SECS 10
 
 namespace Aws
 {
@@ -11,88 +16,94 @@ namespace Aws
     {
         namespace Io
         {
-
-            /**
-             * @private
-             * Holds the bootstrap's shutdown promise.
-             * Lives until the bootstrap's shutdown-complete callback fires.
-             */
-            class ClientBootstrapCallbackData
+            namespace
             {
-              private:
-                Allocator *m_allocator;
-
-              public:
-                ClientBootstrapCallbackData(Allocator *allocator) : m_allocator(allocator) {}
-                /**
-                 * Promise for bootstrap's shutdown.
-                 */
-                std::promise<void> ShutdownPromise;
-                /**
-                 * User callback of bootstrap's shutdown-complete.
-                 */
-                OnClientBootstrapShutdownComplete ShutdownCallback;
-
-                /**
-                 * Internal callback of bootstrap's shutdown-complete
-                 */
-                static void OnShutdownComplete(void *userData)
+                /* Called by event-loop host-resolver, and client-bootstrap shutdown. */
+                void shutdown_callback(void *user_data)
                 {
-                    auto callbackData = static_cast<ClientBootstrapCallbackData *>(userData);
+                    auto shutdown_user_data = static_cast<struct shutdown_user_data *>(user_data);
 
-                    callbackData->ShutdownPromise.set_value();
-                    if (callbackData->ShutdownCallback)
-                    {
-                        callbackData->ShutdownCallback();
-                    }
-
-                    Crt::Delete(callbackData, callbackData->m_allocator);
+                    aws_mutex_lock(&shutdown_user_data->mtx);
+                    shutdown_user_data->shutdown_count += 1;
+                    aws_condition_variable_notify_one(&shutdown_user_data->cv);
+                    aws_mutex_unlock(&shutdown_user_data->mtx);
                 }
-            };
+                /**
+                 * Return true if all three components (event_loop_group, host_resolver, client bootstrap)
+                 * have invoked the above shutdown_callback.
+                 */
+                bool condition_predicate_fn(void *pred_ctx)
+                {
+                    const auto shutdown_user_data = static_cast<struct shutdown_user_data *>(pred_ctx);
+                    return shutdown_user_data->shutdown_count == 3;
+                }
+            }
 
             ClientBootstrap::ClientBootstrap(
                 EventLoopGroup &elGroup,
                 HostResolver &resolver,
                 Allocator *allocator) noexcept
-                : m_bootstrap(nullptr), m_lastError(AWS_ERROR_SUCCESS),
-                  m_callbackData(Crt::New<ClientBootstrapCallbackData>(allocator, allocator)),
-                  m_enableBlockingShutdown(false)
+                : m_bootstrap(nullptr), m_lastError(AWS_ERROR_SUCCESS)
             {
-                m_shutdownFuture = m_callbackData->ShutdownPromise.get_future();
-
                 aws_client_bootstrap_options options;
+
+                if (aws_mutex_init(&m_shutdown_cb_user_data.mtx) != AWS_ERROR_SUCCESS)
+                {
+                    m_lastError = aws_last_error();
+                    return;
+                }
+                if (aws_condition_variable_init(&m_shutdown_cb_user_data.cv) != AWS_ERROR_SUCCESS)
+                {
+                    m_lastError = aws_last_error();
+                    return;
+                }
+
                 options.event_loop_group = elGroup.GetUnderlyingHandle();
                 options.host_resolution_config = resolver.GetConfig();
                 options.host_resolver = resolver.GetUnderlyingHandle();
-                options.on_shutdown_complete = ClientBootstrapCallbackData::OnShutdownComplete;
-                options.user_data = m_callbackData.get();
+                options.on_shutdown_complete = shutdown_callback;
+                options.user_data = &m_shutdown_cb_user_data;
                 m_bootstrap = aws_client_bootstrap_new(allocator, &options);
                 if (!m_bootstrap)
                 {
                     m_lastError = aws_last_error();
                 }
-            }
+                else
+                {
+                    /*
+                     * Override the event_loop_group and host_resolver shutdown callbacks.
+                     * This is ok since within aws-crt-cpp, none of these are set.
+                     * In each case, the shutdown_callback_fn is invoked after the asynchronous
+                     * shutdown of the exiting threads.
+                     */
+                    void *user_data = static_cast<void *>(&m_shutdown_cb_user_data);
 
-            ClientBootstrap::ClientBootstrap(Allocator *allocator) noexcept
-                : ClientBootstrap(
-                      *Crt::ApiHandle::GetOrCreateStaticDefaultEventLoopGroup(),
-                      *Crt::ApiHandle::GetOrCreateStaticDefaultHostResolver(),
-                      allocator)
-            {
+                    m_bootstrap->event_loop_group->shutdown_options.shutdown_callback_fn = shutdown_callback;
+                    m_bootstrap->event_loop_group->shutdown_options.shutdown_callback_user_data = user_data;
+
+                    m_bootstrap->host_resolver->shutdown_options.shutdown_callback_fn = shutdown_callback;
+                    m_bootstrap->host_resolver->shutdown_options.shutdown_callback_user_data = user_data;
+                }
             }
 
             ClientBootstrap::~ClientBootstrap()
             {
                 if (m_bootstrap)
                 {
-                    // Release m_callbackData, it destroys itself when shutdown completes.
-                    m_callbackData.release();
-
                     aws_client_bootstrap_release(m_bootstrap);
-                    if (m_enableBlockingShutdown)
                     {
-                        // If your program is stuck here, stop using EnableBlockingShutdown()
-                        m_shutdownFuture.wait();
+                        aws_mutex_lock(&m_shutdown_cb_user_data.mtx);
+                        aws_condition_variable_wait_for_pred(&m_shutdown_cb_user_data.cv,
+                                                             &m_shutdown_cb_user_data.mtx,
+                                                             aws_timestamp_convert(FINAL_TIMEOUT_SECS,
+                                                                                   AWS_TIMESTAMP_SECS,
+                                                                                   AWS_TIMESTAMP_NANOS, NULL),
+                                                             condition_predicate_fn,
+                                                             static_cast<void *>(&m_shutdown_cb_user_data));
+                        aws_mutex_unlock(&m_shutdown_cb_user_data.mtx);
+                    }
+                    if (m_shutdownCallback) {
+                        m_shutdownCallback();
                     }
                 }
             }
@@ -103,10 +114,8 @@ namespace Aws
 
             void ClientBootstrap::SetShutdownCompleteCallback(OnClientBootstrapShutdownComplete callback)
             {
-                m_callbackData->ShutdownCallback = std::move(callback);
+                m_shutdownCallback = std::move(callback);
             }
-
-            void ClientBootstrap::EnableBlockingShutdown() noexcept { m_enableBlockingShutdown = true; }
 
             aws_client_bootstrap *ClientBootstrap::GetUnderlyingHandle() const noexcept
             {

--- a/source/io/Bootstrap.cpp
+++ b/source/io/Bootstrap.cpp
@@ -86,6 +86,14 @@ namespace Aws
                 }
             }
 
+            ClientBootstrap::ClientBootstrap(Allocator *allocator) noexcept
+                : ClientBootstrap(
+                      *Crt::ApiHandle::GetOrCreateStaticDefaultEventLoopGroup(),
+                      *Crt::ApiHandle::GetOrCreateStaticDefaultHostResolver(),
+                      allocator)
+            {
+            }
+
             ClientBootstrap::~ClientBootstrap()
             {
                 if (m_bootstrap)


### PR DESCRIPTION
*Issue #, if available:* #388

*Description of changes:*
The SDK calls `CleanupCrt()` followed by `ShutdownCRTLogging()`. The former starts destruction of the client bootstrap.
The client bootstrap currently performs _asynchronous shutdown_, which means that exiting threads may attempt to write to the CRT logging subsystem after it has been deleted, causing segmentation faults.

Avoid asynchronous shutdown by awaiting the exiting of the `event_loop_group` and `host_resolver` threads.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
