### PR TITLE
Fix typo

### DIFF
--- a/source/DateTime.cpp
+++ b/source/DateTime.cpp
@@ -84,7 +84,7 @@ namespace Aws
         DateTime DateTime::operator-(const std::chrono::milliseconds &a) const noexcept
         {
             auto currentTime = aws_date_time_as_millis(&m_date_time);
-            currentTime += a.count();
+            currentTime -= a.count();
             return {currentTime};
         }
 


### PR DESCRIPTION
You can't go back in time, but you can subtract time units.
*Issue #, if available:*
A typo in operator-
*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
