### PR TITLE
Fix CMake option for choosing MSVC runtime library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,7 +282,7 @@ aws_prepare_symbol_visibility_args(${PROJECT_NAME} "AWS_CRT_CPP")
 
 # set runtime library
 if(MSVC)
-    if(STATIC_CRT)
+    if(AWS_STATIC_MSVC_RUNTIME_LIBRARY OR STATIC_CRT)
         target_compile_options(${PROJECT_NAME} PRIVATE "/MT$<$<CONFIG:Debug>:d>")
     else()
         target_compile_options(${PROJECT_NAME} PRIVATE "/MD$<$<CONFIG:Debug>:d>")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,9 +289,7 @@ if(MSVC)
     endif()
 endif()
 
-if(CMAKE_BUILD_TYPE STREQUAL "" OR CMAKE_BUILD_TYPE MATCHES Debug)
-    target_compile_definitions(${PROJECT_NAME} PRIVATE "-DDEBUG_BUILD")
-endif()
+target_compile_definitions(${PROJECT_NAME} PRIVATE $<$<CONFIG:Debug>:DEBUG_BUILD>)
 
 # set extra warning flags
 if(AWS_WARNINGS_ARE_ERRORS)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you want to manage these dependencies manually (e.g. you're using them in oth
 `-DBUILD_DEPS=OFF` and `-DCMAKE_PREFIX_PATH=<install>` pointing to the absolute path where you have them installed.
 
 ### MSVC
-If you want to use a statically linked MSVCRT (/MT, /MTd), you can add `-DSTATIC_CRT=ON` to your cmake configuration.
+If you want to use a statically linked MSVCRT (/MT, /MTd), you can add `-DAWS_STATIC_MSVC_RUNTIME_LIBRARY=ON` to your cmake configuration.
 
 ### Apple Silicon (aka M1) and Universal Binaries
 

--- a/bin/elasticurl_cpp/CMakeLists.txt
+++ b/bin/elasticurl_cpp/CMakeLists.txt
@@ -14,10 +14,10 @@ set_target_properties(${ELASTICURL_CPP_PROJECT_NAME} PROPERTIES CXX_STANDARD ${C
 
 #set warnings and runtime library
 if (MSVC)
-    if(STATIC_CRT)
-        target_compile_options(${PROJECT_NAME} PRIVATE "/MT$<$<CONFIG:Debug>:d>")
+    if(AWS_STATIC_MSVC_RUNTIME_LIBRARY OR STATIC_CRT)
+        target_compile_options(${ELASTICURL_CPP_PROJECT_NAME} PRIVATE "/MT$<$<CONFIG:Debug>:d>")
     else()
-        target_compile_options(${PROJECT_NAME} PRIVATE "/MD$<$<CONFIG:Debug>:d>")
+        target_compile_options(${ELASTICURL_CPP_PROJECT_NAME} PRIVATE "/MD$<$<CONFIG:Debug>:d>")
     endif()
     target_compile_options(${ELASTICURL_CPP_PROJECT_NAME} PRIVATE /W4 /WX)
 else ()

--- a/bin/elasticurl_cpp/CMakeLists.txt
+++ b/bin/elasticurl_cpp/CMakeLists.txt
@@ -25,9 +25,7 @@ else ()
 endif ()
 
 
-if (CMAKE_BUILD_TYPE STREQUAL "" OR CMAKE_BUILD_TYPE MATCHES Debug)
-    target_compile_definitions(${ELASTICURL_CPP_PROJECT_NAME} PRIVATE "-DDEBUG_BUILD")
-endif ()
+target_compile_definitions(${ELASTICURL_CPP_PROJECT_NAME} PRIVATE $<$<CONFIG:Debug>:DEBUG_BUILD>)
 
 target_include_directories(${ELASTICURL_CPP_PROJECT_NAME} PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/bin/mqtt5_app/CMakeLists.txt
+++ b/bin/mqtt5_app/CMakeLists.txt
@@ -25,9 +25,7 @@ else ()
 endif ()
 
 
-if (CMAKE_BUILD_TYPE STREQUAL "" OR CMAKE_BUILD_TYPE MATCHES Debug)
-    target_compile_definitions(${MQTT5_APP_PROJECT_NAME} PRIVATE "-DDEBUG_BUILD")
-endif ()
+target_compile_definitions(${MQTT5_APP_PROJECT_NAME} PRIVATE $<$<CONFIG:Debug>:DEBUG_BUILD>)
 
 target_include_directories(${MQTT5_APP_PROJECT_NAME} PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/bin/mqtt5_app/CMakeLists.txt
+++ b/bin/mqtt5_app/CMakeLists.txt
@@ -14,10 +14,10 @@ set_target_properties(${MQTT5_APP_PROJECT_NAME} PROPERTIES CXX_STANDARD ${CMAKE_
 
 #set warnings and runtime library
 if (MSVC)
-    if(STATIC_CRT)
-        target_compile_options(${PROJECT_NAME} PRIVATE "/MT$<$<CONFIG:Debug>:d>")
+    if(AWS_STATIC_MSVC_RUNTIME_LIBRARY OR STATIC_CRT)
+        target_compile_options(${MQTT5_APP_PROJECT_NAME} PRIVATE "/MT$<$<CONFIG:Debug>:d>")
     else()
-        target_compile_options(${PROJECT_NAME} PRIVATE "/MD$<$<CONFIG:Debug>:d>")
+        target_compile_options(${MQTT5_APP_PROJECT_NAME} PRIVATE "/MD$<$<CONFIG:Debug>:d>")
     endif()
     target_compile_options(${MQTT5_APP_PROJECT_NAME} PRIVATE /W4 /WX)
 else ()

--- a/bin/mqtt5_canary/CMakeLists.txt
+++ b/bin/mqtt5_canary/CMakeLists.txt
@@ -25,10 +25,7 @@ else ()
     target_compile_options(${MQTT5_CANARY_PROJECT_NAME} PRIVATE -Wall -Wno-long-long -pedantic -Werror)
 endif ()
 
-
-if (CMAKE_BUILD_TYPE STREQUAL "" OR CMAKE_BUILD_TYPE MATCHES Debug)
-    target_compile_definitions(${MQTT5_CANARY_PROJECT_NAME} PRIVATE "-DDEBUG_BUILD")
-endif ()
+target_compile_definitions(${MQTT5_CANARY_PROJECT_NAME} PRIVATE $<$<CONFIG:Debug>:DEBUG_BUILD>)
 
 target_include_directories(${MQTT5_CANARY_PROJECT_NAME} PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/bin/mqtt5_canary/CMakeLists.txt
+++ b/bin/mqtt5_canary/CMakeLists.txt
@@ -15,10 +15,10 @@ set_target_properties(${MQTT5_CANARY_PROJECT_NAME} PROPERTIES CXX_STANDARD ${CMA
 
 #set warnings and runtime library
 if (MSVC)
-    if(STATIC_CRT)
-        target_compile_options(${PROJECT_NAME} PRIVATE "/MT$<$<CONFIG:Debug>:d>")
+    if(AWS_STATIC_MSVC_RUNTIME_LIBRARY OR STATIC_CRT)
+        target_compile_options(${MQTT5_CANARY_PROJECT_NAME} PRIVATE "/MT$<$<CONFIG:Debug>:d>")
     else()
-        target_compile_options(${PROJECT_NAME} PRIVATE "/MD$<$<CONFIG:Debug>:d>")
+        target_compile_options(${MQTT5_CANARY_PROJECT_NAME} PRIVATE "/MD$<$<CONFIG:Debug>:d>")
     endif()
     target_compile_options(${MQTT5_CANARY_PROJECT_NAME} PRIVATE /W4 /WX)
 else ()


### PR DESCRIPTION
**Issue:**
The `-DSTATIC_CRT=ON` CMake option for choosing the MSVC runtime library didn't affect submodules. Also it's a terribly named option, since we refer to this codebase as "CRT".

**Description of changes:**
1) Pick up this fix in the submodules: https://github.com/awslabs/aws-c-common/pull/1054
2) ~STATIC_CRT~ is deprecated, use new `AWS_STATIC_MSVC_RUNTIME_LIBRARY` option instead.
3) Use `$<CONFIG>` generator expressions, instead of checking `${CMAKE_BUILD_TYPE}`, to better support multi-config generators like Visual Studio. See: https://cmake.org/cmake/help/v3.22/manual/cmake-buildsystem.7.html#build-configurations

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
