### PR TITLE
Fix to cmake detection of CRT version by consumers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,9 +347,24 @@ configure_file("cmake/${PROJECT_NAME}-config.cmake"
         "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
         @ONLY)
 
+include(CMakePackageConfigHelpers)
+
+STRING(REPLACE "v" "" AWS_CRT_CPP_VERSION_WITHOUT_V ${AWS_CRT_CPP_VERSION})
+
+write_basic_package_version_file(
+        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
+        VERSION ${AWS_CRT_CPP_VERSION_WITHOUT_V}
+        COMPATIBILITY ExactVersion
+)
+
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/cmake/"
         COMPONENT Development)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/cmake/"
+        COMPONENT Development)
+
 
 if (NOT CMAKE_CROSSCOMPILING)
     if (BUILD_TESTING)


### PR DESCRIPTION
- Adding support for config-version.cmake generation at the top level CMakeLists.txt
- Stripping starting v on version numbers on the update_version script


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
