### PR TITLE
Bump the MQTT5 canary builder version

### DIFF
--- a/codebuild/mqtt5-cpp-canary-test.yml
+++ b/codebuild/mqtt5-cpp-canary-test.yml
@@ -7,7 +7,7 @@ env:
     CANARY_TPS: 50
     CANARY_CLIENT_COUNT: 10
     CANARY_LOG_LEVEL: 'ERROR'
-    BUILDER_VERSION: v0.9.21
+    BUILDER_VERSION: v0.9.44
     BUILDER_SOURCE: releases
     BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
     PACKAGE_NAME: aws-crt-cpp


### PR DESCRIPTION
*Description of changes:*

Bumps the version of the MQTT5 canary builder to the latest release.

___________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
