### PR TITLE
Enable MQTT5 client unit tests in CI and improve MQTT5 client error handling

### DIFF
--- a/.builder/actions/crt-ci-prep.py
+++ b/.builder/actions/crt-ci-prep.py
@@ -12,6 +12,16 @@ class CrtCiPrep(Builder.Action):
         env.shell.setenv("AWS_TESTING_COGNITO_IDENTITY", env.shell.get_secret("aws-c-auth-testing/cognito-identity"))
         env.shell.setenv("AWS_TESTING_STS_ROLE_ARN", env.shell.get_secret("aws-c-auth-testing/sts-role-arn"))
 
+        # Unfortunately, we can't use NamedTemporaryFile and a with-block because NamedTemporaryFile is not readable
+        # on Windows.
+        self._write_environment_script_secret_to_env(env, "mqtt5-testing/github-ci-environment")
+
+        cert_file_name = self._write_secret_to_temp_file(env, "unit-test/certificate")
+        key_file_name = self._write_secret_to_temp_file(env, "unit-test/privatekey")
+
+        env.shell.setenv("AWS_TEST_MQTT5_IOT_CORE_CERTIFICATE_PATH", cert_file_name, quiet=True)
+        env.shell.setenv("AWS_TEST_MQTT5_IOT_CORE_KEY_PATH", key_file_name, quiet=True)
+
         actions = []
 
         return Builder.Script(actions, name='crt-ci-prep')

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ option(AWS_IOT_SDK_VERSION "Set the version reported by Aws::Iot::MqttClientConn
 # ToDo: Scripts to populate environment variables via the CLI and IoT, SecretsManager calls
 #
 option(ENABLE_PROXY_INTEGRATION_TESTS "Whether or not to build and run the proxy integration tests that rely on a proxy server installed and running locally" OFF)
-option(ENABLE_MQTT5_TEST "Whether or not to build and run the mqtt5 integration reply on a proxy server running locally" OFF)
+option(ENABLE_MQTT5_TEST "Whether or not to build and run the mqtt5 integration reply on a proxy server running locally" ON)
 
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/bin/mqtt5_app/main.cpp
+++ b/bin/mqtt5_app/main.cpp
@@ -416,13 +416,7 @@ int main(int argc, char **argv)
 
     if (mqtt5Client == nullptr)
     {
-        std::cerr << "Failed to allocate memory for mqtt5 client." << std::endl;
-        return -1;
-    }
-    if (!*mqtt5Client)
-    {
-        std::cerr << "Failed to Init Mqtt5Client with error code: %d." << aws_error_debug_str(mqtt5Client->LastError())
-                  << std::endl;
+        std::cerr << "Failed to Init Mqtt5Client with error code: %d." << ErrorDebugString(LastError()) << std::endl;
         return -1;
     }
 

--- a/bin/mqtt5_app/main.cpp
+++ b/bin/mqtt5_app/main.cpp
@@ -416,10 +416,16 @@ int main(int argc, char **argv)
 
     if (mqtt5Client == nullptr)
     {
+        std::cerr << "Failed to allocate memory for mqtt5 client." << std::endl;
+        return -1;
+    }
+    if (!*mqtt5Client)
+    {
         std::cerr << "Failed to Init Mqtt5Client with error code: %d." << aws_error_debug_str(mqtt5Client->LastError())
                   << std::endl;
         return -1;
     }
+
     std::cout << "MQTT5: Finish Init Client ...." << std::endl;
     std::cout << "**********************************************************" << std::endl;
 

--- a/bin/mqtt5_canary/main.cpp
+++ b/bin/mqtt5_canary/main.cpp
@@ -899,7 +899,7 @@ int main(int argc, char **argv)
         });
 
         clients[i].client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, appCtx.allocator);
-        if (clients[i].client == nullptr || !*(clients[i].client))
+        if (clients[i].client == nullptr)
         {
             AWS_LOGF_ERROR(AWS_LS_MQTT5_CANARY, "ID:%s Client Creation Failed.", client.clientId.c_str());
             continue;

--- a/bin/mqtt5_canary/main.cpp
+++ b/bin/mqtt5_canary/main.cpp
@@ -899,7 +899,7 @@ int main(int argc, char **argv)
         });
 
         clients[i].client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, appCtx.allocator);
