### PR TITLE
Add Support for choosing PQ TLS Cipher Preferences

### DIFF
--- a/include/aws/crt/io/TlsOptions.h
+++ b/include/aws/crt/io/TlsOptions.h
@@ -179,6 +179,12 @@ namespace Aws
                 void SetMinimumTlsVersion(aws_tls_versions minimumTlsVersion);
 
                 /**
+                 * Sets the preferred TLS Cipher List
+                 * @param cipher_pref: The preferred TLS cipher list.
+                 */
+                void SetTlsCipherPreference(aws_tls_cipher_pref cipher_pref);
+
+                /**
                  * Overrides the default system trust store.
                  * @param caPath: Path to directory containing trusted certificates, which will overrides the
                  * default trust store. Only useful on Unix style systems where all anchors are stored in a directory

--- a/source/io/TlsOptions.cpp
+++ b/source/io/TlsOptions.cpp
@@ -161,6 +161,12 @@ namespace Aws
                 aws_tls_ctx_options_set_minimum_tls_version(&m_options, minimumTlsVersion);
             }
 
+            void TlsContextOptions::SetTlsCipherPreference(aws_tls_cipher_pref cipher_pref)
+            {
+                AWS_ASSERT(m_isInit);
+                aws_tls_ctx_options_set_tls_cipher_preference(&m_options, cipher_pref);
+            }
+
             bool TlsContextOptions::OverrideDefaultTrustStore(const char *caPath, const char *caFile) noexcept
             {
                 AWS_ASSERT(m_isInit);

--- a/tests/HttpClientConnectionManagerTest.cpp
+++ b/tests/HttpClientConnectionManagerTest.cpp
@@ -38,7 +38,8 @@ static int s_TestHttpClientConnectionManagerResourceSafety(struct aws_allocator 
         // ignored if S3 doesn't support them) followed by regular TLS ciphers that can be chosen and negotiated by S3.
         aws_tls_cipher_pref tls_cipher_pref = AWS_IO_TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05;
 
-        if (aws_tls_is_cipher_pref_supported(tls_cipher_pref)) {
+        if (aws_tls_is_cipher_pref_supported(tls_cipher_pref))
+        {
             tlsCtxOptions.SetTlsCipherPreference(tls_cipher_pref);
         }
 

--- a/tests/HttpClientConnectionManagerTest.cpp
+++ b/tests/HttpClientConnectionManagerTest.cpp
@@ -33,6 +33,15 @@ static int s_TestHttpClientConnectionManagerResourceSafety(struct aws_allocator 
 
         Aws::Crt::Io::TlsContextOptions tlsCtxOptions = Aws::Crt::Io::TlsContextOptions::InitDefaultClient();
 
+        // Ensure that if PQ TLS ciphers are supported on the current platform, that setting them works when connecting
+        // to S3. This TlsCipherPreference has post quantum ciphers at the top of it's preference list (that will be
+        // ignored if S3 doesn't support them) followed by regular TLS ciphers that can be chosen and negotiated by S3.
+        aws_tls_cipher_pref tls_cipher_pref = AWS_IO_TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05;
+
+        if (aws_tls_is_cipher_pref_supported(tls_cipher_pref)) {
+            tlsCtxOptions.SetTlsCipherPreference(tls_cipher_pref);
+        }
+
         Aws::Crt::Io::TlsContext tlsContext(tlsCtxOptions, Aws::Crt::Io::TlsMode::CLIENT, allocator);
         ASSERT_TRUE(tlsContext);
 

--- a/tests/TLSContextTest.cpp
+++ b/tests/TLSContextTest.cpp
@@ -13,6 +13,7 @@ static int s_TestTLSContextResourceSafety(Aws::Crt::Allocator *allocator, void *
     {
         Aws::Crt::ApiHandle apiHandle(allocator);
         Aws::Crt::Io::TlsContextOptions tlsCtxOptions = Aws::Crt::Io::TlsContextOptions::InitDefaultClient();
+        tlsCtxOptions.SetTlsCipherPreference(AWS_IO_TLS_CIPHER_PREF_SYSTEM_DEFAULT);
 
         Aws::Crt::Io::TlsContext tlsContext(tlsCtxOptions, Aws::Crt::Io::TlsMode::CLIENT, allocator);
         ASSERT_TRUE(tlsContext);


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Add support for configuring TLS Cipher Preferences (Eg Post-Quantum TLS Ciphers).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
