### PR TITLE
Add Mqtt5ClientBuilder method to set bootstrap

### DIFF
--- a/include/aws/iot/Mqtt5Client.h
+++ b/include/aws/iot/Mqtt5Client.h
@@ -270,6 +270,16 @@ namespace Aws
             Mqtt5ClientBuilder &WithPort(uint16_t port) noexcept;
 
             /**
+             * Set booststrap for mqtt5 client
+             *
+             * @param bootStrap bootstrap used for mqtt5 client. The default ClientBootstrap see
+             * Aws::Crt::ApiHandle::GetOrCreateStaticDefaultClientBootstrap.
+             *
+             * @return this option object
+             */
+            Mqtt5ClientBuilder &WithBootstrap(Crt::Io::ClientBootstrap *bootStrap) noexcept;
+
+            /**
              * Sets the certificate authority for the endpoint you're connecting to. This is a path to a file on disk
              * and must be in PEM format.
              *
@@ -514,11 +524,6 @@ namespace Aws
              * Network port of the MQTT server to connect to.
              */
             uint16_t m_port;
-
-            /**
-             * Client bootstrap to use.  In almost all cases, this can be left undefined.
-             */
-            Io::ClientBootstrap *m_bootstrap;
 
             /**
              * TLS context for secure socket connections.

--- a/source/iot/Mqtt5Client.cpp
+++ b/source/iot/Mqtt5Client.cpp
@@ -313,6 +313,12 @@ namespace Aws
             return *this;
         }
 
+        Mqtt5ClientBuilder &Mqtt5ClientBuilder::WithBootstrap(Crt::Io::ClientBootstrap *bootStrap) noexcept
+        {
+            m_options->WithBootstrap(bootStrap);
+            return *this;
+        }
+
         Mqtt5ClientBuilder &Mqtt5ClientBuilder::WithCertificateAuthority(const char *caPath) noexcept
         {
             if (m_tlsConnectionOptions)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Found this inconsistency when trying to build a Mqtt5Client.
Setting the bootstrap is available when using Mqtt5ClientOptions directly but it was missing from Mqtt5ClientBuilder.

-----------------------

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
