### PR TITLE
Updated crypto bindings to include SHA1, added one-shot polymorphic s…

### DIFF
--- a/include/aws/crt/crypto/HMAC.h
+++ b/include/aws/crt/crypto/HMAC.h
@@ -88,6 +88,12 @@ namespace Aws
                  */
                 bool Digest(ByteBuf &output, size_t truncateTo = 0) noexcept;
 
+                /**
+                 * Returns the size of the digest for this hmac algorithm. If this object is not valid, it will
+                 * return 0 instead.
+                 */
+                size_t DigestSize() const noexcept;
+
               private:
                 HMAC(aws_hmac *hmac) noexcept;
                 HMAC() = delete;

--- a/include/aws/crt/crypto/Hash.h
+++ b/include/aws/crt/crypto/Hash.h
@@ -15,8 +15,9 @@ namespace Aws
     {
         namespace Crypto
         {
-            static const size_t SHA256_DIGEST_SIZE = 32;
-            static const size_t MD5_DIGEST_SIZE = 16;
+            static const size_t SHA1_DIGEST_SIZE = AWS_SHA1_LEN;
+            static const size_t SHA256_DIGEST_SIZE = AWS_SHA256_LEN;
+            static const size_t MD5_DIGEST_SIZE = AWS_MD5_LEN;
 
             /**
              * Computes a SHA256 Hash over input, and writes the digest to output. If truncateTo is non-zero, the digest
@@ -60,6 +61,26 @@ namespace Aws
             bool AWS_CRT_CPP_API ComputeMD5(const ByteCursor &input, ByteBuf &output, size_t truncateTo = 0) noexcept;
 
             /**
+             * Computes a SHA1 Hash over input, and writes the digest to output. If truncateTo is non-zero, the digest
+             * will be truncated to the value of truncateTo. Returns true on success. If this function fails,
+             * Aws::Crt::LastError() will contain the error that occurred. Unless you're using 'truncateTo',
+             * output should have a minimum capacity of MD5_DIGEST_SIZE.
+             */
+            bool AWS_CRT_CPP_API ComputeSHA1(
+                Allocator *allocator,
+                const ByteCursor &input,
+                ByteBuf &output,
+                size_t truncateTo = 0) noexcept;
+
+            /**
+             * Computes a SHA1 Hash using the default allocator over input, and writes the digest to output. If
+             * truncateTo is non-zero, the digest will be truncated to the value of truncateTo. Returns true on success.
+             * If this function fails, Aws::Crt::LastError() will contain the error that occurred. Unless you're using
+             * 'truncateTo', output should have a minimum capacity of SHA1_DIGEST_SIZE.
+             */
+            bool AWS_CRT_CPP_API ComputeSHA1(const ByteCursor &input, ByteBuf &output, size_t truncateTo = 0) noexcept;
+
+            /**
              * Streaming Hash object. The typical use case is for computing the hash of an object that is too large to
              * load into memory. You can call Update() multiple times as you load chunks of data into memory. When
              * you're finished simply call Digest(). After Digest() is called, this object is no longer usable.
@@ -89,6 +110,11 @@ namespace Aws
                 static Hash CreateSHA256(Allocator *allocator = ApiAllocator()) noexcept;
 
                 /**
+                 * Creates an instance of a Stream SHA1 Hash.
+                 */
+                static Hash CreateSHA1(Allocator *allocator = ApiAllocator()) noexcept;
+
+                /**
                  * Creates an instance of a Streaming MD5 Hash.
                  */
                 static Hash CreateMD5(Allocator *allocator = ApiAllocator()) noexcept;
@@ -106,6 +132,14 @@ namespace Aws
                  * SHA256 digest. Returns true on success. Call LastError() for the reason this call failed.
                  */
                 bool Digest(ByteBuf &output, size_t truncateTo = 0) noexcept;
+
+                bool ComputeOneShot(const ByteCursor &input, ByteBuf &output, size_t truncateTo) noexcept;
+
+                /**
+                 * Returns the size of the digest for this hash algorithm. If this object is not valid, it will
+                 * return 0 instead.
+                 */
+                size_t DigestSize() const noexcept;
 
               private:
                 Hash(aws_hash *hash) noexcept;

--- a/source/crypto/HMAC.cpp
+++ b/source/crypto/HMAC.cpp
@@ -110,6 +110,16 @@ namespace Aws
                 return false;
             }
 
+            size_t HMAC::DigestSize() const noexcept
+            {
+                if (*this)
+                {
+                    return m_hmac->digest_size;
+                }
+
+                return 0;
+            }
+
             aws_hmac_vtable ByoHMAC::s_Vtable = {
                 "aws-crt-cpp-byo-crypto-hmac",
                 "aws-crt-cpp-byo-crypto",

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ add_test_case(JsonExplicitNull)
 add_test_case(JsonBoolTest)
 add_test_case(SHA256ResourceSafety)
 add_test_case(MD5ResourceSafety)
+add_test_case(SHA1ResourceSafety)
 add_test_case(SHA256HMACResourceSafety)
 
 if(NOT BYO_CRYPTO)

--- a/tests/HMACTest.cpp
+++ b/tests/HMACTest.cpp
@@ -32,6 +32,7 @@ static int s_TestSHA256HMACResourceSafety(struct aws_allocator *allocator, void 
         uint8_t output[Aws::Crt::Crypto::SHA256_HMAC_DIGEST_SIZE] = {0};
         Aws::Crt::ByteBuf outputBuf = Aws::Crt::ByteBufFromEmptyArray(output, sizeof(output));
 
+        ASSERT_UINT_EQUALS(Aws::Crt::Crypto::SHA256_HMAC_DIGEST_SIZE, sha256Hmac.DigestSize());
         ASSERT_TRUE(sha256Hmac.Update(input));
         ASSERT_TRUE(sha256Hmac.Digest(outputBuf));
         ASSERT_FALSE(sha256Hmac);

--- a/tests/HashTest.cpp
+++ b/tests/HashTest.cpp
@@ -28,6 +28,8 @@ static int s_TestSHA256ResourceSafety(struct aws_allocator *allocator, void *)
 
         ASSERT_TRUE(sha256.Update(input));
         ASSERT_TRUE(sha256.Digest(outputBuf));
+        ASSERT_UINT_EQUALS(Aws::Crt::Crypto::SHA256_DIGEST_SIZE, sha256.DigestSize());
+
         ASSERT_FALSE(sha256);
 
         ASSERT_BIN_ARRAYS_EQUALS(expectedBuf.buffer, expectedBuf.len, outputBuf.buffer, outputBuf.len);
@@ -71,6 +73,8 @@ static int s_TestMD5ResourceSafety(struct aws_allocator *allocator, void *)
 
         ASSERT_TRUE(md5.Update(input));
         ASSERT_TRUE(md5.Digest(outputBuf));
+        ASSERT_UINT_EQUALS(Aws::Crt::Crypto::MD5_DIGEST_SIZE, md5.DigestSize());
+
         ASSERT_FALSE(md5);
 
         ASSERT_BIN_ARRAYS_EQUALS(expectedBuf.buffer, expectedBuf.len, outputBuf.buffer, outputBuf.len);
@@ -80,6 +84,36 @@ static int s_TestMD5ResourceSafety(struct aws_allocator *allocator, void *)
 }
 
 AWS_TEST_CASE(MD5ResourceSafety, s_TestMD5ResourceSafety)
+
+static int s_TestSHA1ResourceSafety(struct aws_allocator *allocator, void *)
+{
+    {
+        Aws::Crt::ApiHandle apiHandle(allocator);
+        Aws::Crt::Crypto::Hash sha1 = Aws::Crt::Crypto::Hash::CreateSHA1(allocator);
+        ASSERT_TRUE(sha1);
+
+        Aws::Crt::ByteCursor input = aws_byte_cursor_from_c_str("abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu");
+        uint8_t expected[] =
+        {
+            0xa4, 0x9b, 0x24, 0x46, 0xa0, 0x2c, 0x64, 0x5b, 0xf4, 0x19, 0xf9, 0x95, 0xb6, 0x70, 0x91, 0x25, 0x3a,0x04, 0xa2, 0x59
+        };
+        Aws::Crt::ByteBuf expectedBuf = Aws::Crt::ByteBufFromArray(expected, sizeof(expected));
+
+        uint8_t output[Aws::Crt::Crypto::SHA1_DIGEST_SIZE] = {0};
+        Aws::Crt::ByteBuf outputBuf = Aws::Crt::ByteBufFromEmptyArray(output, sizeof(output));
+
+        ASSERT_TRUE(sha1.Update(input));
+        ASSERT_TRUE(sha1.Digest(outputBuf));
+        ASSERT_UINT_EQUALS(Aws::Crt::Crypto::SHA1_DIGEST_SIZE, sha1.DigestSize());
+        ASSERT_FALSE(sha1);
+
+        ASSERT_BIN_ARRAYS_EQUALS(expectedBuf.buffer, expectedBuf.len, outputBuf.buffer, outputBuf.len);
+    }
+
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(SHA1ResourceSafety, s_TestSHA1ResourceSafety)
 
 #else
 


### PR DESCRIPTION
…upport to better support the cpp sdk API.

This can't actually be bound out to the CPP SDK until I add AES implementations to aws-c-cal, but this gets us the hashing algorithms at least.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
