### PR TITLE
Fix typo on NegotiatedSettings (Avaliable->Available)

### DIFF
--- a/include/aws/crt/mqtt/Mqtt5Packets.h
+++ b/include/aws/crt/mqtt/Mqtt5Packets.h
@@ -491,17 +491,17 @@ namespace Aws
                 /**
                  * @return Whether the server supports wildcard subscriptions.
                  */
-                bool getWildcardSubscriptionsAvaliable() const noexcept;
+                bool getWildcardSubscriptionsAvailable() const noexcept;
 
                 /**
                  * @return Whether the server supports subscription identifiers
                  */
-                bool getSubscriptionIdentifiersAvaliable() const noexcept;
+                bool getSubscriptionIdentifiersAvailable() const noexcept;
 
                 /**
                  * @return Whether the server supports shared subscriptions
                  */
-                bool getSharedSubscriptionsAvaliable() const noexcept;
+                bool getSharedSubscriptionsAvailable() const noexcept;
 
                 /**
                  * @return Whether the client has rejoined an existing session.
@@ -560,17 +560,17 @@ namespace Aws
                 /**
                  * Whether the server supports wildcard subscriptions.
                  */
-                bool m_wildcardSubscriptionsAvaliable;
+                bool m_wildcardSubscriptionsAvailable;
 
                 /**
                  * Whether the server supports subscription identifiers
                  */
-                bool m_subscriptionIdentifiersAvaliable;
+                bool m_subscriptionIdentifiersAvailable;
 
                 /**
                  * Whether the server supports shared subscriptions
                  */
-                bool m_sharedSubscriptionsAvaliable;
+                bool m_sharedSubscriptionsAvailable;
 
                 /**
                  * Whether the client has rejoined an existing session.
@@ -1221,7 +1221,7 @@ namespace Aws
                  *
                  * @return Whether the server supports wildcard subscriptions.
                  */
-                const Crt::Optional<bool> &getWildcardSubscriptionsAvaliable() const noexcept;
+                const Crt::Optional<bool> &getWildcardSubscriptionsAvailable() const noexcept;
 
                 /**
                  * Indicates whether the server supports subscription identifiers.  If null, subscription identifiers
@@ -1232,7 +1232,7 @@ namespace Aws
                  *
                  * @return whether the server supports subscription identifiers.
                  */
-                const Crt::Optional<bool> &getSubscriptionIdentifiersAvaliable() const noexcept;
+                const Crt::Optional<bool> &getSubscriptionIdentifiersAvailable() const noexcept;
 
                 /**
                  * Indicates whether the server supports shared subscription topic filters.  If null, shared
@@ -1243,7 +1243,7 @@ namespace Aws
                  *
                  * @return whether the server supports shared subscription topic filters.
                  */
-                const Crt::Optional<bool> &getSharedSubscriptionsAvaliable() const noexcept;
+                const Crt::Optional<bool> &getSharedSubscriptionsAvailable() const noexcept;
 
                 /**
                  * Server-requested override of the keep alive interval, in seconds.  If null, the keep alive value sent
@@ -1378,7 +1378,7 @@ namespace Aws
                  * See [MQTT5 Wildcard Subscriptions
                  * Available](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901091)
                  */
-                Crt::Optional<bool> m_wildcardSubscriptionsAvaliable;
+                Crt::Optional<bool> m_wildcardSubscriptionsAvailable;
 
                 /**
                  * Indicates whether the server supports subscription identifiers.  If undefined, subscription
@@ -1387,7 +1387,7 @@ namespace Aws
                  * See [MQTT5 Subscription Identifiers
                  * Available](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901092)
                  */
-                Crt::Optional<bool> m_subscriptionIdentifiersAvaliable;
+                Crt::Optional<bool> m_subscriptionIdentifiersAvailable;
 
                 /**
                  * Indicates whether the server supports shared subscription topic filters.  If undefined, shared
@@ -1396,7 +1396,7 @@ namespace Aws
                  * See [MQTT5 Shared Subscriptions
                  * Available](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901093)
                  */
