### PR TITLE
Full backwards compat with custom auth in MQTT311

### DIFF
--- a/include/aws/iot/MqttClient.h
+++ b/include/aws/iot/MqttClient.h
@@ -331,8 +331,8 @@ namespace Aws
              * @param authorizerName The name of the custom authorizer. If an empty string is passed, then
              *                       'x-amz-customauthorizer-name' will not be added with the MQTT connection.
              * @param authorizerSignature The signature of the custom authorizer.
-             *                            NOTE: This will NOT work without the token key name and token value, which requires
-     *                                    using the non-depreciated API. This will always fail if set.
+             *                            NOTE: This will NOT work without the token key name and token value, which
+             * requires using the non-depreciated API. This will always fail if set.
              * @param password The password to use with the custom authorizer. If null is passed, then no password will
              *                 be set.
              *

--- a/include/aws/iot/MqttClient.h
+++ b/include/aws/iot/MqttClient.h
@@ -330,11 +330,9 @@ namespace Aws
              *                 username is set then no username will be passed with the MQTT connection.
              * @param authorizerName The name of the custom authorizer. If an empty string is passed, then
              *                       'x-amz-customauthorizer-name' will not be added with the MQTT connection.
-             * @param authorizerSignature The signature of the custom authorizer. If an empty string is passed, then
-             *                            'x-amz-customauthorizer-signature' will not be added with the MQTT connection.
-             *                            The signature must be based on the private key associated with the custom
-             *                            authorizer. The signature must be base64 encoded. It is strongly suggested
-             *                            to URL-encode this value; the SDK will not do so for you.
+             * @param authorizerSignature The signature of the custom authorizer.
+             *                            NOTE: This will NOT work without the token key name and token value, which requires
+     *                                    using the non-depreciated API. This will always fail if set.
              * @param password The password to use with the custom authorizer. If null is passed, then no password will
              *                 be set.
              *

--- a/include/aws/iot/MqttClient.h
+++ b/include/aws/iot/MqttClient.h
@@ -332,7 +332,7 @@ namespace Aws
              *                       'x-amz-customauthorizer-name' will not be added with the MQTT connection.
              * @param authorizerSignature The signature of the custom authorizer.
              *                            NOTE: This will NOT work without the token key name and token value, which
-             * requires using the non-depreciated API. This will always fail if set.
+             * requires using the non-depreciated API.
              * @param password The password to use with the custom authorizer. If null is passed, then no password will
              *                 be set.
              *

--- a/source/iot/MqttClient.cpp
+++ b/source/iot/MqttClient.cpp
@@ -355,14 +355,9 @@ namespace Aws
             {
                 usernameString = AddToUsernameParameter(usernameString, authorizerName, "x-amz-customauthorizer-name=");
             }
