### PR TITLE
Give write permissions to release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   update-version:
     runs-on: ubuntu-20.04 # latest
+    permissions:
+      contents: write # allow push
 
     steps:
     - name: Checkout Sources


### PR DESCRIPTION
A few months back, we restricted tightened person Github workflows to be read-only by default. That broke the "release" workflow, which pushes changes to `main`.

This should fix it

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