-                Crt::Optional<bool> m_sharedSubscriptionsAvaliable;
+                Crt::Optional<bool> m_sharedSubscriptionsAvailable;
 
                 /**
                  * Server-requested override of the keep alive interval, in seconds.  If undefined, the keep alive value

--- a/source/mqtt/Mqtt5Packets.cpp
+++ b/source/mqtt/Mqtt5Packets.cpp
@@ -804,9 +804,9 @@ namespace Aws
                 setPacketOptional(m_topicAliasMaximum, packet.topic_alias_maximum);
                 setPacketStringOptional(m_reasonString, packet.reason_string);
                 setUserProperties(m_userProperties, packet.user_properties, packet.user_property_count);
-                setPacketOptional(m_wildcardSubscriptionsAvaliable, packet.wildcard_subscriptions_available);
-                setPacketOptional(m_subscriptionIdentifiersAvaliable, packet.subscription_identifiers_available);
-                setPacketOptional(m_sharedSubscriptionsAvaliable, packet.shared_subscriptions_available);
+                setPacketOptional(m_wildcardSubscriptionsAvailable, packet.wildcard_subscriptions_available);
+                setPacketOptional(m_subscriptionIdentifiersAvailable, packet.subscription_identifiers_available);
+                setPacketOptional(m_sharedSubscriptionsAvailable, packet.shared_subscriptions_available);
                 setPacketOptional(m_serverKeepAlive, packet.server_keep_alive);
                 setPacketStringOptional(m_responseInformation, packet.response_information);
                 setPacketStringOptional(m_serverReference, packet.server_reference);
@@ -849,19 +849,19 @@ namespace Aws
 
             const Vector<UserProperty> &ConnAckPacket::getUserProperty() const noexcept { return m_userProperties; }
 
-            const Crt::Optional<bool> &ConnAckPacket::getWildcardSubscriptionsAvaliable() const noexcept
+            const Crt::Optional<bool> &ConnAckPacket::getWildcardSubscriptionsAvailable() const noexcept
             {
-                return m_wildcardSubscriptionsAvaliable;
+                return m_wildcardSubscriptionsAvailable;
             }
 
-            const Crt::Optional<bool> &ConnAckPacket::getSubscriptionIdentifiersAvaliable() const noexcept
+            const Crt::Optional<bool> &ConnAckPacket::getSubscriptionIdentifiersAvailable() const noexcept
             {
-                return m_subscriptionIdentifiersAvaliable;
+                return m_subscriptionIdentifiersAvailable;
             }
 
-            const Crt::Optional<bool> &ConnAckPacket::getSharedSubscriptionsAvaliable() const noexcept
+            const Crt::Optional<bool> &ConnAckPacket::getSharedSubscriptionsAvailable() const noexcept
             {
-                return m_sharedSubscriptionsAvaliable;
+                return m_sharedSubscriptionsAvailable;
             }
 
             const Crt::Optional<uint16_t> &ConnAckPacket::getServerKeepAlive() const noexcept
@@ -1176,9 +1176,9 @@ namespace Aws
                 m_serverKeepAliveSec = negotiated_settings.server_keep_alive;
 
                 m_retainAvailable = negotiated_settings.retain_available;
-                m_wildcardSubscriptionsAvaliable = negotiated_settings.wildcard_subscriptions_available;
-                m_subscriptionIdentifiersAvaliable = negotiated_settings.subscription_identifiers_available;
-                m_sharedSubscriptionsAvaliable = negotiated_settings.shared_subscriptions_available;
+                m_wildcardSubscriptionsAvailable = negotiated_settings.wildcard_subscriptions_available;
+                m_subscriptionIdentifiersAvailable = negotiated_settings.subscription_identifiers_available;
+                m_sharedSubscriptionsAvailable = negotiated_settings.shared_subscriptions_available;
                 m_rejoinedSession = negotiated_settings.rejoined_session;
 
                 m_clientId = Crt::String(
@@ -1204,19 +1204,19 @@ namespace Aws
 
             bool NegotiatedSettings::getRetainAvailable() const noexcept { return m_retainAvailable; }
 
-            bool NegotiatedSettings::getWildcardSubscriptionsAvaliable() const noexcept
+            bool NegotiatedSettings::getWildcardSubscriptionsAvailable() const noexcept
             {
-                return m_wildcardSubscriptionsAvaliable;
+                return m_wildcardSubscriptionsAvailable;
             }
 
-            bool NegotiatedSettings::getSubscriptionIdentifiersAvaliable() const noexcept
+            bool NegotiatedSettings::getSubscriptionIdentifiersAvailable() const noexcept
             {
-                return m_subscriptionIdentifiersAvaliable;
+                return m_subscriptionIdentifiersAvailable;
             }
 
-            bool NegotiatedSettings::getSharedSubscriptionsAvaliable() const noexcept
+            bool NegotiatedSettings::getSharedSubscriptionsAvailable() const noexcept
             {
-                return m_sharedSubscriptionsAvaliable;
+                return m_sharedSubscriptionsAvailable;
             }
 
             bool NegotiatedSettings::getRejoinedSession() const noexcept { return m_rejoinedSession; }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

While exploring what was being provided by `NegotiatedSettings`, I noticed that some methods were misspelled.

----------------------

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