-        if (clients[i].client == nullptr)
+        if (clients[i].client == nullptr || !*(clients[i].client))
         {
             AWS_LOGF_ERROR(AWS_LS_MQTT5_CANARY, "ID:%s Client Creation Failed.", client.clientId.c_str());
             continue;

--- a/source/iot/Mqtt5Client.cpp
+++ b/source/iot/Mqtt5Client.cpp
@@ -408,7 +408,7 @@ namespace Aws
                 if (port != 443)
                 {
                     AWS_LOGF_WARN(
-                        AWS_LS_MQTT_GENERAL,
+                        AWS_LS_MQTT5_GENERAL,
                         "Attempting to connect to authorizer with unsupported port. Port is not 443...");
                 }
                 if (!m_websocketConfig)
@@ -439,7 +439,7 @@ namespace Aws
                     if (!buildMqtt5FinalUsername(m_customAuthConfig, username))
                     {
                         AWS_LOGF_ERROR(
-                            AWS_LS_MQTT5_CLIENT,
+                            AWS_LS_MQTT5_GENERAL,
                             "Failed to setup CustomAuthorizerConfig, please check if the parameters are set "
                             "correctly.");
                         return nullptr;

--- a/source/iot/Mqtt5Client.cpp
+++ b/source/iot/Mqtt5Client.cpp
@@ -125,8 +125,14 @@ namespace Aws
                 Crt::Io::TlsContextOptions::InitClientWithMtls(certPath, pkeyPath, allocator);
             if (!result->m_tlsConnectionOptions.value())
             {
-                result->m_lastError = result->m_tlsConnectionOptions->LastError();
-                return result;
+                int error_code = result->m_tlsConnectionOptions->LastError();
+                AWS_LOGF_ERROR(
+                    AWS_LS_MQTT5_GENERAL,
+                    "Mqtt5ClientBuilder: Failed to setup TLS connection options with error %d:%s",
+                    error_code,
+                    aws_error_debug_str(error_code));
+                delete result;
+                return nullptr;
             }
             result->WithHostName(hostName);
             return result;
@@ -142,8 +148,14 @@ namespace Aws
             result->m_tlsConnectionOptions = Crt::Io::TlsContextOptions::InitClientWithMtls(cert, pkey, allocator);
             if (!result->m_tlsConnectionOptions.value())
             {
-                result->m_lastError = result->m_tlsConnectionOptions->LastError();
-                return result;
+                int error_code = result->m_tlsConnectionOptions->LastError();
+                AWS_LOGF_ERROR(
+                    AWS_LS_MQTT5_GENERAL,
+                    "Mqtt5ClientBuilder: Failed to setup TLS connection options with error %d:%s",
+                    error_code,
+                    aws_error_debug_str(error_code));
+                delete result;
+                return nullptr;
             }
             result->WithHostName(hostName);
             return result;
@@ -159,8 +171,14 @@ namespace Aws
                 Crt::Io::TlsContextOptions::InitClientWithMtlsPkcs11(pkcs11Options, allocator);
             if (!result->m_tlsConnectionOptions.value())
             {
-                result->m_lastError = result->m_tlsConnectionOptions->LastError();
-                return result;
+                int error_code = result->m_tlsConnectionOptions->LastError();
+                AWS_LOGF_ERROR(
+                    AWS_LS_MQTT5_GENERAL,
+                    "Mqtt5ClientBuilder: Failed to setup TLS connection options with error %d:%s",
+                    error_code,
+                    aws_error_debug_str(error_code));
+                delete result;
+                return nullptr;
             }
             result->WithHostName(hostName);
             return result;
@@ -176,8 +194,14 @@ namespace Aws
                 Crt::Io::TlsContextOptions::InitClientWithMtlsSystemPath(windowsCertStorePath, allocator);
             if (!result->m_tlsConnectionOptions.value())
             {
-                result->m_lastError = result->m_tlsConnectionOptions->LastError();
-                return result;
+                int error_code = result->m_tlsConnectionOptions->LastError();
+                AWS_LOGF_ERROR(
+                    AWS_LS_MQTT5_GENERAL,
+                    "Mqtt5ClientBuilder: Failed to setup TLS connection options with error %d:%s",
+                    error_code,
+                    aws_error_debug_str(error_code));
+                delete result;
+                return nullptr;
             }
             result->WithHostName(hostName);
             return result;
@@ -190,6 +214,17 @@ namespace Aws
         {
             Mqtt5ClientBuilder *result = new Mqtt5ClientBuilder(allocator);
             result->m_tlsConnectionOptions = Crt::Io::TlsContextOptions::InitDefaultClient();
+            if (!result->m_tlsConnectionOptions.value())
+            {
+                int error_code = result->m_tlsConnectionOptions->LastError();
+                AWS_LOGF_ERROR(
+                    AWS_LS_MQTT5_GENERAL,
+                    "Mqtt5ClientBuilder: Failed to setup TLS connection options with error %d:%s",
+                    error_code,
+                    aws_error_debug_str(error_code));
+                delete result;
+                return nullptr;
+            }
             result->WithHostName(hostName);
             result->m_websocketConfig = config;
             return result;
@@ -202,6 +237,17 @@ namespace Aws
         {
             Mqtt5ClientBuilder *result = new Mqtt5ClientBuilder(allocator);
             result->m_tlsConnectionOptions = Crt::Io::TlsContextOptions::InitDefaultClient();
+            if (!result->m_tlsConnectionOptions.value())
+            {
+                int error_code = result->m_tlsConnectionOptions->LastError();
+                AWS_LOGF_ERROR(
+                    AWS_LS_MQTT5_GENERAL,
+                    "Mqtt5ClientBuilder: Failed to setup TLS connection options with error %d:%s",
+                    error_code,
+                    aws_error_debug_str(error_code));
+                delete result;
+                return nullptr;
+            }
             result->WithHostName(hostName);
             result->WithCustomAuthorizer(customAuthConfig);
             return result;
@@ -215,6 +261,17 @@ namespace Aws
         {
             Mqtt5ClientBuilder *result = new Mqtt5ClientBuilder(allocator);
             result->m_tlsConnectionOptions = Crt::Io::TlsContextOptions::InitDefaultClient();
+            if (!result->m_tlsConnectionOptions.value())
+            {
+                int error_code = result->m_tlsConnectionOptions->LastError();
+                AWS_LOGF_ERROR(
+                    AWS_LS_MQTT5_GENERAL,
+                    "Mqtt5ClientBuilder: Failed to setup TLS connection options with error %d:%s",
+                    error_code,
+                    aws_error_debug_str(error_code));
+                delete result;
+                return nullptr;
+            }
             result->WithHostName(hostName);
             result->m_websocketConfig = config;
             result->WithCustomAuthorizer(customAuthConfig);

--- a/source/mqtt/Mqtt5Client.cpp
+++ b/source/mqtt/Mqtt5Client.cpp
@@ -49,6 +49,14 @@ namespace Aws
                 }
 
                 toSeat = new (toSeat) Mqtt5Client(options, allocator);
+
+                // Creation failed, make sure we release the allocated memory
+                if (!*toSeat)
+                {
+                    Crt::Delete(toSeat, allocator);
+                    return nullptr;
+                }
+
                 return std::shared_ptr<Mqtt5Client>(
                     toSeat, [allocator](Mqtt5Client *client) { Crt::Delete(client, allocator); });
             }

--- a/source/mqtt/Mqtt5Client.cpp
+++ b/source/mqtt/Mqtt5Client.cpp
@@ -49,14 +49,6 @@ namespace Aws
                 }
 
                 toSeat = new (toSeat) Mqtt5Client(options, allocator);
-
-                // Creation failed, make sure we release the allocated memory
-                if (!*toSeat)
-                {
-                    Crt::Delete(toSeat, allocator);
-                    return nullptr;
-                }
-
                 return std::shared_ptr<Mqtt5Client>(
                     toSeat, [allocator](Mqtt5Client *client) { Crt::Delete(client, allocator); });
             }

--- a/tests/Mqtt5ClientTest.cpp
+++ b/tests/Mqtt5ClientTest.cpp
@@ -504,7 +504,7 @@ static int s_TestMqtt5DirectConnectionMinimal(Aws::Crt::Allocator *allocator, vo
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_ERROR_UNKNOWN;
     }
 
     ApiHandle apiHandle(allocator);
@@ -1753,6 +1753,11 @@ static int s_TestMqtt5NegotiatedSettingsRejoinAlways(Aws::Crt::Allocator *alloca
     static const uint32_t SESSION_EXPIRY_INTERVAL_SEC = 3600;
 
     Mqtt5TestEnvVars mqtt5TestVars(allocator, MQTT5CONNECT_DIRECT);
+    if (!mqtt5TestVars)
+    {
+        printf("Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
+    }
 
     ApiHandle apiHandle(allocator);
 

--- a/tests/Mqtt5ClientTest.cpp
+++ b/tests/Mqtt5ClientTest.cpp
@@ -105,7 +105,7 @@ struct Mqtt5TestEnvVars
                 {
                     return;
                 }
-                if(m_hostname == NULL || m_port == NULL)
+                if (m_hostname == NULL || m_port == NULL)
                 {
                     m_error = AWS_OP_ERR;
                     return;
@@ -126,7 +126,7 @@ struct Mqtt5TestEnvVars
                 {
                     return;
                 }
-                if(m_hostname == NULL || m_port == NULL || m_username == NULL || m_password == NULL)
+                if (m_hostname == NULL || m_port == NULL || m_username == NULL || m_password == NULL)
                 {
                     m_error = AWS_OP_ERR;
                     return;
@@ -148,7 +148,7 @@ struct Mqtt5TestEnvVars
                 {
                     return;
                 }
-                if(m_hostname == NULL || m_port == NULL || m_certificate_path == NULL || m_private_key_path == NULL)
+                if (m_hostname == NULL || m_port == NULL || m_certificate_path == NULL || m_private_key_path == NULL)
                 {
                     m_error = AWS_OP_ERR;
                     return;
@@ -168,7 +168,7 @@ struct Mqtt5TestEnvVars
                 {
                     return;
                 }
-                if(m_hostname == NULL || m_port == NULL)
+                if (m_hostname == NULL || m_port == NULL)
                 {
                     m_error = AWS_OP_ERR;
                     return;
@@ -192,7 +192,7 @@ struct Mqtt5TestEnvVars
                 {
                     return;
                 }
-                if(m_hostname == NULL || m_port == NULL || m_username == NULL || m_password == NULL)
+                if (m_hostname == NULL || m_port == NULL || m_username == NULL || m_password == NULL)
                 {
                     m_error = AWS_OP_ERR;
                     return;
@@ -217,7 +217,7 @@ struct Mqtt5TestEnvVars
                 {
                     return;
                 }
-                if(m_hostname == NULL || m_port == NULL || m_certificate_path == NULL || m_private_key_path == NULL)
+                if (m_hostname == NULL || m_port == NULL || m_certificate_path == NULL || m_private_key_path == NULL)
                 {
                     m_error = AWS_OP_ERR;
                     return;
@@ -241,7 +241,7 @@ struct Mqtt5TestEnvVars
                 {
                     return;
                 }
-                if(m_hostname == NULL || m_certificate_path == NULL || m_private_key_path == NULL)
+                if (m_hostname == NULL || m_certificate_path == NULL || m_private_key_path == NULL)
                 {
                     m_error = AWS_OP_ERR;
                     return;
@@ -677,7 +677,7 @@ static int s_TestMqtt5DirectConnectionWithHttpProxy(Aws::Crt::Allocator *allocat
     mqtt5Options.withHostName(mqtt5TestVars.m_hostname_string).withPort(mqtt5TestVars.m_port_value);
 
     // HTTP PROXY
-    if(mqtt5TestVars.m_httpproxy_hostname->len == 0)
+    if (mqtt5TestVars.m_httpproxy_hostname->len == 0)
     {
         printf("HTTP PROXY Environment Variables are not set for the test, skip the test");
         return AWS_ERROR_SUCCESS;
@@ -1072,7 +1072,7 @@ static int s_TestMqtt5WSConnectionWithHttpProxy(Aws::Crt::Allocator *allocator, 
     mqtt5Options.withPort(443);
 
     // HTTP PROXY
-    if(mqtt5TestVars.m_httpproxy_hostname->len == 0)
+    if (mqtt5TestVars.m_httpproxy_hostname->len == 0)
     {
         printf("HTTP PROXY Environment Variables are not set for the test, skip the test");
         return AWS_ERROR_SUCCESS;

--- a/tests/Mqtt5ClientTest.cpp
+++ b/tests/Mqtt5ClientTest.cpp
@@ -414,7 +414,7 @@ static int s_TestMqtt5NewClientMin(Aws::Crt::Allocator *allocator, void *)
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(*mqtt5Client);
 
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
 AWS_TEST_CASE(Mqtt5NewClientMinimal, s_TestMqtt5NewClientMin)
@@ -486,7 +486,7 @@ static int s_TestMqtt5NewClientFull(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(*mqtt5Client);
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
 AWS_TEST_CASE(Mqtt5NewClientFull, s_TestMqtt5NewClientFull)
@@ -504,7 +504,7 @@ static int s_TestMqtt5DirectConnectionMinimal(Aws::Crt::Allocator *allocator, vo
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_UNKNOWN;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -524,7 +524,7 @@ static int s_TestMqtt5DirectConnectionMinimal(Aws::Crt::Allocator *allocator, vo
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
     stoppedPromise.get_future().get();
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
 AWS_TEST_CASE(Mqtt5DirectConnectionMinimal, s_TestMqtt5DirectConnectionMinimal)
@@ -538,7 +538,7 @@ static int s_TestMqtt5DirectConnectionWithBasicAuth(Aws::Crt::Allocator *allocat
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -564,7 +564,7 @@ static int s_TestMqtt5DirectConnectionWithBasicAuth(Aws::Crt::Allocator *allocat
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
     stoppedPromise.get_future().get();
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
 AWS_TEST_CASE(Mqtt5DirectConnectionWithBasicAuth, s_TestMqtt5DirectConnectionWithBasicAuth)
@@ -578,7 +578,7 @@ static int s_TestMqtt5DirectConnectionWithTLS(Aws::Crt::Allocator *allocator, vo
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -609,7 +609,7 @@ static int s_TestMqtt5DirectConnectionWithTLS(Aws::Crt::Allocator *allocator, vo
     connectionPromise.get_future().get();
     ASSERT_TRUE(mqtt5Client->Stop());
     stoppedPromise.get_future().get();
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
 AWS_TEST_CASE(Mqtt5DirectConnectionWithTLS, s_TestMqtt5DirectConnectionWithTLS)
@@ -624,7 +624,7 @@ static int s_TestMqtt5DirectConnectionWithMutualTLS(Aws::Crt::Allocator *allocat
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -654,7 +654,7 @@ static int s_TestMqtt5DirectConnectionWithMutualTLS(Aws::Crt::Allocator *allocat
     connectionPromise.get_future().get();
     ASSERT_TRUE(mqtt5Client->Stop());
     stoppedPromise.get_future().get();
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
 AWS_TEST_CASE(Mqtt5DirectConnectionWithMutualTLS, s_TestMqtt5DirectConnectionWithMutualTLS)
@@ -668,7 +668,7 @@ static int s_TestMqtt5DirectConnectionWithHttpProxy(Aws::Crt::Allocator *allocat
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -680,7 +680,7 @@ static int s_TestMqtt5DirectConnectionWithHttpProxy(Aws::Crt::Allocator *allocat
     if (mqtt5TestVars.m_httpproxy_hostname->len == 0)
     {
         printf("HTTP PROXY Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SUCCESS;
     }
     Aws::Crt::Http::HttpClientConnectionProxyOptions proxyOptions;
     proxyOptions.HostName = mqtt5TestVars.m_httpproxy_hostname_string;
@@ -709,7 +709,7 @@ static int s_TestMqtt5DirectConnectionWithHttpProxy(Aws::Crt::Allocator *allocat
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
     stoppedPromise.get_future().get();
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
 AWS_TEST_CASE(Mqtt5DirectConnectionWithHttpProxy, s_TestMqtt5DirectConnectionWithHttpProxy)
@@ -723,7 +723,7 @@ static int s_TestMqtt5DirectConnectionFull(Aws::Crt::Allocator *allocator, void 
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -792,7 +792,7 @@ static int s_TestMqtt5DirectConnectionFull(Aws::Crt::Allocator *allocator, void 
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
     stoppedPromise.get_future().get();
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 AWS_TEST_CASE(Mqtt5DirectConnectionFull, s_TestMqtt5DirectConnectionFull)
 
@@ -809,7 +809,7 @@ static int s_TestMqtt5WSConnectionMinimal(Aws::Crt::Allocator *allocator, void *
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -851,7 +851,7 @@ static int s_TestMqtt5WSConnectionMinimal(Aws::Crt::Allocator *allocator, void *
     connectionPromise.get_future().get();
     ASSERT_TRUE(mqtt5Client->Stop());
     stoppedPromise.get_future().get();
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
 AWS_TEST_CASE(Mqtt5WSConnectionMinimal, s_TestMqtt5WSConnectionMinimal)
@@ -865,7 +865,7 @@ static int s_TestMqtt5WSConnectionWithBasicAuth(Aws::Crt::Allocator *allocator, 
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -913,7 +913,7 @@ static int s_TestMqtt5WSConnectionWithBasicAuth(Aws::Crt::Allocator *allocator, 
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
     stoppedPromise.get_future().get();
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
 AWS_TEST_CASE(Mqtt5WSConnectionWithBasicAuth, s_TestMqtt5WSConnectionWithBasicAuth)
@@ -927,7 +927,7 @@ static int s_TestMqtt5WSConnectionWithTLS(Aws::Crt::Allocator *allocator, void *
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -979,7 +979,7 @@ static int s_TestMqtt5WSConnectionWithTLS(Aws::Crt::Allocator *allocator, void *
     connectionPromise.get_future().get();
     ASSERT_TRUE(mqtt5Client->Stop());
     stoppedPromise.get_future().get();
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
 AWS_TEST_CASE(Mqtt5WSConnectionWithTLS, s_TestMqtt5WSConnectionWithTLS)
@@ -994,7 +994,7 @@ static int s_TestMqtt5WSConnectionWithMutualTLS(Aws::Crt::Allocator *allocator, 
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -1047,7 +1047,7 @@ static int s_TestMqtt5WSConnectionWithMutualTLS(Aws::Crt::Allocator *allocator, 
     connectionPromise.get_future().get();
     ASSERT_TRUE(mqtt5Client->Stop());
     stoppedPromise.get_future().get();
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
 AWS_TEST_CASE(Mqtt5WSConnectionWithMutualTLS, s_TestMqtt5WSConnectionWithMutualTLS)
@@ -1062,7 +1062,7 @@ static int s_TestMqtt5WSConnectionWithHttpProxy(Aws::Crt::Allocator *allocator, 
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -1075,7 +1075,7 @@ static int s_TestMqtt5WSConnectionWithHttpProxy(Aws::Crt::Allocator *allocator, 
     if (mqtt5TestVars.m_httpproxy_hostname->len == 0)
     {
         printf("HTTP PROXY Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SUCCESS;
     }
     Aws::Crt::Http::HttpClientConnectionProxyOptions proxyOptions;
     proxyOptions.HostName = mqtt5TestVars.m_httpproxy_hostname_string;
@@ -1129,7 +1129,7 @@ static int s_TestMqtt5WSConnectionWithHttpProxy(Aws::Crt::Allocator *allocator, 
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
     stoppedPromise.get_future().get();
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
 AWS_TEST_CASE(Mqtt5WSConnectionWithHttpProxy, s_TestMqtt5WSConnectionWithHttpProxy)
@@ -1143,7 +1143,7 @@ static int s_TestMqtt5WSConnectionFull(Aws::Crt::Allocator *allocator, void *)
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -1235,7 +1235,7 @@ static int s_TestMqtt5WSConnectionFull(Aws::Crt::Allocator *allocator, void *)
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
     stoppedPromise.get_future().get();
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 AWS_TEST_CASE(Mqtt5WSConnectionFull, s_TestMqtt5WSConnectionFull)
 
@@ -1252,7 +1252,7 @@ static int s_TestMqtt5DirectInvalidHostname(Aws::Crt::Allocator *allocator, void
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -1272,7 +1272,7 @@ static int s_TestMqtt5DirectInvalidHostname(Aws::Crt::Allocator *allocator, void
     ASSERT_FALSE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
     stoppedPromise.get_future().get();
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 AWS_TEST_CASE(Mqtt5InvalidHostname, s_TestMqtt5DirectInvalidHostname)
 
@@ -1285,7 +1285,7 @@ static int s_TestMqtt5DirectInvalidPort(Aws::Crt::Allocator *allocator, void *)
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -1305,7 +1305,7 @@ static int s_TestMqtt5DirectInvalidPort(Aws::Crt::Allocator *allocator, void *)
     ASSERT_FALSE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
     stoppedPromise.get_future().get();
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 AWS_TEST_CASE(Mqtt5InvalidPort, s_TestMqtt5DirectInvalidPort)
 
@@ -1318,7 +1318,7 @@ static int s_TestMqtt5WSInvalidPort(Aws::Crt::Allocator *allocator, void *)
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -1360,7 +1360,7 @@ static int s_TestMqtt5WSInvalidPort(Aws::Crt::Allocator *allocator, void *)
     ASSERT_FALSE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
     stoppedPromise.get_future().get();
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 AWS_TEST_CASE(Mqtt5WSInvalidPort, s_TestMqtt5WSInvalidPort)
 
@@ -1373,7 +1373,7 @@ static int s_TestMqtt5SocketTimeout(Aws::Crt::Allocator *allocator, void *)
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -1407,7 +1407,7 @@ static int s_TestMqtt5SocketTimeout(Aws::Crt::Allocator *allocator, void *)
     ASSERT_FALSE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
     stoppedPromise.get_future().get();
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 AWS_TEST_CASE(Mqtt5SocketTimeout, s_TestMqtt5SocketTimeout)
 
@@ -1420,7 +1420,7 @@ static int s_TestMqtt5IncorrectBasicAuth(Aws::Crt::Allocator *allocator, void *)
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -1446,7 +1446,7 @@ static int s_TestMqtt5IncorrectBasicAuth(Aws::Crt::Allocator *allocator, void *)
     ASSERT_FALSE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
     stoppedPromise.get_future().get();
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
 AWS_TEST_CASE(Mqtt5IncorrectBasicAuth, s_TestMqtt5IncorrectBasicAuth)
@@ -1458,7 +1458,7 @@ static int s_TestMqtt5IncorrectWSConnect(Aws::Crt::Allocator *allocator, void *)
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -1493,7 +1493,7 @@ static int s_TestMqtt5IncorrectWSConnect(Aws::Crt::Allocator *allocator, void *)
     ASSERT_FALSE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
     stoppedPromise.get_future().get();
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
 AWS_TEST_CASE(Mqtt5IncorrectWSConnect, s_TestMqtt5IncorrectWSConnect)
@@ -1507,7 +1507,7 @@ static int s_TestMqtt5DoubleClientIDFailure(Aws::Crt::Allocator *allocator, void
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -1563,7 +1563,7 @@ static int s_TestMqtt5DoubleClientIDFailure(Aws::Crt::Allocator *allocator, void
     stopped2Promise.get_future().get();
     ASSERT_TRUE(mqtt5Client1->Stop());
     stopped1Promise.get_future().get();
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
 AWS_TEST_CASE(Mqtt5DoubleClientIDFailure, s_TestMqtt5DoubleClientIDFailure)
@@ -1585,7 +1585,7 @@ static int s_TestMqtt5NegotiatedSettingsHappy(Aws::Crt::Allocator *allocator, vo
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -1620,7 +1620,7 @@ static int s_TestMqtt5NegotiatedSettingsHappy(Aws::Crt::Allocator *allocator, vo
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
     stoppedPromise.get_future().get();
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
 AWS_TEST_CASE(Mqtt5NegotiatedSettingsHappy, s_TestMqtt5NegotiatedSettingsHappy)
@@ -1639,7 +1639,7 @@ static int s_TestMqtt5NegotiatedSettingsFull(Aws::Crt::Allocator *allocator, voi
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -1680,7 +1680,7 @@ static int s_TestMqtt5NegotiatedSettingsFull(Aws::Crt::Allocator *allocator, voi
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
     stoppedPromise.get_future().get();
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
 AWS_TEST_CASE(Mqtt5NegotiatedSettingsFull, s_TestMqtt5NegotiatedSettingsFull)
@@ -1699,7 +1699,7 @@ static int s_TestMqtt5NegotiatedSettingsLimit(Aws::Crt::Allocator *allocator, vo
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -1740,7 +1740,7 @@ static int s_TestMqtt5NegotiatedSettingsLimit(Aws::Crt::Allocator *allocator, vo
     ASSERT_TRUE(mqtt5Client->Stop());
     stoppedPromise.get_future().get();
 
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
 AWS_TEST_CASE(Mqtt5NegotiatedSettingsLimit, s_TestMqtt5NegotiatedSettingsLimit)
@@ -1756,7 +1756,7 @@ static int s_TestMqtt5NegotiatedSettingsRejoinAlways(Aws::Crt::Allocator *alloca
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -1814,7 +1814,7 @@ static int s_TestMqtt5NegotiatedSettingsRejoinAlways(Aws::Crt::Allocator *alloca
     ASSERT_TRUE(sessionMqtt5Client->Stop());
     sessionStoppedPromise.get_future().get();
 
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
 AWS_TEST_CASE(Mqtt5NegotiatedSettingsRejoinAlways, s_TestMqtt5NegotiatedSettingsRejoinAlways)
@@ -1832,7 +1832,7 @@ static int s_TestMqtt5SubUnsub(Aws::Crt::Allocator *allocator, void *)
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -1897,7 +1897,7 @@ static int s_TestMqtt5SubUnsub(Aws::Crt::Allocator *allocator, void *)
 
     ASSERT_TRUE(receivedCount == 1);
 
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
 AWS_TEST_CASE(Mqtt5SubUnsub, s_TestMqtt5SubUnsub)
@@ -1911,7 +1911,7 @@ static int s_TestMqtt5WillTest(Aws::Crt::Allocator *allocator, void *)
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -1984,7 +1984,7 @@ static int s_TestMqtt5WillTest(Aws::Crt::Allocator *allocator, void *)
     ASSERT_TRUE(subscriber->Stop());
     subscriberStoppedPromise.get_future().get();
 
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
 AWS_TEST_CASE(Mqtt5WillTest, s_TestMqtt5WillTest)
@@ -2002,7 +2002,7 @@ static int s_TestMqtt5NullPublish(Aws::Crt::Allocator *allocator, void *)
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -2033,7 +2033,7 @@ static int s_TestMqtt5NullPublish(Aws::Crt::Allocator *allocator, void *)
     ASSERT_TRUE(mqtt5Client->Stop());
     stoppedPromise.get_future().get();
 
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
 AWS_TEST_CASE(Mqtt5NullPublish, s_TestMqtt5NullPublish)
@@ -2047,7 +2047,7 @@ static int s_TestMqtt5NullSubscribe(Aws::Crt::Allocator *allocator, void *)
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -2077,7 +2077,7 @@ static int s_TestMqtt5NullSubscribe(Aws::Crt::Allocator *allocator, void *)
     ASSERT_TRUE(mqtt5Client->Stop());
     stoppedPromise.get_future().get();
 
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
 AWS_TEST_CASE(Mqtt5NullSubscribe, s_TestMqtt5NullSubscribe)
@@ -2091,7 +2091,7 @@ static int s_TestMqtt5NullUnsubscribe(Aws::Crt::Allocator *allocator, void *)
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -2122,7 +2122,7 @@ static int s_TestMqtt5NullUnsubscribe(Aws::Crt::Allocator *allocator, void *)
     ASSERT_TRUE(mqtt5Client->Stop());
     stoppedPromise.get_future().get();
 
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
 AWS_TEST_CASE(Mqtt5NullUnsubscribe, s_TestMqtt5NullUnsubscribe)
@@ -2133,7 +2133,7 @@ static int s_TestMqtt5NullConnectPacket(Aws::Crt::Allocator *allocator, void *)
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -2154,7 +2154,7 @@ static int s_TestMqtt5NullConnectPacket(Aws::Crt::Allocator *allocator, void *)
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_FALSE(*mqtt5Client);
 
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
 AWS_TEST_CASE(Mqtt5NullConnectPacket, s_TestMqtt5NullConnectPacket)
@@ -2173,7 +2173,7 @@ static int s_TestMqtt5QoS1SubPub(Aws::Crt::Allocator *allocator, void *)
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -2258,7 +2258,7 @@ static int s_TestMqtt5QoS1SubPub(Aws::Crt::Allocator *allocator, void *)
     ASSERT_TRUE(publisher->Stop());
     publisherStoppedPromise.get_future().get();
 
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
 AWS_TEST_CASE(Mqtt5QoS1SubPub, s_TestMqtt5QoS1SubPub)
@@ -2279,7 +2279,7 @@ static int s_TestMqtt5RetainSetAndClear(Aws::Crt::Allocator *allocator, void *)
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -2372,7 +2372,7 @@ static int s_TestMqtt5RetainSetAndClear(Aws::Crt::Allocator *allocator, void *)
     stopped3Promise.get_future().get();
     ASSERT_TRUE(mqtt5Client1->Stop());
     stopped1Promise.get_future().get();
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
 AWS_TEST_CASE(Mqtt5RetainSetAndClear, s_TestMqtt5RetainSetAndClear)
@@ -2387,7 +2387,7 @@ static int s_TestIoTMqtt5ConnectWithmTLS(Aws::Crt::Allocator *allocator, void *)
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -2412,7 +2412,7 @@ static int s_TestIoTMqtt5ConnectWithmTLS(Aws::Crt::Allocator *allocator, void *)
     stoppedPromise.get_future().get();
 
     delete builder;
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 AWS_TEST_CASE(IoTMqtt5ConnectWithmTLS, s_TestIoTMqtt5ConnectWithmTLS)
 
@@ -2425,7 +2425,7 @@ static int s_TestIoTMqtt5ConnectWithWebsocket(Aws::Crt::Allocator *allocator, vo
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -2458,7 +2458,7 @@ static int s_TestIoTMqtt5ConnectWithWebsocket(Aws::Crt::Allocator *allocator, vo
     stoppedPromise.get_future().get();
 
     delete builder;
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
 AWS_TEST_CASE(IoTMqtt5ConnectWithWebsocket, s_TestIoTMqtt5ConnectWithWebsocket)
@@ -2472,7 +2472,7 @@ static int s_TestIoTMqtt5ConnectWithSigningCustomAuth(Aws::Crt::Allocator *alloc
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -2495,7 +2495,7 @@ static int s_TestIoTMqtt5ConnectWithSigningCustomAuth(Aws::Crt::Allocator *alloc
     if (error != AWS_OP_SUCCESS)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     Aws::Iot::Mqtt5CustomAuthConfig authConfig(allocator);
@@ -2529,7 +2529,7 @@ static int s_TestIoTMqtt5ConnectWithSigningCustomAuth(Aws::Crt::Allocator *alloc
     aws_string_destroy(tokenSignature);
 
     delete builder;
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 AWS_TEST_CASE(IoTMqtt5ConnectWithSigningCustomAuth, s_TestIoTMqtt5ConnectWithSigningCustomAuth)
 
@@ -2542,7 +2542,7 @@ static int s_TestIoTMqtt5ConnectWithNoSigningCustomAuth(Aws::Crt::Allocator *all
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     struct aws_string *authname = NULL;
@@ -2556,7 +2556,7 @@ static int s_TestIoTMqtt5ConnectWithNoSigningCustomAuth(Aws::Crt::Allocator *all
     if (error != AWS_OP_SUCCESS)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -2585,7 +2585,7 @@ static int s_TestIoTMqtt5ConnectWithNoSigningCustomAuth(Aws::Crt::Allocator *all
     aws_string_destroy(password);
 
     delete builder;
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 AWS_TEST_CASE(IoTMqtt5ConnectWithNoSigningCustomAuth, s_TestIoTMqtt5ConnectWithNoSigningCustomAuth)
 
@@ -2598,7 +2598,7 @@ static int s_TestIoTMqtt5ConnectWithNoSigningCustomAuthWebsockets(Aws::Crt::Allo
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     struct aws_string *authname = NULL;
@@ -2612,7 +2612,7 @@ static int s_TestIoTMqtt5ConnectWithNoSigningCustomAuthWebsockets(Aws::Crt::Allo
     if (error != AWS_OP_SUCCESS)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -2644,7 +2644,7 @@ static int s_TestIoTMqtt5ConnectWithNoSigningCustomAuthWebsockets(Aws::Crt::Allo
     aws_string_destroy(password);
 
     delete builder;
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 AWS_TEST_CASE(IoTMqtt5ConnectWithNoSigningCustomAuthWebsockets, s_TestIoTMqtt5ConnectWithNoSigningCustomAuthWebsockets)
 
@@ -2657,7 +2657,7 @@ static int s_TestIoTMqtt5ConnectWithSigningCustomAuthWebsockets(Aws::Crt::Alloca
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -2680,7 +2680,7 @@ static int s_TestIoTMqtt5ConnectWithSigningCustomAuthWebsockets(Aws::Crt::Alloca
     if (error != AWS_OP_SUCCESS)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     Aws::Iot::Mqtt5CustomAuthConfig authConfig(allocator);
@@ -2717,7 +2717,7 @@ static int s_TestIoTMqtt5ConnectWithSigningCustomAuthWebsockets(Aws::Crt::Alloca
     aws_string_destroy(tokenSignature);
 
     delete builder;
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 AWS_TEST_CASE(IoTMqtt5ConnectWithSigningCustomAuthWebsockets, s_TestIoTMqtt5ConnectWithSigningCustomAuthWebsockets)
 
@@ -2734,7 +2734,7 @@ static int s_TestMqtt5InterruptSub(Aws::Crt::Allocator *allocator, void *)
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -2768,7 +2768,7 @@ static int s_TestMqtt5InterruptSub(Aws::Crt::Allocator *allocator, void *)
     stoppedPromise.get_future().get();
 
     delete builder;
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
 AWS_TEST_CASE(Mqtt5InterruptSub, s_TestMqtt5InterruptSub)
@@ -2782,7 +2782,7 @@ static int s_TestMqtt5InterruptUnsub(Aws::Crt::Allocator *allocator, void *)
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -2818,7 +2818,7 @@ static int s_TestMqtt5InterruptUnsub(Aws::Crt::Allocator *allocator, void *)
     stoppedPromise.get_future().get();
 
     delete builder;
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
 AWS_TEST_CASE(Mqtt5InterruptUnsub, s_TestMqtt5InterruptUnsub)
@@ -2832,7 +2832,7 @@ static int s_TestMqtt5InterruptPublishQoS1(Aws::Crt::Allocator *allocator, void 
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -2867,7 +2867,7 @@ static int s_TestMqtt5InterruptPublishQoS1(Aws::Crt::Allocator *allocator, void 
     stoppedPromise.get_future().get();
 
     delete builder;
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
 AWS_TEST_CASE(Mqtt5InterruptPublishQoS1, s_TestMqtt5InterruptPublishQoS1)
@@ -2885,7 +2885,7 @@ static int s_TestMqtt5OperationStatisticsSimple(Aws::Crt::Allocator *allocator, 
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_ERROR_SUCCESS;
+        return AWS_OP_SKIP;
     }
 
     ApiHandle apiHandle(allocator);
@@ -2931,7 +2931,7 @@ static int s_TestMqtt5OperationStatisticsSimple(Aws::Crt::Allocator *allocator, 
     ASSERT_TRUE(mqtt5Client->Stop());
     stoppedPromise.get_future().get();
 
-    return AWS_ERROR_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
 AWS_TEST_CASE(Mqtt5OperationStatisticsSimple, s_TestMqtt5OperationStatisticsSimple)

--- a/tests/Mqtt5ClientTest.cpp
+++ b/tests/Mqtt5ClientTest.cpp
@@ -413,7 +413,6 @@ static int s_TestMqtt5NewClientMin(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
 
     return AWS_OP_SUCCESS;
 }
@@ -487,7 +486,7 @@ static int s_TestMqtt5NewClientFull(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
+
     return AWS_OP_SUCCESS;
 }
 
@@ -522,7 +521,7 @@ static int s_TestMqtt5DirectConnectionMinimal(Aws::Crt::Allocator *allocator, vo
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
+
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -562,7 +561,6 @@ static int s_TestMqtt5DirectConnectionWithBasicAuth(Aws::Crt::Allocator *allocat
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
 
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
@@ -609,7 +607,7 @@ static int s_TestMqtt5DirectConnectionWithTLS(Aws::Crt::Allocator *allocator, vo
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
+
     ASSERT_TRUE(mqtt5Client->Start());
     connectionPromise.get_future().get();
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -655,7 +653,7 @@ static int s_TestMqtt5DirectConnectionWithMutualTLS(Aws::Crt::Allocator *allocat
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
+
     ASSERT_TRUE(mqtt5Client->Start());
     connectionPromise.get_future().get();
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -710,7 +708,6 @@ static int s_TestMqtt5DirectConnectionWithHttpProxy(Aws::Crt::Allocator *allocat
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
 
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
@@ -795,7 +792,7 @@ static int s_TestMqtt5DirectConnectionFull(Aws::Crt::Allocator *allocator, void 
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
+
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -855,7 +852,7 @@ static int s_TestMqtt5WSConnectionMinimal(Aws::Crt::Allocator *allocator, void *
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
+
     ASSERT_TRUE(mqtt5Client->Start());
     connectionPromise.get_future().get();
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -917,7 +914,6 @@ static int s_TestMqtt5WSConnectionWithBasicAuth(Aws::Crt::Allocator *allocator, 
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
 
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
@@ -985,7 +981,7 @@ static int s_TestMqtt5WSConnectionWithTLS(Aws::Crt::Allocator *allocator, void *
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
+
     ASSERT_TRUE(mqtt5Client->Start());
     connectionPromise.get_future().get();
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -1054,7 +1050,7 @@ static int s_TestMqtt5WSConnectionWithMutualTLS(Aws::Crt::Allocator *allocator, 
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
+
     ASSERT_TRUE(mqtt5Client->Start());
     connectionPromise.get_future().get();
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -1136,7 +1132,6 @@ static int s_TestMqtt5WSConnectionWithHttpProxy(Aws::Crt::Allocator *allocator, 
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
 
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
@@ -1244,7 +1239,7 @@ static int s_TestMqtt5WSConnectionFull(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
+
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -1282,7 +1277,7 @@ static int s_TestMqtt5DirectInvalidHostname(Aws::Crt::Allocator *allocator, void
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
+
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_FALSE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -1316,7 +1311,7 @@ static int s_TestMqtt5DirectInvalidPort(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
+
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_FALSE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -1372,7 +1367,7 @@ static int s_TestMqtt5WSInvalidPort(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
+
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_FALSE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -1419,7 +1414,6 @@ static int s_TestMqtt5SocketTimeout(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
 
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_FALSE(connectionPromise.get_future().get());
@@ -1459,7 +1453,6 @@ static int s_TestMqtt5IncorrectBasicAuth(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
 
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_FALSE(connectionPromise.get_future().get());
@@ -1508,7 +1501,7 @@ static int s_TestMqtt5IncorrectWSConnect(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
+
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_FALSE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -1559,13 +1552,11 @@ static int s_TestMqtt5DoubleClientIDFailure(Aws::Crt::Allocator *allocator, void
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client1 = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client1);
-    ASSERT_TRUE(*mqtt5Client1);
 
     s_setupConnectionLifeCycle(mqtt5Options, connection2Promise, stopped2Promise, "Client2");
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client2 = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client2);
-    ASSERT_TRUE(*mqtt5Client2);
 
     ASSERT_TRUE(mqtt5Client1->Start());
     // Client 1 is connected.
@@ -1636,7 +1627,6 @@ static int s_TestMqtt5NegotiatedSettingsHappy(Aws::Crt::Allocator *allocator, vo
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
 
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
@@ -1697,7 +1687,6 @@ static int s_TestMqtt5NegotiatedSettingsFull(Aws::Crt::Allocator *allocator, voi
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
 
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
@@ -1757,7 +1746,6 @@ static int s_TestMqtt5NegotiatedSettingsLimit(Aws::Crt::Allocator *allocator, vo
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
 
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
@@ -1809,7 +1797,6 @@ static int s_TestMqtt5NegotiatedSettingsRejoinAlways(Aws::Crt::Allocator *alloca
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
 
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
@@ -1884,7 +1871,7 @@ static int s_TestMqtt5SubUnsub(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
+
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
 
@@ -1965,7 +1952,6 @@ static int s_TestMqtt5WillTest(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> subscriber = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(subscriber);
-    ASSERT_TRUE(*subscriber);
 
     /* Set will for client option */
     std::shared_ptr<Aws::Crt::Mqtt5::ConnectPacket> packetConnect = std::make_shared<Aws::Crt::Mqtt5::ConnectPacket>();
@@ -1979,7 +1965,6 @@ static int s_TestMqtt5WillTest(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> publisher = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(publisher);
-    ASSERT_TRUE(*publisher);
 
     ASSERT_TRUE(publisher->Start());
     publisherConnectionPromise.get_future().get();
@@ -2043,7 +2028,7 @@ static int s_TestMqtt5NullPublish(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
+
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
 
@@ -2089,7 +2074,7 @@ static int s_TestMqtt5NullSubscribe(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
+
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
 
@@ -2134,7 +2119,6 @@ static int s_TestMqtt5NullUnsubscribe(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
 
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
@@ -2179,9 +2163,8 @@ static int s_TestMqtt5NullConnectPacket(Aws::Crt::Allocator *allocator, void *)
     mqtt5Options.WithConnectOptions(packetConnect);
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
-    ASSERT_TRUE(mqtt5Client);
-    ASSERT_FALSE(*mqtt5Client);
-    ASSERT_TRUE(mqtt5Client->LastError() == AWS_ERROR_MQTT5_CLIENT_OPTIONS_VALIDATION);
+    ASSERT_FALSE(mqtt5Client);
+    ASSERT_TRUE(LastError() == AWS_ERROR_MQTT5_CLIENT_OPTIONS_VALIDATION);
 
     return AWS_OP_SUCCESS;
 }
@@ -2240,13 +2223,11 @@ static int s_TestMqtt5QoS1SubPub(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> subscriber = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(subscriber);
-    ASSERT_TRUE(*subscriber);
 
     s_setupConnectionLifeCycle(mqtt5Options, publisherConnectionPromise, publisherStoppedPromise, "Publisher");
 
     std::shared_ptr<Mqtt5::Mqtt5Client> publisher = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(publisher);
-    ASSERT_TRUE(*publisher);
 
     ASSERT_TRUE(publisher->Start());
     ASSERT_TRUE(publisherConnectionPromise.get_future().get());
@@ -2332,7 +2313,6 @@ static int s_TestMqtt5RetainSetAndClear(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client1 = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client1);
-    ASSERT_TRUE(*mqtt5Client1);
 
     s_setupConnectionLifeCycle(mqtt5Options, connection2Promise, stopped2Promise, "Client2");
 
@@ -2347,7 +2327,6 @@ static int s_TestMqtt5RetainSetAndClear(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client2 = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client2);
-    ASSERT_TRUE(*mqtt5Client2);
 
     s_setupConnectionLifeCycle(mqtt5Options, connection3Promise, stopped3Promise, "Client3");
 
@@ -2363,7 +2342,6 @@ static int s_TestMqtt5RetainSetAndClear(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client3 = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client3);
-    ASSERT_TRUE(*mqtt5Client3);
 
     // 1. client1 start and publish a retian message
     ASSERT_TRUE(mqtt5Client1->Start());
@@ -2430,6 +2408,8 @@ static int s_TestIoTMqtt5ConnectWithmTLS(Aws::Crt::Allocator *allocator, void *)
         mqtt5TestVars.m_private_key_path_string.c_str(),
         allocator);
 
+    ASSERT_TRUE(builder);
+
     std::promise<bool> connectionPromise;
     std::promise<void> stoppedPromise;
 
@@ -2438,7 +2418,7 @@ static int s_TestIoTMqtt5ConnectWithmTLS(Aws::Crt::Allocator *allocator, void *)
     std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> mqtt5Client = builder->Build();
 
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
+
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -2476,6 +2456,7 @@ static int s_TestIoTMqtt5ConnectWithWebsocket(Aws::Crt::Allocator *allocator, vo
 
     Aws::Iot::Mqtt5ClientBuilder *builder = Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithWebsocket(
         mqtt5TestVars.m_hostname_string, websocketConfig, allocator);
+    ASSERT_TRUE(builder);
 
     std::promise<bool> connectionPromise;
     std::promise<void> stoppedPromise;
@@ -2485,7 +2466,7 @@ static int s_TestIoTMqtt5ConnectWithWebsocket(Aws::Crt::Allocator *allocator, vo
     std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> mqtt5Client = builder->Build();
 
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
+
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -2542,6 +2523,8 @@ static int s_TestIoTMqtt5ConnectWithSigningCustomAuth(Aws::Crt::Allocator *alloc
 
     Aws::Iot::Mqtt5ClientBuilder *builder = Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithCustomAuthorizer(
         mqtt5TestVars.m_hostname_string, authConfig, allocator);
+    ASSERT_TRUE(builder);
+
     std::promise<bool> connectionPromise;
     std::promise<void> stoppedPromise;
 
@@ -2550,7 +2533,7 @@ static int s_TestIoTMqtt5ConnectWithSigningCustomAuth(Aws::Crt::Allocator *alloc
     std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> mqtt5Client = builder->Build();
 
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
+
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -2602,6 +2585,7 @@ static int s_TestIoTMqtt5ConnectWithNoSigningCustomAuth(Aws::Crt::Allocator *all
 
     Aws::Iot::Mqtt5ClientBuilder *builder = Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithCustomAuthorizer(
         mqtt5TestVars.m_hostname_string, authConfig, allocator);
+    ASSERT_TRUE(builder);
     std::promise<bool> connectionPromise;
     std::promise<void> stoppedPromise;
 
@@ -2610,7 +2594,7 @@ static int s_TestIoTMqtt5ConnectWithNoSigningCustomAuth(Aws::Crt::Allocator *all
     std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> mqtt5Client = builder->Build();
 
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
+
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -2662,6 +2646,7 @@ static int s_TestIoTMqtt5ConnectWithNoSigningCustomAuthWebsockets(Aws::Crt::Allo
     Aws::Iot::Mqtt5ClientBuilder *builder =
         Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithCustomAuthorizerWebsocket(
             mqtt5TestVars.m_hostname_string, authConfig, websocketConfig, allocator);
+    ASSERT_TRUE(builder);
     std::promise<bool> connectionPromise;
     std::promise<void> stoppedPromise;
 
@@ -2670,7 +2655,7 @@ static int s_TestIoTMqtt5ConnectWithNoSigningCustomAuthWebsockets(Aws::Crt::Allo
     std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> mqtt5Client = builder->Build();
 
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
+
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -2733,6 +2718,7 @@ static int s_TestIoTMqtt5ConnectWithSigningCustomAuthWebsockets(Aws::Crt::Alloca
     Aws::Iot::Mqtt5ClientBuilder *builder =
         Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithCustomAuthorizerWebsocket(
             mqtt5TestVars.m_hostname_string, authConfig, websocketConfig, allocator);
+    ASSERT_TRUE(builder);
     std::promise<bool> connectionPromise;
     std::promise<void> stoppedPromise;
 
@@ -2741,7 +2727,7 @@ static int s_TestIoTMqtt5ConnectWithSigningCustomAuthWebsockets(Aws::Crt::Alloca
     std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> mqtt5Client = builder->Build();
 
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
+
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -2782,6 +2768,7 @@ static int s_TestMqtt5InterruptSub(Aws::Crt::Allocator *allocator, void *)
         mqtt5TestVars.m_certificate_path_string.c_str(),
         mqtt5TestVars.m_private_key_path_string.c_str(),
         allocator);
+    ASSERT_TRUE(builder);
 
     std::promise<bool> connectionPromise;
     std::promise<void> stoppedPromise;
@@ -2791,7 +2778,7 @@ static int s_TestMqtt5InterruptSub(Aws::Crt::Allocator *allocator, void *)
     std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> mqtt5Client = builder->Build();
 
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
+
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
 
@@ -2831,7 +2818,7 @@ static int s_TestMqtt5InterruptUnsub(Aws::Crt::Allocator *allocator, void *)
         mqtt5TestVars.m_certificate_path_string.c_str(),
         mqtt5TestVars.m_private_key_path_string.c_str(),
         allocator);
-
+    ASSERT_TRUE(builder);
     std::promise<bool> connectionPromise;
     std::promise<void> stoppedPromise;
 
@@ -2840,7 +2827,7 @@ static int s_TestMqtt5InterruptUnsub(Aws::Crt::Allocator *allocator, void *)
     std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> mqtt5Client = builder->Build();
 
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
+
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
 
@@ -2882,6 +2869,7 @@ static int s_TestMqtt5InterruptPublishQoS1(Aws::Crt::Allocator *allocator, void 
         mqtt5TestVars.m_certificate_path_string.c_str(),
         mqtt5TestVars.m_private_key_path_string.c_str(),
         allocator);
+    ASSERT_TRUE(builder);
 
     std::promise<bool> connectionPromise;
     std::promise<void> stoppedPromise;
@@ -2891,7 +2879,7 @@ static int s_TestMqtt5InterruptPublishQoS1(Aws::Crt::Allocator *allocator, void 
     std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> mqtt5Client = builder->Build();
 
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
+
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
 
@@ -2943,7 +2931,7 @@ static int s_TestMqtt5OperationStatisticsSimple(Aws::Crt::Allocator *allocator, 
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-    ASSERT_TRUE(*mqtt5Client);
+
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
 

--- a/tests/Mqtt5ClientTest.cpp
+++ b/tests/Mqtt5ClientTest.cpp
@@ -486,7 +486,6 @@ static int s_TestMqtt5NewClientFull(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-
     return AWS_OP_SUCCESS;
 }
 
@@ -521,7 +520,6 @@ static int s_TestMqtt5DirectConnectionMinimal(Aws::Crt::Allocator *allocator, vo
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -607,7 +605,6 @@ static int s_TestMqtt5DirectConnectionWithTLS(Aws::Crt::Allocator *allocator, vo
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-
     ASSERT_TRUE(mqtt5Client->Start());
     connectionPromise.get_future().get();
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -653,7 +650,6 @@ static int s_TestMqtt5DirectConnectionWithMutualTLS(Aws::Crt::Allocator *allocat
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-
     ASSERT_TRUE(mqtt5Client->Start());
     connectionPromise.get_future().get();
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -792,7 +788,6 @@ static int s_TestMqtt5DirectConnectionFull(Aws::Crt::Allocator *allocator, void 
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -852,7 +847,6 @@ static int s_TestMqtt5WSConnectionMinimal(Aws::Crt::Allocator *allocator, void *
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-
     ASSERT_TRUE(mqtt5Client->Start());
     connectionPromise.get_future().get();
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -981,7 +975,6 @@ static int s_TestMqtt5WSConnectionWithTLS(Aws::Crt::Allocator *allocator, void *
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-
     ASSERT_TRUE(mqtt5Client->Start());
     connectionPromise.get_future().get();
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -1050,7 +1043,6 @@ static int s_TestMqtt5WSConnectionWithMutualTLS(Aws::Crt::Allocator *allocator, 
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-
     ASSERT_TRUE(mqtt5Client->Start());
     connectionPromise.get_future().get();
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -1239,7 +1231,6 @@ static int s_TestMqtt5WSConnectionFull(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -1277,7 +1268,6 @@ static int s_TestMqtt5DirectInvalidHostname(Aws::Crt::Allocator *allocator, void
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_FALSE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -1311,7 +1301,6 @@ static int s_TestMqtt5DirectInvalidPort(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_FALSE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -1367,7 +1356,6 @@ static int s_TestMqtt5WSInvalidPort(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_FALSE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -1501,7 +1489,6 @@ static int s_TestMqtt5IncorrectWSConnect(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_FALSE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -1871,7 +1858,6 @@ static int s_TestMqtt5SubUnsub(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
 
@@ -2028,7 +2014,6 @@ static int s_TestMqtt5NullPublish(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
 
@@ -2074,7 +2059,6 @@ static int s_TestMqtt5NullSubscribe(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
 
@@ -2418,7 +2402,6 @@ static int s_TestIoTMqtt5ConnectWithmTLS(Aws::Crt::Allocator *allocator, void *)
     std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> mqtt5Client = builder->Build();
 
     ASSERT_TRUE(mqtt5Client);
-
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -2466,7 +2449,6 @@ static int s_TestIoTMqtt5ConnectWithWebsocket(Aws::Crt::Allocator *allocator, vo
     std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> mqtt5Client = builder->Build();
 
     ASSERT_TRUE(mqtt5Client);
-
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -2533,7 +2515,6 @@ static int s_TestIoTMqtt5ConnectWithSigningCustomAuth(Aws::Crt::Allocator *alloc
     std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> mqtt5Client = builder->Build();
 
     ASSERT_TRUE(mqtt5Client);
-
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -2594,7 +2575,6 @@ static int s_TestIoTMqtt5ConnectWithNoSigningCustomAuth(Aws::Crt::Allocator *all
     std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> mqtt5Client = builder->Build();
 
     ASSERT_TRUE(mqtt5Client);
-
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -2655,7 +2635,6 @@ static int s_TestIoTMqtt5ConnectWithNoSigningCustomAuthWebsockets(Aws::Crt::Allo
     std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> mqtt5Client = builder->Build();
 
     ASSERT_TRUE(mqtt5Client);
-
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -2727,7 +2706,6 @@ static int s_TestIoTMqtt5ConnectWithSigningCustomAuthWebsockets(Aws::Crt::Alloca
     std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> mqtt5Client = builder->Build();
 
     ASSERT_TRUE(mqtt5Client);
-
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -2778,7 +2756,6 @@ static int s_TestMqtt5InterruptSub(Aws::Crt::Allocator *allocator, void *)
     std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> mqtt5Client = builder->Build();
 
     ASSERT_TRUE(mqtt5Client);
-
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
 
@@ -2827,7 +2804,6 @@ static int s_TestMqtt5InterruptUnsub(Aws::Crt::Allocator *allocator, void *)
     std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> mqtt5Client = builder->Build();
 
     ASSERT_TRUE(mqtt5Client);
-
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
 
@@ -2879,7 +2855,6 @@ static int s_TestMqtt5InterruptPublishQoS1(Aws::Crt::Allocator *allocator, void 
     std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> mqtt5Client = builder->Build();
 
     ASSERT_TRUE(mqtt5Client);
-
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
 
@@ -2931,7 +2906,6 @@ static int s_TestMqtt5OperationStatisticsSimple(Aws::Crt::Allocator *allocator, 
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
-
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
 

--- a/tests/Mqtt5ClientTest.cpp
+++ b/tests/Mqtt5ClientTest.cpp
@@ -413,6 +413,7 @@ static int s_TestMqtt5NewClientMin(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
 
     return AWS_OP_SUCCESS;
 }
@@ -485,6 +486,7 @@ static int s_TestMqtt5NewClientFull(Aws::Crt::Allocator *allocator, void *)
     s_setupConnectionLifeCycle(mqtt5Options, connectionPromise, stoppedPromise);
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
+    ASSERT_TRUE(mqtt5Client);
     ASSERT_TRUE(*mqtt5Client);
     return AWS_OP_SUCCESS;
 }
@@ -520,6 +522,7 @@ static int s_TestMqtt5DirectConnectionMinimal(Aws::Crt::Allocator *allocator, vo
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -559,6 +562,7 @@ static int s_TestMqtt5DirectConnectionWithBasicAuth(Aws::Crt::Allocator *allocat
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
 
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
@@ -605,6 +609,7 @@ static int s_TestMqtt5DirectConnectionWithTLS(Aws::Crt::Allocator *allocator, vo
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
     ASSERT_TRUE(mqtt5Client->Start());
     connectionPromise.get_future().get();
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -650,6 +655,7 @@ static int s_TestMqtt5DirectConnectionWithMutualTLS(Aws::Crt::Allocator *allocat
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
     ASSERT_TRUE(mqtt5Client->Start());
     connectionPromise.get_future().get();
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -704,6 +710,7 @@ static int s_TestMqtt5DirectConnectionWithHttpProxy(Aws::Crt::Allocator *allocat
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
 
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
@@ -788,6 +795,7 @@ static int s_TestMqtt5DirectConnectionFull(Aws::Crt::Allocator *allocator, void 
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -847,6 +855,7 @@ static int s_TestMqtt5WSConnectionMinimal(Aws::Crt::Allocator *allocator, void *
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
     ASSERT_TRUE(mqtt5Client->Start());
     connectionPromise.get_future().get();
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -908,6 +917,7 @@ static int s_TestMqtt5WSConnectionWithBasicAuth(Aws::Crt::Allocator *allocator, 
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
 
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
@@ -975,6 +985,7 @@ static int s_TestMqtt5WSConnectionWithTLS(Aws::Crt::Allocator *allocator, void *
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
     ASSERT_TRUE(mqtt5Client->Start());
     connectionPromise.get_future().get();
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -1043,6 +1054,7 @@ static int s_TestMqtt5WSConnectionWithMutualTLS(Aws::Crt::Allocator *allocator, 
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
     ASSERT_TRUE(mqtt5Client->Start());
     connectionPromise.get_future().get();
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -1124,6 +1136,7 @@ static int s_TestMqtt5WSConnectionWithHttpProxy(Aws::Crt::Allocator *allocator, 
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
 
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
@@ -1231,6 +1244,7 @@ static int s_TestMqtt5WSConnectionFull(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -1268,6 +1282,7 @@ static int s_TestMqtt5DirectInvalidHostname(Aws::Crt::Allocator *allocator, void
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_FALSE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -1301,6 +1316,7 @@ static int s_TestMqtt5DirectInvalidPort(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_FALSE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -1356,6 +1372,7 @@ static int s_TestMqtt5WSInvalidPort(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_FALSE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -1402,6 +1419,7 @@ static int s_TestMqtt5SocketTimeout(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
 
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_FALSE(connectionPromise.get_future().get());
@@ -1441,6 +1459,7 @@ static int s_TestMqtt5IncorrectBasicAuth(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
 
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_FALSE(connectionPromise.get_future().get());
@@ -1489,6 +1508,7 @@ static int s_TestMqtt5IncorrectWSConnect(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_FALSE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -1539,11 +1559,13 @@ static int s_TestMqtt5DoubleClientIDFailure(Aws::Crt::Allocator *allocator, void
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client1 = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client1);
+    ASSERT_TRUE(*mqtt5Client1);
 
     s_setupConnectionLifeCycle(mqtt5Options, connection2Promise, stopped2Promise, "Client2");
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client2 = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client2);
+    ASSERT_TRUE(*mqtt5Client2);
 
     ASSERT_TRUE(mqtt5Client1->Start());
     // Client 1 is connected.
@@ -1614,6 +1636,7 @@ static int s_TestMqtt5NegotiatedSettingsHappy(Aws::Crt::Allocator *allocator, vo
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
 
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
@@ -1674,6 +1697,7 @@ static int s_TestMqtt5NegotiatedSettingsFull(Aws::Crt::Allocator *allocator, voi
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
 
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
@@ -1733,6 +1757,7 @@ static int s_TestMqtt5NegotiatedSettingsLimit(Aws::Crt::Allocator *allocator, vo
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
 
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
@@ -1784,6 +1809,7 @@ static int s_TestMqtt5NegotiatedSettingsRejoinAlways(Aws::Crt::Allocator *alloca
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
 
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
@@ -1858,6 +1884,7 @@ static int s_TestMqtt5SubUnsub(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
 
@@ -1938,6 +1965,7 @@ static int s_TestMqtt5WillTest(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> subscriber = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(subscriber);
+    ASSERT_TRUE(*subscriber);
 
     /* Set will for client option */
     std::shared_ptr<Aws::Crt::Mqtt5::ConnectPacket> packetConnect = std::make_shared<Aws::Crt::Mqtt5::ConnectPacket>();
@@ -1951,6 +1979,7 @@ static int s_TestMqtt5WillTest(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> publisher = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(publisher);
+    ASSERT_TRUE(*publisher);
 
     ASSERT_TRUE(publisher->Start());
     publisherConnectionPromise.get_future().get();
@@ -2014,6 +2043,7 @@ static int s_TestMqtt5NullPublish(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
 
@@ -2059,6 +2089,7 @@ static int s_TestMqtt5NullSubscribe(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
 
@@ -2103,6 +2134,7 @@ static int s_TestMqtt5NullUnsubscribe(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
 
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
@@ -2147,7 +2179,9 @@ static int s_TestMqtt5NullConnectPacket(Aws::Crt::Allocator *allocator, void *)
     mqtt5Options.WithConnectOptions(packetConnect);
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
-    ASSERT_FALSE(mqtt5Client);
+    ASSERT_TRUE(mqtt5Client);
+    ASSERT_FALSE(*mqtt5Client);
+    ASSERT_TRUE(mqtt5Client->LastError() == AWS_ERROR_MQTT5_CONNECT_OPTIONS_VALIDATION);
 
     return AWS_OP_SUCCESS;
 }
@@ -2206,11 +2240,13 @@ static int s_TestMqtt5QoS1SubPub(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> subscriber = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(subscriber);
+    ASSERT_TRUE(*subscriber);
 
     s_setupConnectionLifeCycle(mqtt5Options, publisherConnectionPromise, publisherStoppedPromise, "Publisher");
 
     std::shared_ptr<Mqtt5::Mqtt5Client> publisher = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(publisher);
+    ASSERT_TRUE(*publisher);
 
     ASSERT_TRUE(publisher->Start());
     ASSERT_TRUE(publisherConnectionPromise.get_future().get());
@@ -2296,6 +2332,7 @@ static int s_TestMqtt5RetainSetAndClear(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client1 = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client1);
+    ASSERT_TRUE(*mqtt5Client1);
 
     s_setupConnectionLifeCycle(mqtt5Options, connection2Promise, stopped2Promise, "Client2");
 
@@ -2310,6 +2347,7 @@ static int s_TestMqtt5RetainSetAndClear(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client2 = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client2);
+    ASSERT_TRUE(*mqtt5Client2);
 
     s_setupConnectionLifeCycle(mqtt5Options, connection3Promise, stopped3Promise, "Client3");
 
@@ -2325,6 +2363,7 @@ static int s_TestMqtt5RetainSetAndClear(Aws::Crt::Allocator *allocator, void *)
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client3 = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client3);
+    ASSERT_TRUE(*mqtt5Client3);
 
     // 1. client1 start and publish a retian message
     ASSERT_TRUE(mqtt5Client1->Start());
@@ -2399,6 +2438,7 @@ static int s_TestIoTMqtt5ConnectWithmTLS(Aws::Crt::Allocator *allocator, void *)
     std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> mqtt5Client = builder->Build();
 
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -2445,6 +2485,7 @@ static int s_TestIoTMqtt5ConnectWithWebsocket(Aws::Crt::Allocator *allocator, vo
     std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> mqtt5Client = builder->Build();
 
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -2509,6 +2550,7 @@ static int s_TestIoTMqtt5ConnectWithSigningCustomAuth(Aws::Crt::Allocator *alloc
     std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> mqtt5Client = builder->Build();
 
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -2568,6 +2610,7 @@ static int s_TestIoTMqtt5ConnectWithNoSigningCustomAuth(Aws::Crt::Allocator *all
     std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> mqtt5Client = builder->Build();
 
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -2627,6 +2670,7 @@ static int s_TestIoTMqtt5ConnectWithNoSigningCustomAuthWebsockets(Aws::Crt::Allo
     std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> mqtt5Client = builder->Build();
 
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -2697,6 +2741,7 @@ static int s_TestIoTMqtt5ConnectWithSigningCustomAuthWebsockets(Aws::Crt::Alloca
     std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> mqtt5Client = builder->Build();
 
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
     ASSERT_TRUE(mqtt5Client->Stop());
@@ -2746,6 +2791,7 @@ static int s_TestMqtt5InterruptSub(Aws::Crt::Allocator *allocator, void *)
     std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> mqtt5Client = builder->Build();
 
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
 
@@ -2794,6 +2840,7 @@ static int s_TestMqtt5InterruptUnsub(Aws::Crt::Allocator *allocator, void *)
     std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> mqtt5Client = builder->Build();
 
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
 
@@ -2844,6 +2891,7 @@ static int s_TestMqtt5InterruptPublishQoS1(Aws::Crt::Allocator *allocator, void 
     std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> mqtt5Client = builder->Build();
 
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
 
@@ -2895,6 +2943,7 @@ static int s_TestMqtt5OperationStatisticsSimple(Aws::Crt::Allocator *allocator, 
 
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
+    ASSERT_TRUE(*mqtt5Client);
     ASSERT_TRUE(mqtt5Client->Start());
     ASSERT_TRUE(connectionPromise.get_future().get());
 

--- a/tests/Mqtt5ClientTest.cpp
+++ b/tests/Mqtt5ClientTest.cpp
@@ -454,6 +454,7 @@ static int s_TestMqtt5DirectConnectionMinimal(Aws::Crt::Allocator *allocator, vo
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
     }
 
     ApiHandle apiHandle(allocator);
@@ -487,6 +488,7 @@ static int s_TestMqtt5DirectConnectionWithBasicAuth(Aws::Crt::Allocator *allocat
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
     }
 
     ApiHandle apiHandle(allocator);
@@ -526,6 +528,7 @@ static int s_TestMqtt5DirectConnectionWithTLS(Aws::Crt::Allocator *allocator, vo
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
     }
 
     ApiHandle apiHandle(allocator);
@@ -571,6 +574,7 @@ static int s_TestMqtt5DirectConnectionWithMutualTLS(Aws::Crt::Allocator *allocat
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
     }
 
     ApiHandle apiHandle(allocator);
@@ -614,6 +618,7 @@ static int s_TestMqtt5DirectConnectionWithHttpProxy(Aws::Crt::Allocator *allocat
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
     }
 
     ApiHandle apiHandle(allocator);
@@ -663,6 +668,7 @@ static int s_TestMqtt5DirectConnectionFull(Aws::Crt::Allocator *allocator, void 
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
     }
 
     ApiHandle apiHandle(allocator);
@@ -748,6 +754,7 @@ static int s_TestMqtt5WSConnectionMinimal(Aws::Crt::Allocator *allocator, void *
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
     }
 
     ApiHandle apiHandle(allocator);
@@ -803,6 +810,7 @@ static int s_TestMqtt5WSConnectionWithBasicAuth(Aws::Crt::Allocator *allocator, 
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
     }
 
     ApiHandle apiHandle(allocator);
@@ -864,6 +872,7 @@ static int s_TestMqtt5WSConnectionWithTLS(Aws::Crt::Allocator *allocator, void *
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
     }
 
     ApiHandle apiHandle(allocator);
@@ -930,6 +939,7 @@ static int s_TestMqtt5WSConnectionWithMutualTLS(Aws::Crt::Allocator *allocator, 
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
     }
 
     ApiHandle apiHandle(allocator);
@@ -997,6 +1007,7 @@ static int s_TestMqtt5WSConnectionWithHttpProxy(Aws::Crt::Allocator *allocator, 
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
     }
 
     ApiHandle apiHandle(allocator);
@@ -1072,6 +1083,7 @@ static int s_TestMqtt5WSConnectionFull(Aws::Crt::Allocator *allocator, void *)
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
     }
 
     ApiHandle apiHandle(allocator);
@@ -1180,6 +1192,7 @@ static int s_TestMqtt5DirectInvalidHostname(Aws::Crt::Allocator *allocator, void
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
     }
 
     ApiHandle apiHandle(allocator);
@@ -1212,6 +1225,7 @@ static int s_TestMqtt5DirectInvalidPort(Aws::Crt::Allocator *allocator, void *)
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
     }
 
     ApiHandle apiHandle(allocator);
@@ -1244,6 +1258,7 @@ static int s_TestMqtt5WSInvalidPort(Aws::Crt::Allocator *allocator, void *)
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
     }
 
     ApiHandle apiHandle(allocator);
@@ -1298,6 +1313,7 @@ static int s_TestMqtt5SocketTimeout(Aws::Crt::Allocator *allocator, void *)
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
     }
 
     ApiHandle apiHandle(allocator);
@@ -1344,6 +1360,7 @@ static int s_TestMqtt5IncorrectBasicAuth(Aws::Crt::Allocator *allocator, void *)
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
     }
 
     ApiHandle apiHandle(allocator);
@@ -1381,6 +1398,7 @@ static int s_TestMqtt5IncorrectWSConnect(Aws::Crt::Allocator *allocator, void *)
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
     }
 
     ApiHandle apiHandle(allocator);
@@ -1429,6 +1447,7 @@ static int s_TestMqtt5DoubleClientIDFailure(Aws::Crt::Allocator *allocator, void
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
     }
 
     ApiHandle apiHandle(allocator);
@@ -1506,6 +1525,7 @@ static int s_TestMqtt5NegotiatedSettingsHappy(Aws::Crt::Allocator *allocator, vo
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
     }
 
     ApiHandle apiHandle(allocator);
@@ -1559,6 +1579,7 @@ static int s_TestMqtt5NegotiatedSettingsFull(Aws::Crt::Allocator *allocator, voi
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
     }
 
     ApiHandle apiHandle(allocator);
@@ -1618,6 +1639,7 @@ static int s_TestMqtt5NegotiatedSettingsLimit(Aws::Crt::Allocator *allocator, vo
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
     }
 
     ApiHandle apiHandle(allocator);
@@ -1745,6 +1767,7 @@ static int s_TestMqtt5SubUnsub(Aws::Crt::Allocator *allocator, void *)
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
     }
 
     ApiHandle apiHandle(allocator);
@@ -1823,6 +1846,7 @@ static int s_TestMqtt5WillTest(Aws::Crt::Allocator *allocator, void *)
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
     }
 
     ApiHandle apiHandle(allocator);
@@ -1913,6 +1937,7 @@ static int s_TestMqtt5NullPublish(Aws::Crt::Allocator *allocator, void *)
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
     }
 
     ApiHandle apiHandle(allocator);
@@ -1957,6 +1982,7 @@ static int s_TestMqtt5NullSubscribe(Aws::Crt::Allocator *allocator, void *)
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
     }
 
     ApiHandle apiHandle(allocator);
@@ -2000,6 +2026,7 @@ static int s_TestMqtt5NullUnsubscribe(Aws::Crt::Allocator *allocator, void *)
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
     }
 
     ApiHandle apiHandle(allocator);
@@ -2041,6 +2068,7 @@ static int s_TestMqtt5NullConnectPacket(Aws::Crt::Allocator *allocator, void *)
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
     }
 
     ApiHandle apiHandle(allocator);
@@ -2080,6 +2108,7 @@ static int s_TestMqtt5QoS1SubPub(Aws::Crt::Allocator *allocator, void *)
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
     }
 
     ApiHandle apiHandle(allocator);
@@ -2185,6 +2214,7 @@ static int s_TestMqtt5RetainSetAndClear(Aws::Crt::Allocator *allocator, void *)
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
     }
 
     ApiHandle apiHandle(allocator);
@@ -2447,6 +2477,7 @@ static int s_TestIoTMqtt5ConnectWithNoSigningCustomAuth(Aws::Crt::Allocator *all
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
     }
 
     struct aws_string *authname = NULL;
@@ -2502,6 +2533,7 @@ static int s_TestIoTMqtt5ConnectWithNoSigningCustomAuthWebsockets(Aws::Crt::Allo
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
     }
 
     struct aws_string *authname = NULL;
@@ -2788,6 +2820,7 @@ static int s_TestMqtt5OperationStatisticsSimple(Aws::Crt::Allocator *allocator, 
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
     }
 
     ApiHandle apiHandle(allocator);

--- a/tests/Mqtt5ClientTest.cpp
+++ b/tests/Mqtt5ClientTest.cpp
@@ -2181,7 +2181,7 @@ static int s_TestMqtt5NullConnectPacket(Aws::Crt::Allocator *allocator, void *)
     std::shared_ptr<Mqtt5::Mqtt5Client> mqtt5Client = Mqtt5::Mqtt5Client::NewMqtt5Client(mqtt5Options, allocator);
     ASSERT_TRUE(mqtt5Client);
     ASSERT_FALSE(*mqtt5Client);
-    ASSERT_TRUE(mqtt5Client->LastError() == AWS_ERROR_MQTT5_CONNECT_OPTIONS_VALIDATION);
+    ASSERT_TRUE(mqtt5Client->LastError() == AWS_ERROR_MQTT5_CLIENT_OPTIONS_VALIDATION);
 
     return AWS_OP_SUCCESS;
 }

--- a/tests/Mqtt5ClientTest.cpp
+++ b/tests/Mqtt5ClientTest.cpp
@@ -101,11 +101,17 @@ struct Mqtt5TestEnvVars
             {
                 m_error |= aws_get_environment_value(allocator, s_mqtt5_test_envName_direct_hostName, &m_hostname);
                 m_error |= aws_get_environment_value(allocator, s_mqtt5_test_envName_direct_port, &m_port);
-                if (m_error == AWS_OP_SUCCESS)
+                if (m_error != AWS_OP_SUCCESS)
                 {
-                    m_hostname_string = aws_string_c_str(m_hostname);
-                    m_port_value = static_cast<uint16_t>(atoi(aws_string_c_str(m_port)));
+                    return;
                 }
+                if(m_hostname == NULL || m_port == NULL)
+                {
+                    m_error = AWS_OP_ERR;
+                    return;
+                }
+                m_hostname_string = aws_string_c_str(m_hostname);
+                m_port_value = static_cast<uint16_t>(atoi(aws_string_c_str(m_port)));
                 break;
             }
             case MQTT5CONNECT_DIRECT_BASIC_AUTH:
@@ -116,13 +122,19 @@ struct Mqtt5TestEnvVars
                 m_error |= aws_get_environment_value(allocator, s_mqtt5_test_envName_basic_username, &m_username);
                 m_error |= aws_get_environment_value(allocator, s_mqtt5_test_envName_basic_password, &m_password);
 
-                if (m_error == AWS_OP_SUCCESS)
+                if (m_error != AWS_OP_SUCCESS)
                 {
-                    m_hostname_string = aws_string_c_str(m_hostname);
-                    m_port_value = static_cast<uint16_t>(atoi(aws_string_c_str(m_port)));
-                    m_username_string = aws_string_c_str(m_username);
-                    m_password_cursor = ByteCursorFromArray(m_password->bytes, m_password->len);
+                    return;
                 }
+                if(m_hostname == NULL || m_port == NULL || m_username == NULL || m_password == NULL)
+                {
+                    m_error = AWS_OP_ERR;
+                    return;
+                }
+                m_hostname_string = aws_string_c_str(m_hostname);
+                m_port_value = static_cast<uint16_t>(atoi(aws_string_c_str(m_port)));
+                m_username_string = aws_string_c_str(m_username);
+                m_password_cursor = ByteCursorFromArray(m_password->bytes, m_password->len);
                 break;
             }
             case MQTT5CONNECT_DIRECT_TLS:
@@ -132,13 +144,19 @@ struct Mqtt5TestEnvVars
                 m_error |= aws_get_environment_value(allocator, s_mqtt5_test_envName_certificate, &m_certificate_path);
                 m_error |= aws_get_environment_value(allocator, s_mqtt5_test_envName_private_key, &m_private_key_path);
 
-                if (m_error == AWS_OP_SUCCESS)
+                if (m_error != AWS_OP_SUCCESS)
                 {
-                    m_hostname_string = aws_string_c_str(m_hostname);
-                    m_port_value = static_cast<uint16_t>(atoi(aws_string_c_str(m_port)));
-                    m_certificate_path_string = aws_string_c_str(m_certificate_path);
-                    m_private_key_path_string = aws_string_c_str(m_private_key_path);
+                    return;
                 }
+                if(m_hostname == NULL || m_port == NULL || m_certificate_path == NULL || m_private_key_path == NULL)
+                {
+                    m_error = AWS_OP_ERR;
+                    return;
+                }
+                m_hostname_string = aws_string_c_str(m_hostname);
+                m_port_value = static_cast<uint16_t>(atoi(aws_string_c_str(m_port)));
+                m_certificate_path_string = aws_string_c_str(m_certificate_path);
+                m_private_key_path_string = aws_string_c_str(m_private_key_path);
                 break;
             }
             case MQTT5CONNECT_WS:
@@ -146,7 +164,15 @@ struct Mqtt5TestEnvVars
                 m_error |= aws_get_environment_value(allocator, s_mqtt5_test_envName_websocket_hostName, &m_hostname);
                 m_error |= aws_get_environment_value(allocator, s_mqtt5_test_envName_websocket_port, &m_port);
 
-                if (m_error == AWS_OP_SUCCESS)
+                if (m_error != AWS_OP_SUCCESS)
+                {
+                    return;
+                }
+                if(m_hostname == NULL || m_port == NULL)
+                {
+                    m_error = AWS_OP_ERR;
+                    return;
+                }
                 {
                     m_hostname_string = aws_string_c_str(m_hostname);
                     m_port_value = static_cast<uint16_t>(atoi(aws_string_c_str(m_port)));
@@ -162,7 +188,15 @@ struct Mqtt5TestEnvVars
                 m_error |= aws_get_environment_value(allocator, s_mqtt5_test_envName_basic_username, &m_username);
                 m_error |= aws_get_environment_value(allocator, s_mqtt5_test_envName_basic_password, &m_password);
 
-                if (m_error == AWS_OP_SUCCESS)
+                if (m_error != AWS_OP_SUCCESS)
+                {
+                    return;
+                }
+                if(m_hostname == NULL || m_port == NULL || m_username == NULL || m_password == NULL)
+                {
+                    m_error = AWS_OP_ERR;
+                    return;
+                }
                 {
                     m_hostname_string = aws_string_c_str(m_hostname);
                     m_port_value = static_cast<uint16_t>(atoi(aws_string_c_str(m_port)));
@@ -179,7 +213,15 @@ struct Mqtt5TestEnvVars
                 m_error |= aws_get_environment_value(allocator, s_mqtt5_test_envName_certificate, &m_certificate_path);
                 m_error |= aws_get_environment_value(allocator, s_mqtt5_test_envName_private_key, &m_private_key_path);
 
-                if (m_error == AWS_OP_SUCCESS)
+                if (m_error != AWS_OP_SUCCESS)
+                {
+                    return;
+                }
+                if(m_hostname == NULL || m_port == NULL || m_certificate_path == NULL || m_private_key_path == NULL)
+                {
+                    m_error = AWS_OP_ERR;
+                    return;
+                }
                 {
                     m_hostname_string = aws_string_c_str(m_hostname);
                     m_port_value = static_cast<uint16_t>(atoi(aws_string_c_str(m_port)));
@@ -195,7 +237,15 @@ struct Mqtt5TestEnvVars
                     aws_get_environment_value(allocator, s_mqtt5_test_envName_iot_certificate, &m_certificate_path);
                 m_error |= aws_get_environment_value(allocator, s_mqtt5_test_envName_iot_key, &m_private_key_path);
 
-                if (m_error == AWS_OP_SUCCESS)
+                if (m_error != AWS_OP_SUCCESS)
+                {
+                    return;
+                }
+                if(m_hostname == NULL || m_certificate_path == NULL || m_private_key_path == NULL)
+                {
+                    m_error = AWS_OP_ERR;
+                    return;
+                }
                 {
                     m_hostname_string = aws_string_c_str(m_hostname);
                     m_certificate_path_string = aws_string_c_str(m_certificate_path);
@@ -213,7 +263,7 @@ struct Mqtt5TestEnvVars
         m_error |= aws_get_environment_value(allocator, s_mqtt5_test_envName_proxy_hostname, &m_httpproxy_hostname);
         m_error |= aws_get_environment_value(allocator, s_mqtt5_test_envName_proxy_port, &m_httpproxy_port);
 
-        if (m_error == AWS_OP_SUCCESS)
+        if (m_error == AWS_OP_SUCCESS && m_httpproxy_hostname != NULL && m_httpproxy_port != NULL)
         {
             m_httpproxy_hostname_string = aws_string_c_str(m_httpproxy_hostname);
             m_httpproxy_port_value = static_cast<uint16_t>(atoi(aws_string_c_str(m_httpproxy_port)));
@@ -627,6 +677,11 @@ static int s_TestMqtt5DirectConnectionWithHttpProxy(Aws::Crt::Allocator *allocat
     mqtt5Options.withHostName(mqtt5TestVars.m_hostname_string).withPort(mqtt5TestVars.m_port_value);
 
     // HTTP PROXY
+    if(mqtt5TestVars.m_httpproxy_hostname->len == 0)
+    {
+        printf("HTTP PROXY Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
+    }
     Aws::Crt::Http::HttpClientConnectionProxyOptions proxyOptions;
     proxyOptions.HostName = mqtt5TestVars.m_httpproxy_hostname_string;
     proxyOptions.Port = mqtt5TestVars.m_httpproxy_port_value;
@@ -1017,6 +1072,11 @@ static int s_TestMqtt5WSConnectionWithHttpProxy(Aws::Crt::Allocator *allocator, 
     mqtt5Options.withPort(443);
 
     // HTTP PROXY
+    if(mqtt5TestVars.m_httpproxy_hostname->len == 0)
+    {
+        printf("HTTP PROXY Environment Variables are not set for the test, skip the test");
+        return AWS_ERROR_SUCCESS;
+    }
     Aws::Crt::Http::HttpClientConnectionProxyOptions proxyOptions;
     proxyOptions.HostName = mqtt5TestVars.m_httpproxy_hostname_string;
     proxyOptions.Port = mqtt5TestVars.m_httpproxy_port_value;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. As the latest c-common change added a way to skip a test. We enable the Mqtt5 Unit tests in the CI and skip it if the environment variable is not set
2. The Mqtt5 client and builder will now return nullptr on failure. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
