### PR TITLE
PKCS12 builder support

### DIFF
--- a/include/aws/iot/Mqtt5Client.h
+++ b/include/aws/iot/Mqtt5Client.h
@@ -176,17 +176,16 @@ namespace Aws
             /**
              * Sets the builder up for MTLS, using a PKCS#12 file for private key operations.
              *
-             * @param hostName - AWS IoT endpoint to connect to
-             * @param pkcs12_file - The PKCS12 file to use
-             * @param pkcs12_password - The password for the PKCS12 file
+             * NOTE: This only works on MacOS devices.
+             *
+             * @param options The PKCS12 options to use.
              * @param allocator - memory allocator to use
              *
              * @return Mqtt5ClientBuilder
              */
             static Mqtt5ClientBuilder *NewMqtt5ClientBuilderWithMtlsPkcs12(
                 const Crt::String hostName,
-                const char *pkcs12_file,
-                const char *pkcs12_password,
+                const struct Pkcs12Options &options,
                 Crt::Allocator *allocator = Crt::ApiAllocator()) noexcept;
 
             /**

--- a/include/aws/iot/Mqtt5Client.h
+++ b/include/aws/iot/Mqtt5Client.h
@@ -174,6 +174,22 @@ namespace Aws
                 Crt::Allocator *allocator = Crt::ApiAllocator()) noexcept;
 
             /**
+             * Sets the builder up for MTLS, using a PKCS#12 file for private key operations.
+             *
+             * @param hostName - AWS IoT endpoint to connect to
+             * @param pkcs12_file - The PKCS12 file to use
+             * @param pkcs12_password - The password for the PKCS12 file
+             * @param allocator - memory allocator to use
+             *
+             * @return Mqtt5ClientBuilder
+             */
+            static Mqtt5ClientBuilder *NewMqtt5ClientBuilderWithMtlsPkcs12(
+                const Crt::String hostName,
+                const char* pkcs12_file,
+                const char* pkcs12_password,
+                Crt::Allocator *allocator = Crt::ApiAllocator()) noexcept;
+
+            /**
              * Sets the builder up for MTLS, using a certificate in a Windows certificate store.
              *
              * NOTE: This only works on Windows.

--- a/include/aws/iot/Mqtt5Client.h
+++ b/include/aws/iot/Mqtt5Client.h
@@ -185,8 +185,8 @@ namespace Aws
              */
             static Mqtt5ClientBuilder *NewMqtt5ClientBuilderWithMtlsPkcs12(
                 const Crt::String hostName,
-                const char* pkcs12_file,
-                const char* pkcs12_password,
+                const char *pkcs12_file,
+                const char *pkcs12_password,
                 Crt::Allocator *allocator = Crt::ApiAllocator()) noexcept;
 
             /**

--- a/include/aws/iot/Mqtt5Client.h
+++ b/include/aws/iot/Mqtt5Client.h
@@ -178,6 +178,7 @@ namespace Aws
              *
              * NOTE: This only works on MacOS devices.
              *
+             * @param hostName - AWS IoT endpoint to connect to
              * @param options The PKCS12 options to use.
              * @param allocator - memory allocator to use
              *

--- a/include/aws/iot/MqttClient.h
+++ b/include/aws/iot/MqttClient.h
@@ -101,6 +101,16 @@ namespace Aws
         };
 
         /**
+         * A simple struct to hold the options for creating a PKCS12 builder. Used to differentiate the
+         * PKCS12 builder from the mTLS builder, which would use the exact sample input types without this struct.
+         */
+        struct pkcs12Options
+        {
+            const char *pkcs12_file;
+            const char *pkcs12_password;
+        };
+
+        /**
          * Represents configuration parameters for building a MqttClientConnectionConfig object. You can use a single
          * instance of this class PER MqttClientConnectionConfig you want to generate. If you want to generate a config
          * for a different endpoint or port etc... you need a new instance of this class.
@@ -146,6 +156,19 @@ namespace Aws
              */
             MqttClientConnectionConfigBuilder(
                 const Crt::Io::TlsContextPkcs11Options &pkcs11Options,
+                Crt::Allocator *allocator = Crt::ApiAllocator()) noexcept;
+
+            /**
+             * Sets the builder up for MTLS using a PKCS12 file and password. These are files on disk and must be in the
+             * PEM format.
+             *
+             * NOTE: This only works on MacOS devices.
+             *
+             * @param options The PKCS12 options to use. Has to contain a PKCS12 filepath and password.
+             * @param allocator memory allocator to use
+             */
+            MqttClientConnectionConfigBuilder(
+                const struct pkcs12Options &options,
                 Crt::Allocator *allocator = Crt::ApiAllocator()) noexcept;
 
             /**

--- a/include/aws/iot/MqttClient.h
+++ b/include/aws/iot/MqttClient.h
@@ -101,16 +101,6 @@ namespace Aws
         };
 
         /**
-         * A simple struct to hold the options for creating a PKCS12 builder. Used to differentiate the
-         * PKCS12 builder from the mTLS builder, which would use the exact sample input types without this struct.
-         */
-        struct pkcs12Options
-        {
-            const char *pkcs12_file;
-            const char *pkcs12_password;
-        };
-
-        /**
          * Represents configuration parameters for building a MqttClientConnectionConfig object. You can use a single
          * instance of this class PER MqttClientConnectionConfig you want to generate. If you want to generate a config
          * for a different endpoint or port etc... you need a new instance of this class.
@@ -168,7 +158,7 @@ namespace Aws
              * @param allocator memory allocator to use
              */
             MqttClientConnectionConfigBuilder(
-                const struct pkcs12Options &options,
+                const struct Pkcs12Options &options,
                 Crt::Allocator *allocator = Crt::ApiAllocator()) noexcept;
 
             /**

--- a/include/aws/iot/MqttCommon.h
+++ b/include/aws/iot/MqttCommon.h
@@ -97,6 +97,16 @@ namespace Aws
             Crt::String ServiceName;
         };
 
+        /**
+         * A simple struct to hold the options for creating a PKCS12 builder. Used to differentiate the
+         * PKCS12 builder from other options in the mTLS builders.
+         */
+        struct Pkcs12Options
+        {
+            Crt::String pkcs12_file;
+            Crt::String pkcs12_password;
+        };
+
     } // namespace Iot
 } // namespace Aws
 

