### PR TITLE
Fix format specifier in canary

### DIFF
--- a/bin/mqtt5_canary/main.cpp
+++ b/bin/mqtt5_canary/main.cpp
@@ -216,10 +216,7 @@ static void s_ParseOptions(int argc, char **argv, struct AppCtx &ctx, struct Aws
                 }
                 else
                 {
-                    fprintf(
-                        stderr,
-                        "Succeed to parse uri %s\n",
-                        static_cast<const char *>(AWS_BYTE_CURSOR_PRI(ctx.uri.GetFullUri())));
+                    fprintf(stderr, "Succeed to parse uri " PRInSTR "\n", AWS_BYTE_CURSOR_PRI(ctx.uri.GetFullUri()));
                 }
                 break;
             default:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Use `PRInSTR` to specify the string length, otherwise it would cause buffer overflow with `fprintf`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
