### PR TITLE
how to use system installation of libcrypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,25 @@ aws-crt-cpp has not been tested in this configuration.
 aws-crt-cpp's cmake configuration scripts are known to get confused by this,
 and will not enable optimizations that would benefit an independent `arm64` or `x86_64` build.
 
+### OpenSSL and LibCrypto (Unix only)
+
+If your application uses OpenSSL, configure with `-DUSE_OPENSSL=ON`.
+
+aws-crt-cpp does not use OpenSSL for TLS.
+On Apple and Windows devices, the OS's default TLS library is used.
+On Unix devices, [s2n-tls](https://github.com/aws/s2n-tls) is used.
+But s2n-tls uses libcrypto, the cryptography math library bundled with OpenSSL.
+To simplify the build process, the source code for s2n-tls and libcrypto are
+included as git submodules and built along with aws-crt-cpp.
+But if your application is also loading the system installation of OpenSSL
+(i.e. your application uses libcurl which uses libssl which uses libcrypto)
+there may be crashes as the application tries to use two different versions of libcrypto at once.
+
+Setting `-DUSE_OPENSSL=ON` will cause aws-crt-cpp to link against your system's existing `libcrypto`,
+instead of building its own copy.
+
+You can ignore all this on Windows and Apple platforms, where aws-crt-cpp uses the OS's default libraries for TLS and cryptography math.
+
 ## Dependencies?
 
 There are no non-OS dependencies that AWS does not own, maintain, and ship.


### PR DESCRIPTION
**Issue:**
https://github.com/aws/aws-iot-device-sdk-cpp-v2/issues/499

User encountering crashes when they build an application that used the IoT SDK and libcurl, which created a dependency on two different versions of libcrypto, which leads to crazy runtime crashes.

**Description of Changes:**

Explain the `-DUSE_OPENSSL=ON` build option, and when you'd want to use it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
