### PR TITLE
Fix destruct http message double free

### DIFF
--- a/include/aws/crt/RefCounted.h
+++ b/include/aws/crt/RefCounted.h
@@ -47,6 +47,7 @@ namespace Aws
                 std::shared_ptr<T> tmpStrongPtr;
 
                 m_mutex.lock();
+                AWS_ASSERT(m_count > 0 && "refcount has gone negative");
                 if (m_count-- == 1)
                 {
                     std::swap(m_strongPtr, tmpStrongPtr);

--- a/include/aws/crt/RefCounted.h
+++ b/include/aws/crt/RefCounted.h
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#include <aws/common/assert.h>
 #include <memory>
 #include <mutex>
 

--- a/source/http/HttpRequestResponse.cpp
+++ b/source/http/HttpRequestResponse.cpp
@@ -26,21 +26,7 @@ namespace Aws
                 }
             }
 
-            HttpMessage::~HttpMessage()
-            {
-                if (m_message != nullptr)
-                {
-                    aws_input_stream *old_stream = aws_http_message_get_body_stream(m_message);
-                    if (old_stream != nullptr)
-                    {
-                        aws_input_stream_destroy(old_stream);
-                    }
-
-                    aws_http_message_release(m_message);
-
-                    m_message = nullptr;
-                }
-            }
+            HttpMessage::~HttpMessage() { m_message = aws_http_message_release(m_message); }
 
             std::shared_ptr<Aws::Crt::Io::InputStream> HttpMessage::GetBody() const noexcept { return m_bodyStream; }
 


### PR DESCRIPTION
*Description of changes:*
- This fixes an issue that aws_input_stream was being freed twice.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