-            if (!authorizerSignature.empty())
+            if (!authorizerSignature.empty() || !tokenKeyName.empty() || !tokenValue.empty())
             {
-                usernameString =
-                    AddToUsernameParameter(usernameString, authorizerSignature, "x-amz-customauthorizer-signature=");
-            }
-            if (!tokenKeyName.empty() || !tokenValue.empty())
-            {
-                if (tokenKeyName.empty() || tokenValue.empty())
+                if (authorizerSignature.empty() || tokenKeyName.empty() || tokenValue.empty())
                 {
                     AWS_LOGF_ERROR(
                         AWS_LS_MQTT_CLIENT,
@@ -371,6 +366,8 @@ namespace Aws
                     m_lastError = AWS_ERROR_INVALID_ARGUMENT;
                     return *this;
                 }
+                usernameString =
+                    AddToUsernameParameter(usernameString, authorizerSignature, "x-amz-customauthorizer-signature=");
                 usernameString = AddToUsernameParameter(usernameString, tokenValue, tokenKeyName + "=");
             }
 

--- a/source/iot/MqttClient.cpp
+++ b/source/iot/MqttClient.cpp
@@ -355,9 +355,14 @@ namespace Aws
             {
                 usernameString = AddToUsernameParameter(usernameString, authorizerName, "x-amz-customauthorizer-name=");
             }
-            if (!authorizerSignature.empty() || !tokenKeyName.empty() || !tokenValue.empty())
+            if (!authorizerSignature.empty())
             {
-                if (authorizerSignature.empty() || tokenKeyName.empty() || tokenValue.empty())
+                usernameString =
+                    AddToUsernameParameter(usernameString, authorizerSignature, "x-amz-customauthorizer-signature=");
+            }
+            if (!tokenKeyName.empty() || !tokenValue.empty())
+            {
+                if (tokenKeyName.empty() || tokenValue.empty())
                 {
                     AWS_LOGF_ERROR(
                         AWS_LS_MQTT_CLIENT,
@@ -366,8 +371,6 @@ namespace Aws
                     m_lastError = AWS_ERROR_INVALID_ARGUMENT;
                     return *this;
                 }
-                usernameString =
-                    AddToUsernameParameter(usernameString, authorizerSignature, "x-amz-customauthorizer-signature=");
                 usernameString = AddToUsernameParameter(usernameString, tokenValue, tokenKeyName + "=");
             }
 

--- a/source/iot/MqttClient.cpp
+++ b/source/iot/MqttClient.cpp
@@ -363,7 +363,7 @@ namespace Aws
                         AWS_LS_MQTT_CLIENT,
                         "id=%p: Signed custom authorizers with signature will not work without a token key name and "
                         "token value. Your connection may be rejected/stalled on the IoT Core side due to this. Please "
-                        "use the non-deprecate API and pass both the token key name and token value to connect to a "
+                        "use the non-deprecated API and pass both the token key name and token value to connect to a "
                         "signed custom authorizer.",
                         (void *)this);
                 }

--- a/source/iot/MqttClient.cpp
+++ b/source/iot/MqttClient.cpp
@@ -355,9 +355,24 @@ namespace Aws
             {
                 usernameString = AddToUsernameParameter(usernameString, authorizerName, "x-amz-customauthorizer-name=");
             }
