### PR TITLE
Add the main page to the documentation

### DIFF
--- a/docsrc/Doxyfile
+++ b/docsrc/Doxyfile
@@ -874,7 +874,8 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = include \
-                         source
+                         source \
+                         docsrc/index.md
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
*Description of changes:*

Fixes `index.md` not being included in the Doxygen source, causing the main page of the documentation generated by Doxygen to be blank. See https://awslabs.github.io/aws-crt-cpp/, while it should be the contents of https://github.com/awslabs/aws-crt-cpp/blob/main/docsrc/index.md

________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
