### PR TITLE
Fix null env var handling in Mqtt311ClientTest

### DIFF
--- a/tests/MqttClientTest.cpp
+++ b/tests/MqttClientTest.cpp
@@ -149,8 +149,8 @@ static int s_TestIoTMqtt311ConnectWithNoSigningCustomAuth(Aws::Crt::Allocator *a
     error |= aws_get_environment_value(allocator, s_mqtt5_test_envName_iot_nosign_custom_auth_username, &username);
     error |= aws_get_environment_value(allocator, s_mqtt5_test_envName_iot_nosign_custom_auth_password, &password);
 
-    bool env_vars_set = (endpoint && authname && username && password);
-    if (error != AWS_OP_SUCCESS || !env_vars_set)
+    bool isEveryEnvVarSet = (endpoint && authname && username && password);
+    if (error != AWS_OP_SUCCESS || !isEveryEnvVarSet)
     {
         printf("Environment Variables are not set for the test, skip the test");
         aws_string_destroy(empty_string);
@@ -243,9 +243,9 @@ static int s_TestIoTMqtt311ConnectWithSigningCustomAuth(Aws::Crt::Allocator *all
     error |= aws_get_environment_value(allocator, s_mqtt5_test_envName_iot_sign_custom_auth_tokenkey, &tokenKeyName);
     error |= aws_get_environment_value(allocator, s_mqtt5_test_envName_iot_sign_custom_auth_tokenvalue, &tokenValue);
 
-    bool env_vars_set = (endpoint && authname && username && password && signature
+    bool isEveryEnvVarSet = (endpoint && authname && username && password && signature
             && tokenKeyName && tokenValue);
-    if (error != AWS_OP_SUCCESS || !env_vars_set)
+    if (error != AWS_OP_SUCCESS || !isEveryEnvVarSet)
     {
         printf("Environment Variables are not set for the test, skip the test");
         return AWS_OP_SKIP;

--- a/tests/MqttClientTest.cpp
+++ b/tests/MqttClientTest.cpp
@@ -149,9 +149,11 @@ static int s_TestIoTMqtt311ConnectWithNoSigningCustomAuth(Aws::Crt::Allocator *a
     error |= aws_get_environment_value(allocator, s_mqtt5_test_envName_iot_nosign_custom_auth_username, &username);
     error |= aws_get_environment_value(allocator, s_mqtt5_test_envName_iot_nosign_custom_auth_password, &password);
 
-    if (error != AWS_OP_SUCCESS || endpoint == NULL || authname == NULL || username == NULL || password == NULL)
+    bool env_vars_set = (endpoint && authname && username && password);
+    if (error != AWS_OP_SUCCESS || !env_vars_set)
     {
         printf("Environment Variables are not set for the test, skip the test");
+        aws_string_destroy(empty_string);
         return AWS_OP_SKIP;
     }
 
@@ -241,7 +243,9 @@ static int s_TestIoTMqtt311ConnectWithSigningCustomAuth(Aws::Crt::Allocator *all
     error |= aws_get_environment_value(allocator, s_mqtt5_test_envName_iot_sign_custom_auth_tokenkey, &tokenKeyName);
     error |= aws_get_environment_value(allocator, s_mqtt5_test_envName_iot_sign_custom_auth_tokenvalue, &tokenValue);
 
-    if (error != AWS_OP_SUCCESS)
+    bool env_vars_set = (endpoint && authname && username && password && signature
+            && tokenKeyName && tokenValue);
+    if (error != AWS_OP_SUCCESS || !env_vars_set)
     {
         printf("Environment Variables are not set for the test, skip the test");
         return AWS_OP_SKIP;


### PR DESCRIPTION
*Description of changes:*

s2n-tls runs the CRT tests on pull requests to avoid breaking CRT. We don't set up these environment variables, so if I understand the intention correctly than these tests should be skipped.

However, skipping IoTMqtt311ConnectWithNoSigningCustomAuth causes a memory leak and IoTMqtt311ConnectWithSigningCustomAuth doesn't skip even if none of the variables are set. This is breaking the s2n-tls PR checks.

I've confirmed locally that the previously failing tests now succeed with this fix.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
