### PR TITLE
Fix ambiguity around InputStream::ReadImpl() errors

### DIFF
--- a/include/aws/crt/io/Stream.h
+++ b/include/aws/crt/io/Stream.h
@@ -105,9 +105,12 @@ namespace Aws
                  * Read up-to buffer::capacity - buffer::len into buffer::buffer
                  * Increment buffer::len by the amount you read in.
                  *
-                 * @return true on success, false otherwise. Return false, when there is nothing left to read.
-                 * You SHOULD raise an error via aws_raise_error()
-                 * if an actual failure condition occurs.
+                 * @return true if nothing went wrong.
+                 * Return true even if you read 0 bytes because the end-of-file has been reached.
+                 * Return true even if you read 0 bytes because data is not currently available.
+                 *
+                 * Return false if an actual failure condition occurs,
+                 * you SHOULD also raise an error via aws_raise_error().
                  */
                 virtual bool ReadImpl(ByteBuf &buffer) noexcept = 0;
 

--- a/source/io/Stream.cpp
+++ b/source/io/Stream.cpp
@@ -24,9 +24,19 @@ namespace Aws
             {
                 auto impl = static_cast<InputStream *>(stream->impl);
 
+                // Detect whether implementation raises an error when reporting failure.
+                // Docs for C++ SeekImpl API say you "SHOULD" raise an error,
+                // but the C API does in fact require an error to be raised.
+                aws_reset_error();
+
                 if (impl->SeekImpl(offset, static_cast<StreamSeekBasis>(basis)))
                 {
                     return AWS_OP_SUCCESS;
+                }
+
+                if (aws_last_error() == 0)
+                {
+                    aws_raise_error(AWS_IO_STREAM_SEEK_FAILED);
                 }
 
                 return AWS_OP_ERR;
@@ -36,9 +46,19 @@ namespace Aws
             {
                 auto impl = static_cast<InputStream *>(stream->impl);
 
+                // Detect whether implementation raises an error when reporting failure.
+                // Docs for C++ ReadImpl API say you "SHOULD" raise an error,
+                // but the C API does in fact require an error to be raised.
+                aws_reset_error();
+
                 if (impl->ReadImpl(*dest))
                 {
                     return AWS_OP_SUCCESS;
+                }
+
+                if (aws_last_error() == 0)
+                {
+                    aws_raise_error(AWS_IO_STREAM_READ_FAILED);
                 }
 
                 return AWS_OP_ERR;


### PR DESCRIPTION
- Clarify that ReadImpl() should only return false on failure. The docs were ambiguous about whether false meant "done" or "failed".
- Ensure that aws_raise_error() is raised if any ReadImpl() implementation fails to do so. The docs docs only say you "SHOULD" raise an error, and the 2 implementations I've seen don't bother to do so.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