-            if (!authorizerSignature.empty() || !tokenKeyName.empty() || !tokenValue.empty())
+            if (!authorizerSignature.empty())
             {
-                if (authorizerSignature.empty() || tokenKeyName.empty() || tokenValue.empty())
+                if (tokenKeyName.empty() || tokenValue.empty())
+                {
+                    AWS_LOGF_WARN(
+                        AWS_LS_MQTT_CLIENT,
+                        "id=%p: Signed custom authorizers with signature will not work without a token key name and "
+                        "token value. Your connection may be rejected/stalled on the IoT Core side due to this. Please "
+                        "use the non-deprecate API and pass both the token key name and token value to connect to a "
+                        "signed custom authorizer.",
+                        (void *)this);
+                }
+                usernameString =
+                    AddToUsernameParameter(usernameString, authorizerSignature, "x-amz-customauthorizer-signature=");
+            }
+            if (!tokenKeyName.empty() || !tokenValue.empty())
+            {
+                if (tokenKeyName.empty() || tokenValue.empty())
                 {
                     AWS_LOGF_ERROR(
                         AWS_LS_MQTT_CLIENT,
@@ -366,8 +381,6 @@ namespace Aws
                     m_lastError = AWS_ERROR_INVALID_ARGUMENT;
                     return *this;
                 }
-                usernameString =
-                    AddToUsernameParameter(usernameString, authorizerSignature, "x-amz-customauthorizer-signature=");
                 usernameString = AddToUsernameParameter(usernameString, tokenValue, tokenKeyName + "=");
             }
 

--- a/tests/MqttClientTest.cpp
+++ b/tests/MqttClientTest.cpp
@@ -7,9 +7,9 @@
 #include <aws/common/common.h>
 #include <aws/common/environment.h>
 #include <aws/common/string.h>
+#include <aws/crt/UUID.h>
 #include <aws/iot/MqttClient.h>
 #include <aws/iot/MqttCommon.h>
-#include <aws/crt/UUID.h>
 
 #include <utility>
 
@@ -212,7 +212,7 @@ static int s_TestIoTMqtt311ConnectWithNoSigningCustomAuth(Aws::Crt::Allocator *a
     Aws::Crt::UUID Uuid;
     Aws::Crt::String uuidStr = Uuid.ToString();
 
-    if (!connection->Connect(aws_string_c_str(uuidStr), true /*cleanSession*/, 5000 /*keepAliveTimeSecs*/))
+    if (!connection->Connect(aws_string_c_str(&uuidStr), true /*cleanSession*/, 5000 /*keepAliveTimeSecs*/))
     {
         printf("Failed to connect");
         ASSERT_TRUE(false);
@@ -324,7 +324,7 @@ static int s_TestIoTMqtt311ConnectWithSigningCustomAuth(Aws::Crt::Allocator *all
     Aws::Crt::UUID Uuid;
     Aws::Crt::String uuidStr = Uuid.ToString();
 
-    if (!connection->Connect(aws_string_c_str(uuidStr), true /*cleanSession*/, 5000 /*keepAliveTimeSecs*/))
+    if (!connection->Connect(aws_string_c_str(&uuidStr), true /*cleanSession*/, 5000 /*keepAliveTimeSecs*/))
     {
         printf("Failed to connect");
         ASSERT_TRUE(false);

--- a/tests/MqttClientTest.cpp
+++ b/tests/MqttClientTest.cpp
@@ -212,7 +212,7 @@ static int s_TestIoTMqtt311ConnectWithNoSigningCustomAuth(Aws::Crt::Allocator *a
     Aws::Crt::UUID Uuid;
     Aws::Crt::String uuidStr = Uuid.ToString();
 
-    if (!connection->Connect(aws_string_c_str(&uuidStr), true /*cleanSession*/, 5000 /*keepAliveTimeSecs*/))
+    if (!connection->Connect(uuidStr.c_str(), true /*cleanSession*/, 5000 /*keepAliveTimeSecs*/))
     {
         printf("Failed to connect");
         ASSERT_TRUE(false);
@@ -324,7 +324,7 @@ static int s_TestIoTMqtt311ConnectWithSigningCustomAuth(Aws::Crt::Allocator *all
     Aws::Crt::UUID Uuid;
     Aws::Crt::String uuidStr = Uuid.ToString();
 
-    if (!connection->Connect(aws_string_c_str(&uuidStr), true /*cleanSession*/, 5000 /*keepAliveTimeSecs*/))
+    if (!connection->Connect(uuidStr.c_str(), true /*cleanSession*/, 5000 /*keepAliveTimeSecs*/))
     {
         printf("Failed to connect");
         ASSERT_TRUE(false);

--- a/tests/MqttClientTest.cpp
+++ b/tests/MqttClientTest.cpp
@@ -149,7 +149,12 @@ static int s_TestIoTMqtt311ConnectWithNoSigningCustomAuth(Aws::Crt::Allocator *a
     error |= aws_get_environment_value(allocator, s_mqtt5_test_envName_iot_nosign_custom_auth_username, &username);
     error |= aws_get_environment_value(allocator, s_mqtt5_test_envName_iot_nosign_custom_auth_password, &password);
 
-    if (error != AWS_OP_SUCCESS || endpoint == NULL || authname == NULL || username == NULL || password == NULL)
+    bool isEveryEnvVarSet = (endpoint && authname && username && password);
+    if (isEveryEnvVarSet == true)
+    {
+        isEveryEnvVarSet = (!endpoint->empty() && !authname->empty() && !username->empty() && !password->empty());
+    }
+    if (error != AWS_OP_SUCCESS || isEveryEnvVarSet == false)
     {
         printf("Environment Variables are not set for the test, skip the test");
         return AWS_OP_SKIP;
@@ -241,7 +246,14 @@ static int s_TestIoTMqtt311ConnectWithSigningCustomAuth(Aws::Crt::Allocator *all
     error |= aws_get_environment_value(allocator, s_mqtt5_test_envName_iot_sign_custom_auth_tokenkey, &tokenKeyName);
     error |= aws_get_environment_value(allocator, s_mqtt5_test_envName_iot_sign_custom_auth_tokenvalue, &tokenValue);
 
-    if (error != AWS_OP_SUCCESS)
+    bool isEveryEnvVarSet = (endpoint && authname && username && password && signature && tokenKeyName && tokenValue);
+    if (isEveryEnvVarSet == true)
+    {
+        isEveryEnvVarSet =
+            (!endpoint->empty() && !authname->empty() && !username->empty() && !password->empty() &&
+             !signature->empty() && !tokenKeyName->empty() && !tokenValue->empty());
+    }
+    if (error != AWS_OP_SUCCESS || isEveryEnvVarSet == false)
     {
         printf("Environment Variables are not set for the test, skip the test");
         return AWS_OP_SKIP;

--- a/tests/MqttClientTest.cpp
+++ b/tests/MqttClientTest.cpp
@@ -138,7 +138,6 @@ AWS_TEST_CASE(MqttClientNewConnectionUninitializedTlsContext, s_TestMqttClientNe
  */
 static int s_TestIoTMqtt311ConnectWithNoSigningCustomAuth(Aws::Crt::Allocator *allocator, void *)
 {
-    int returnResult = AWS_OP_SUCCESS;
     struct aws_string *endpoint = NULL;
     struct aws_string *authname = NULL;
     struct aws_string *username = NULL;
@@ -160,8 +159,12 @@ static int s_TestIoTMqtt311ConnectWithNoSigningCustomAuth(Aws::Crt::Allocator *a
     if (error != AWS_OP_SUCCESS || isEveryEnvVarSet == false)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        returnResult = AWS_OP_SKIP;
-        goto cleanup;
+        aws_string_destroy(endpoint);
+        aws_string_destroy(authname);
+        aws_string_destroy(username);
+        aws_string_destroy(password);
+        aws_string_destroy(empty_string);
+        return AWS_OP_SKIP;
     }
 
     Aws::Crt::ApiHandle apiHandle(allocator);
@@ -219,15 +222,13 @@ static int s_TestIoTMqtt311ConnectWithNoSigningCustomAuth(Aws::Crt::Allocator *a
     {
         connectionClosedPromise.get_future().wait();
     }
-    goto cleanup;
 
-cleanup:
     aws_string_destroy(endpoint);
     aws_string_destroy(authname);
     aws_string_destroy(username);
     aws_string_destroy(password);
     aws_string_destroy(empty_string);
-    return returnResult;
+    return AWS_OP_SUCCESS;
 }
 AWS_TEST_CASE(IoTMqtt311ConnectWithNoSigningCustomAuth, s_TestIoTMqtt311ConnectWithNoSigningCustomAuth)
 
@@ -236,7 +237,6 @@ AWS_TEST_CASE(IoTMqtt311ConnectWithNoSigningCustomAuth, s_TestIoTMqtt311ConnectW
  */
 static int s_TestIoTMqtt311ConnectWithSigningCustomAuth(Aws::Crt::Allocator *allocator, void *)
 {
-    int returnResult = AWS_OP_SUCCESS;
     struct aws_string *endpoint = NULL;
     struct aws_string *authname = NULL;
     struct aws_string *username = NULL;
@@ -264,8 +264,14 @@ static int s_TestIoTMqtt311ConnectWithSigningCustomAuth(Aws::Crt::Allocator *all
     if (error != AWS_OP_SUCCESS || isEveryEnvVarSet == false)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        returnResult = AWS_OP_SKIP;
-        goto cleanup;
+        aws_string_destroy(endpoint);
+        aws_string_destroy(authname);
+        aws_string_destroy(username);
+        aws_string_destroy(password);
+        aws_string_destroy(signature);
+        aws_string_destroy(tokenKeyName);
+        aws_string_destroy(tokenValue);
+        return AWS_OP_SKIP;
     }
 
     Aws::Crt::ApiHandle apiHandle(allocator);
@@ -325,9 +331,7 @@ static int s_TestIoTMqtt311ConnectWithSigningCustomAuth(Aws::Crt::Allocator *all
     {
         connectionClosedPromise.get_future().wait();
     }
-    goto cleanup;
 
-cleanup:
     aws_string_destroy(endpoint);
     aws_string_destroy(authname);
     aws_string_destroy(username);
@@ -335,6 +339,6 @@ cleanup:
     aws_string_destroy(signature);
     aws_string_destroy(tokenKeyName);
     aws_string_destroy(tokenValue);
-    return returnResult;
+    return AWS_OP_SUCCESS;
 }
 AWS_TEST_CASE(IoTMqtt311ConnectWithSigningCustomAuth, s_TestIoTMqtt311ConnectWithSigningCustomAuth)

--- a/tests/MqttClientTest.cpp
+++ b/tests/MqttClientTest.cpp
@@ -9,6 +9,7 @@
 #include <aws/common/string.h>
 #include <aws/iot/MqttClient.h>
 #include <aws/iot/MqttCommon.h>
+#include <aws/crt/UUID.h>
 
 #include <utility>
 
@@ -208,7 +209,10 @@ static int s_TestIoTMqtt311ConnectWithNoSigningCustomAuth(Aws::Crt::Allocator *a
     connection->OnConnectionCompleted = std::move(onConnectionCompleted);
     connection->OnDisconnect = std::move(onDisconnect);
 
-    if (!connection->Connect(aws_string_c_str(endpoint), true /*cleanSession*/, 5000 /*keepAliveTimeSecs*/))
+    Aws::Crt::UUID Uuid;
+    Aws::Crt::String uuidStr = Uuid.ToString();
+
+    if (!connection->Connect(aws_string_c_str(uuidStr), true /*cleanSession*/, 5000 /*keepAliveTimeSecs*/))
     {
         printf("Failed to connect");
         ASSERT_TRUE(false);
@@ -317,7 +321,10 @@ static int s_TestIoTMqtt311ConnectWithSigningCustomAuth(Aws::Crt::Allocator *all
     connection->OnConnectionCompleted = std::move(onConnectionCompleted);
     connection->OnDisconnect = std::move(onDisconnect);
 
-    if (!connection->Connect(aws_string_c_str(endpoint), true /*cleanSession*/, 5000 /*keepAliveTimeSecs*/))
+    Aws::Crt::UUID Uuid;
+    Aws::Crt::String uuidStr = Uuid.ToString();
+
+    if (!connection->Connect(aws_string_c_str(uuidStr), true /*cleanSession*/, 5000 /*keepAliveTimeSecs*/))
     {
         printf("Failed to connect");
         ASSERT_TRUE(false);

--- a/tests/MqttClientTest.cpp
+++ b/tests/MqttClientTest.cpp
@@ -138,6 +138,7 @@ AWS_TEST_CASE(MqttClientNewConnectionUninitializedTlsContext, s_TestMqttClientNe
  */
 static int s_TestIoTMqtt311ConnectWithNoSigningCustomAuth(Aws::Crt::Allocator *allocator, void *)
 {
+    int returnResult = AWS_OP_SUCCESS;
     struct aws_string *endpoint = NULL;
     struct aws_string *authname = NULL;
     struct aws_string *username = NULL;
@@ -152,12 +153,15 @@ static int s_TestIoTMqtt311ConnectWithNoSigningCustomAuth(Aws::Crt::Allocator *a
     bool isEveryEnvVarSet = (endpoint && authname && username && password);
     if (isEveryEnvVarSet == true)
     {
-        isEveryEnvVarSet = (!endpoint->empty() && !authname->empty() && !username->empty() && !password->empty());
+        isEveryEnvVarSet =
+            (aws_string_is_valid(endpoint) && aws_string_is_valid(authname) && aws_string_is_valid(username) &&
+             aws_string_is_valid(password));
     }
     if (error != AWS_OP_SUCCESS || isEveryEnvVarSet == false)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_OP_SKIP;
+        returnResult = AWS_OP_SKIP;
+        goto cleanup;
     }
 
     Aws::Crt::ApiHandle apiHandle(allocator);
@@ -215,13 +219,15 @@ static int s_TestIoTMqtt311ConnectWithNoSigningCustomAuth(Aws::Crt::Allocator *a
     {
         connectionClosedPromise.get_future().wait();
     }
+    goto cleanup;
 
+cleanup:
     aws_string_destroy(endpoint);
     aws_string_destroy(authname);
     aws_string_destroy(username);
     aws_string_destroy(password);
     aws_string_destroy(empty_string);
-    return AWS_OP_SUCCESS;
+    return returnResult;
 }
 AWS_TEST_CASE(IoTMqtt311ConnectWithNoSigningCustomAuth, s_TestIoTMqtt311ConnectWithNoSigningCustomAuth)
 
@@ -230,6 +236,7 @@ AWS_TEST_CASE(IoTMqtt311ConnectWithNoSigningCustomAuth, s_TestIoTMqtt311ConnectW
  */
 static int s_TestIoTMqtt311ConnectWithSigningCustomAuth(Aws::Crt::Allocator *allocator, void *)
 {
+    int returnResult = AWS_OP_SUCCESS;
     struct aws_string *endpoint = NULL;
     struct aws_string *authname = NULL;
     struct aws_string *username = NULL;
@@ -250,13 +257,15 @@ static int s_TestIoTMqtt311ConnectWithSigningCustomAuth(Aws::Crt::Allocator *all
     if (isEveryEnvVarSet == true)
     {
         isEveryEnvVarSet =
-            (!endpoint->empty() && !authname->empty() && !username->empty() && !password->empty() &&
-             !signature->empty() && !tokenKeyName->empty() && !tokenValue->empty());
+            (aws_string_is_valid(endpoint) && aws_string_is_valid(authname) && aws_string_is_valid(username) &&
+             aws_string_is_valid(password) && aws_string_is_valid(signature) && aws_string_is_valid(tokenKeyName) &&
+             aws_string_is_valid(tokenValue));
     }
     if (error != AWS_OP_SUCCESS || isEveryEnvVarSet == false)
     {
         printf("Environment Variables are not set for the test, skip the test");
-        return AWS_OP_SKIP;
+        returnResult = AWS_OP_SKIP;
+        goto cleanup;
     }
 
     Aws::Crt::ApiHandle apiHandle(allocator);
@@ -316,7 +325,9 @@ static int s_TestIoTMqtt311ConnectWithSigningCustomAuth(Aws::Crt::Allocator *all
     {
         connectionClosedPromise.get_future().wait();
     }
+    goto cleanup;
 
+cleanup:
     aws_string_destroy(endpoint);
     aws_string_destroy(authname);
     aws_string_destroy(username);
@@ -324,6 +335,6 @@ static int s_TestIoTMqtt311ConnectWithSigningCustomAuth(Aws::Crt::Allocator *all
     aws_string_destroy(signature);
     aws_string_destroy(tokenKeyName);
     aws_string_destroy(tokenValue);
-    return AWS_OP_SUCCESS;
+    return returnResult;
 }
 AWS_TEST_CASE(IoTMqtt311ConnectWithSigningCustomAuth, s_TestIoTMqtt311ConnectWithSigningCustomAuth)

--- a/tests/MqttClientTest.cpp
+++ b/tests/MqttClientTest.cpp
@@ -208,7 +208,7 @@ static int s_TestIoTMqtt311ConnectWithNoSigningCustomAuth(Aws::Crt::Allocator *a
     connection->OnConnectionCompleted = std::move(onConnectionCompleted);
     connection->OnDisconnect = std::move(onDisconnect);
 
-    if (!connection->Connect(aws_string_c_str(endpoint), false /*cleanSession*/, 1000 /*keepAliveTimeSecs*/))
+    if (!connection->Connect(aws_string_c_str(endpoint), true /*cleanSession*/, 5000 /*keepAliveTimeSecs*/))
     {
         printf("Failed to connect");
         ASSERT_TRUE(false);
@@ -317,7 +317,7 @@ static int s_TestIoTMqtt311ConnectWithSigningCustomAuth(Aws::Crt::Allocator *all
     connection->OnConnectionCompleted = std::move(onConnectionCompleted);
     connection->OnDisconnect = std::move(onDisconnect);
 
-    if (!connection->Connect(aws_string_c_str(endpoint), false /*cleanSession*/, 1000 /*keepAliveTimeSecs*/))
+    if (!connection->Connect(aws_string_c_str(endpoint), true /*cleanSession*/, 5000 /*keepAliveTimeSecs*/))
     {
         printf("Failed to connect");
         ASSERT_TRUE(false);


### PR DESCRIPTION
*Description of changes:*

~~Minor adjustment to stay 100% fully backwards compatible with the MQTT311 custom authorizer API, even if it technically won't/shouldn't work with the old API.~~

Adjusts documentation to note that passing a custom authorizer signature with the old API will always fail.

_________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
