### PR TITLE
Fix a typo in cmake script for headers install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,7 +185,7 @@ file(GLOB AWS_CRT_HTTP_HEADERS
 )
 
 file(GLOB AWS_CRT_ENDPOINT_HEADERS
-    "include/aws/crt/http/*.h"
+    "include/aws/crt/endpoints/*.h"
 )
 
 file(GLOB AWS_CRT_EXTERNAL_HEADERS
@@ -267,7 +267,7 @@ if(WIN32)
         source_group("Header Files\\aws\\iot" FILES ${AWS_CRT_IOT_HEADERS})
         source_group("Header Files\\aws\\crt\\mqtt" FILES ${AWS_CRT_MQTT_HEADERS})
         source_group("Header Files\\aws\\crt\\http" FILES ${AWS_CRT_HTTP_HEADERS})
-        source_group("Header Files\\aws\\crt\\endpoints" FILES ${AWS_CRT_ENDPOINTS_HEADERS})
+        source_group("Header Files\\aws\\crt\\endpoints" FILES ${AWS_CRT_ENDPOINT_HEADERS})
         source_group("Header Files\\aws\\crt\\external" FILES ${AWS_CRT_EXTERNAL_HEADERS})
 
         source_group("Source Files" FILES ${AWS_CRT_SRC})
@@ -343,7 +343,7 @@ install(FILES ${AWS_CRT_IO_HEADERS} DESTINATION "include/aws/crt/io" COMPONENT D
 install(FILES ${AWS_CRT_IOT_HEADERS} DESTINATION "include/aws/iot" COMPONENT Development)
 install(FILES ${AWS_CRT_MQTT_HEADERS} DESTINATION "include/aws/crt/mqtt" COMPONENT Development)
 install(FILES ${AWS_CRT_HTTP_HEADERS} DESTINATION "include/aws/crt/http" COMPONENT Development)
-install(FILES ${AWS_CRT_ENDPOINTS_HEADERS} DESTINATION "include/aws/crt/endpoints" COMPONENT Development)
+install(FILES ${AWS_CRT_ENDPOINT_HEADERS} DESTINATION "include/aws/crt/endpoints" COMPONENT Development)
 
 install(
     TARGETS ${PROJECT_NAME}


### PR DESCRIPTION
*Issue #, if available:*
CRT cmake script did not install new headers
*Description of changes:*
Correct copy-paste typo.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