--- a/source/iot/Mqtt5Client.cpp
+++ b/source/iot/Mqtt5Client.cpp
@@ -186,13 +186,12 @@ namespace Aws
 
         Mqtt5ClientBuilder *Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsPkcs12(
             const Crt::String hostName,
-            const char *pkcs12_file,
-            const char *pkcs12_password,
+            const struct Pkcs12Options &options,
             Crt::Allocator *allocator) noexcept
         {
             Mqtt5ClientBuilder *result = new Mqtt5ClientBuilder(allocator);
-            result->m_tlsConnectionOptions =
-                Crt::Io::TlsContextOptions::InitClientWithMtlsPkcs12(pkcs12_file, pkcs12_password, allocator);
+            result->m_tlsConnectionOptions = Crt::Io::TlsContextOptions::InitClientWithMtlsPkcs12(
+                options.pkcs12_file.c_str(), options.pkcs12_password.c_str(), allocator);
             if (!result->m_tlsConnectionOptions.value())
             {
                 int error_code = result->m_tlsConnectionOptions->LastError();

--- a/source/iot/Mqtt5Client.cpp
+++ b/source/iot/Mqtt5Client.cpp
@@ -184,6 +184,30 @@ namespace Aws
             return result;
         }
 
+        Mqtt5ClientBuilder *Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsPkcs12(
+            const Crt::String hostName,
+            const char* pkcs12_file,
+            const char* pkcs12_password,
+            Crt::Allocator *allocator) noexcept
+        {
+            Mqtt5ClientBuilder *result = new Mqtt5ClientBuilder(allocator);
+            result->m_tlsConnectionOptions =
+                Crt::Io::TlsContextOptions::InitClientWithMtlsPkcs12(pkcs12_file, pkcs12_password, allocator);
+            if (!result->m_tlsConnectionOptions.value())
+            {
+                int error_code = result->m_tlsConnectionOptions->LastError();
+                AWS_LOGF_ERROR(
+                    AWS_LS_MQTT5_GENERAL,
+                    "Mqtt5ClientBuilder: Failed to setup TLS connection options with error %d:%s",
+                    error_code,
+                    aws_error_debug_str(error_code));
+                delete result;
+                return nullptr;
+            }
+            result->WithHostName(hostName);
+            return result;
+        }
+
         Mqtt5ClientBuilder *Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithWindowsCertStorePath(
             const Crt::String hostName,
             const char *windowsCertStorePath,

--- a/source/iot/Mqtt5Client.cpp
+++ b/source/iot/Mqtt5Client.cpp
@@ -186,8 +186,8 @@ namespace Aws
 
         Mqtt5ClientBuilder *Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsPkcs12(
             const Crt::String hostName,
-            const char* pkcs12_file,
-            const char* pkcs12_password,
+            const char *pkcs12_file,
+            const char *pkcs12_password,
             Crt::Allocator *allocator) noexcept
         {
             Mqtt5ClientBuilder *result = new Mqtt5ClientBuilder(allocator);

--- a/source/iot/MqttClient.cpp
+++ b/source/iot/MqttClient.cpp
@@ -120,6 +120,19 @@ namespace Aws
         }
 
         MqttClientConnectionConfigBuilder::MqttClientConnectionConfigBuilder(
+            const struct pkcs12Options &options,
+            Crt::Allocator *allocator) noexcept
+            : MqttClientConnectionConfigBuilder(allocator)
+        {
+            m_contextOptions = Crt::Io::TlsContextOptions::InitClientWithMtlsPkcs12(options.pkcs12_file, options.pkcs12_password, allocator);
+            if (!m_contextOptions)
+            {
+                m_lastError = m_contextOptions.LastError();
+                return;
+            }
+        }
+
+        MqttClientConnectionConfigBuilder::MqttClientConnectionConfigBuilder(
             const char *windowsCertStorePath,
             Crt::Allocator *allocator) noexcept
             : MqttClientConnectionConfigBuilder(allocator)

--- a/source/iot/MqttClient.cpp
+++ b/source/iot/MqttClient.cpp
@@ -124,7 +124,8 @@ namespace Aws
             Crt::Allocator *allocator) noexcept
             : MqttClientConnectionConfigBuilder(allocator)
         {
-            m_contextOptions = Crt::Io::TlsContextOptions::InitClientWithMtlsPkcs12(options.pkcs12_file, options.pkcs12_password, allocator);
+            m_contextOptions = Crt::Io::TlsContextOptions::InitClientWithMtlsPkcs12(
+                options.pkcs12_file, options.pkcs12_password, allocator);
             if (!m_contextOptions)
             {
                 m_lastError = m_contextOptions.LastError();

--- a/source/iot/MqttClient.cpp
+++ b/source/iot/MqttClient.cpp
@@ -130,12 +130,12 @@ namespace Aws
         }
 
         MqttClientConnectionConfigBuilder::MqttClientConnectionConfigBuilder(
-            const struct pkcs12Options &options,
+            const struct Pkcs12Options &options,
             Crt::Allocator *allocator) noexcept
             : MqttClientConnectionConfigBuilder(allocator)
         {
             m_contextOptions = Crt::Io::TlsContextOptions::InitClientWithMtlsPkcs12(
-                options.pkcs12_file, options.pkcs12_password, allocator);
+                options.pkcs12_file.c_str(), options.pkcs12_password.c_str(), allocator);
             if (!m_contextOptions)
             {
                 m_lastError = m_contextOptions.LastError();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ if(NOT BYO_CRYPTO)
     add_test_case(Sigv4aSigningTestCredentials)
     add_net_test_case(IoTMqtt311ConnectWithNoSigningCustomAuth)
     add_net_test_case(IoTMqtt311ConnectWithSigningCustomAuth)
+    add_net_test_case(IoTMqtt311ConnectWithPKCS12)
 endif()
 
 add_test_case(Base64RoundTrip)

--- a/tests/MqttClientTest.cpp
+++ b/tests/MqttClientTest.cpp
@@ -56,9 +56,7 @@ AWS_STATIC_STRING_FROM_LITERAL(
     "AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY_PASSWORD");
 
 // Needed to return "success" instead of skip in Codebuild so it doesn't count as a failure
-AWS_STATIC_STRING_FROM_LITERAL(
-    s_mqtt311_test_envName_codebuild,
-    "CODEBUILD_BUILD_ID");
+AWS_STATIC_STRING_FROM_LITERAL(s_mqtt311_test_envName_codebuild, "CODEBUILD_BUILD_ID");
 
 #if !BYO_CRYPTO
 static int s_TestMqttClientResourceSafety(Aws::Crt::Allocator *allocator, void *ctx)
@@ -389,7 +387,8 @@ static int s_TestIoTMqtt311ConnectWithPKCS12(Aws::Crt::Allocator *allocator, voi
         aws_string_destroy(pkcs12_password);
 
         // If in Codebuild, return as a 'success' even though it is a skip
-        if (codebuild_buildID && aws_string_is_valid(codebuild_buildID)) {
+        if (codebuild_buildID && aws_string_is_valid(codebuild_buildID))
+        {
             aws_string_destroy(codebuild_buildID);
             return AWS_OP_SUCCESS;
         }

--- a/tests/MqttClientTest.cpp
+++ b/tests/MqttClientTest.cpp
@@ -385,12 +385,12 @@ static int s_TestIoTMqtt311ConnectWithPKCS12(Aws::Crt::Allocator *allocator, voi
 
     Aws::Crt::ApiHandle apiHandle(allocator);
 
-    Aws::IoT::Pkcs12Options pkcs12Options = {.pkcs12_file = aws_string_c_str(pkcs12_key),
-                                             .pkcs12_password = aws_string_c_str(pkcs12_password)}
+    Aws::Iot::Pkcs12Options testPkcs12Options =
+        {.pkcs12_file = aws_string_c_str(pkcs12_key), .pkcs12_password = aws_string_c_str(pkcs12_password)}
 
     Aws::Iot::MqttClient client;
     auto clientConfigBuilder =
-        Aws::Iot::MqttClientConnectionConfigBuilder::MqttClientConnectionConfigBuilder(pkcs12Options, allocator);
+        Aws::Iot::MqttClientConnectionConfigBuilder::MqttClientConnectionConfigBuilder(testPkcs12Options, allocator);
     clientConfigBuilder.WithEndpoint(aws_string_c_str(endpoint));
     auto clientConfig = clientConfigBuilder.Build();
     if (!clientConfig)
@@ -444,7 +444,6 @@ static int s_TestIoTMqtt311ConnectWithPKCS12(Aws::Crt::Allocator *allocator, voi
     aws_string_destroy(endpoint);
     aws_string_destroy(pkcs12_key);
     aws_string_destroy(pkcs12_password);
-    aws_string_destroy(empty_string);
     return AWS_OP_SUCCESS;
 }
 AWS_TEST_CASE(IoTMqtt311ConnectWithPKCS12, s_TestIoTMqtt311ConnectWithPKCS12)

--- a/tests/MqttClientTest.cpp
+++ b/tests/MqttClientTest.cpp
@@ -386,11 +386,11 @@ static int s_TestIoTMqtt311ConnectWithPKCS12(Aws::Crt::Allocator *allocator, voi
     Aws::Crt::ApiHandle apiHandle(allocator);
 
     Aws::Iot::Pkcs12Options testPkcs12Options =
-        {.pkcs12_file = aws_string_c_str(pkcs12_key), .pkcs12_password = aws_string_c_str(pkcs12_password)}
+        {.pkcs12_file = aws_string_c_str(pkcs12_key), .pkcs12_password = aws_string_c_str(pkcs12_password)};
 
     Aws::Iot::MqttClient client;
     auto clientConfigBuilder =
-        Aws::Iot::MqttClientConnectionConfigBuilder::MqttClientConnectionConfigBuilder(testPkcs12Options, allocator);
+        Aws::Iot::MqttClientConnectionConfigBuilder(testPkcs12Options, allocator);
     clientConfigBuilder.WithEndpoint(aws_string_c_str(endpoint));
     auto clientConfig = clientConfigBuilder.Build();
     if (!clientConfig)

--- a/tests/MqttClientTest.cpp
+++ b/tests/MqttClientTest.cpp
@@ -50,6 +50,11 @@ AWS_STATIC_STRING_FROM_LITERAL(
     s_mqtt5_test_envName_iot_sign_custom_auth_tokensignature,
     "AWS_TEST_MQTT5_IOT_CORE_SIGNING_AUTHORIZER_TOKEN_SIGNATURE");
 
+AWS_STATIC_STRING_FROM_LITERAL(s_mqtt311_test_envName_iot_pkcs12_key, "AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY");
+AWS_STATIC_STRING_FROM_LITERAL(
+    s_mqtt311_test_envName_iot_pkcs12_key_password,
+    "AWS_TEST_MQTT311_IOT_CORE_PKCS12_KEY_PASSWORD");
+
 #if !BYO_CRYPTO
 static int s_TestMqttClientResourceSafety(Aws::Crt::Allocator *allocator, void *ctx)
 {
@@ -349,3 +354,97 @@ static int s_TestIoTMqtt311ConnectWithSigningCustomAuth(Aws::Crt::Allocator *all
     return AWS_OP_SUCCESS;
 }
 AWS_TEST_CASE(IoTMqtt311ConnectWithSigningCustomAuth, s_TestIoTMqtt311ConnectWithSigningCustomAuth)
+
+/*
+ * PKCS12 connect for MQTT311
+ */
+static int s_TestIoTMqtt311ConnectWithPKCS12(Aws::Crt::Allocator *allocator, void *)
+{
+    struct aws_string *endpoint = NULL;
+    struct aws_string *pkcs12_key = NULL;
+    struct aws_string *pkcs12_password = NULL;
+
+    int error = aws_get_environment_value(allocator, s_mqtt5_test_envName_iot_hostname, &endpoint);
+    error |= aws_get_environment_value(allocator, s_mqtt311_test_envName_iot_pkcs12_key, &pkcs12_key);
+    error |= aws_get_environment_value(allocator, s_mqtt311_test_envName_iot_pkcs12_key_password, &pkcs12_password);
+
+    bool isEveryEnvVarSet = (endpoint && pkcs12_key && pkcs12_password);
+    if (isEveryEnvVarSet == true)
+    {
+        isEveryEnvVarSet =
+            (aws_string_is_valid(endpoint) && aws_string_is_valid(pkcs12_key) && aws_string_is_valid(pkcs12_password));
+    }
+    if (error != AWS_OP_SUCCESS || isEveryEnvVarSet == false)
+    {
+        printf("Environment Variables are not set for the test, skip the test");
+        aws_string_destroy(endpoint);
+        aws_string_destroy(pkcs12_key);
+        aws_string_destroy(pkcs12_password);
+        return AWS_OP_SKIP;
+    }
+
+    Aws::Crt::ApiHandle apiHandle(allocator);
+
+    Aws::IoT::Pkcs12Options pkcs12Options = {.pkcs12_file = aws_string_c_str(pkcs12_key),
+                                             .pkcs12_password = aws_string_c_str(pkcs12_password)}
+
+    Aws::Iot::MqttClient client;
+    auto clientConfigBuilder =
+        Aws::Iot::MqttClientConnectionConfigBuilder::MqttClientConnectionConfigBuilder(pkcs12Options, allocator);
+    clientConfigBuilder.WithEndpoint(aws_string_c_str(endpoint));
+    auto clientConfig = clientConfigBuilder.Build();
+    if (!clientConfig)
+    {
+        printf("Failed to create MQTT311 client from config");
+        ASSERT_TRUE(false);
+    }
+    auto connection = client.NewConnection(clientConfig);
+    if (!*connection)
+    {
+        printf("Failed to create MQTT311 connection from config");
+        ASSERT_TRUE(false);
+    }
+
+    std::promise<bool> connectionCompletedPromise;
+    std::promise<void> connectionClosedPromise;
+    auto onConnectionCompleted =
+        [&](Aws::Crt::Mqtt::MqttConnection &, int errorCode, Aws::Crt::Mqtt::ReturnCode returnCode, bool) {
+            (void)returnCode;
+            if (errorCode)
+            {
+                connectionCompletedPromise.set_value(false);
+            }
+            else
+            {
+                connectionCompletedPromise.set_value(true);
+            }
+        };
+    auto onDisconnect = [&](Aws::Crt::Mqtt::MqttConnection &) { connectionClosedPromise.set_value(); };
+    connection->OnConnectionCompleted = std::move(onConnectionCompleted);
+    connection->OnDisconnect = std::move(onDisconnect);
+
+    Aws::Crt::UUID Uuid;
+    Aws::Crt::String uuidStr = Uuid.ToString();
+
+    if (!connection->Connect(uuidStr.c_str(), true /*cleanSession*/, 5000 /*keepAliveTimeSecs*/))
+    {
+        printf("Failed to connect");
+        ASSERT_TRUE(false);
+    }
+    if (connectionCompletedPromise.get_future().get() == false)
+    {
+        printf("Connection failed");
+        ASSERT_TRUE(false);
+    }
+    if (connection->Disconnect())
+    {
+        connectionClosedPromise.get_future().wait();
+    }
+
+    aws_string_destroy(endpoint);
+    aws_string_destroy(pkcs12_key);
+    aws_string_destroy(pkcs12_password);
+    aws_string_destroy(empty_string);
+    return AWS_OP_SUCCESS;
+}
+AWS_TEST_CASE(IoTMqtt311ConnectWithPKCS12, s_TestIoTMqtt311ConnectWithPKCS12)

--- a/tests/MqttClientTest.cpp
+++ b/tests/MqttClientTest.cpp
@@ -385,12 +385,12 @@ static int s_TestIoTMqtt311ConnectWithPKCS12(Aws::Crt::Allocator *allocator, voi
 
     Aws::Crt::ApiHandle apiHandle(allocator);
 
-    Aws::Iot::Pkcs12Options testPkcs12Options =
-        {.pkcs12_file = aws_string_c_str(pkcs12_key), .pkcs12_password = aws_string_c_str(pkcs12_password)};
+    Aws::Iot::Pkcs12Options testPkcs12Options;
+    testPkcs12Options.pkcs12_file = aws_string_c_str(pkcs12_key);
+    testPkcs12Options.pkcs12_password = aws_string_c_str(pkcs12_password);
 
     Aws::Iot::MqttClient client;
-    auto clientConfigBuilder =
-        Aws::Iot::MqttClientConnectionConfigBuilder(testPkcs12Options, allocator);
+    auto clientConfigBuilder = Aws::Iot::MqttClientConnectionConfigBuilder(testPkcs12Options, allocator);
     clientConfigBuilder.WithEndpoint(aws_string_c_str(endpoint));
     auto clientConfig = clientConfigBuilder.Build();
     if (!clientConfig)


### PR DESCRIPTION
*Description of changes:*

Adds PKCS12 support to the MQTT311 and MQTT5 builders.

___________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
