### PR TITLE
Disable doxygen for private header API

### DIFF
--- a/include/aws/crt/mqtt/private/Mqtt5ClientCore.h
+++ b/include/aws/crt/mqtt/private/Mqtt5ClientCore.h
@@ -1,3 +1,7 @@
+/*! \cond DOXYGEN_PRIVATE
+** Hide API from this file in doxygen. Set DOXYGEN_PRIVATE in doxygen
+** config to enable this file for doxygen.
+*/
 #pragma once
 /**
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
@@ -253,3 +257,4 @@ namespace Aws
         } // namespace Mqtt5
     }     // namespace Crt
 } // namespace Aws
+/*! \endcond */

--- a/include/aws/crt/mqtt/private/MqttConnectionCore.h
+++ b/include/aws/crt/mqtt/private/MqttConnectionCore.h
@@ -1,3 +1,7 @@
+/*! \cond DOXYGEN_PRIVATE
+** Hide API from this file in doxygen. Set DOXYGEN_PRIVATE in doxygen
+** config to enable this file for doxygen.
+*/
 #pragma once
 /**
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
@@ -388,3 +392,4 @@ namespace Aws
         } // namespace Mqtt
     }     // namespace Crt
 } // namespace Aws
+/*! \endcond */

--- a/source/mqtt/Mqtt5ClientCore.cpp
+++ b/source/mqtt/Mqtt5ClientCore.cpp
@@ -1,3 +1,7 @@
+/*! \cond DOXYGEN_PRIVATE
+** Hide API from this file in doxygen. Set DOXYGEN_PRIVATE in doxygen
+** config to enable this file for doxygen.
+*/
 /**
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0.
@@ -651,3 +655,4 @@ namespace Aws
         } // namespace Mqtt5
     }     // namespace Crt
 } // namespace Aws
+/*! \endcond */

--- a/source/mqtt/MqttConnectionCore.cpp
+++ b/source/mqtt/MqttConnectionCore.cpp
@@ -1,3 +1,7 @@
+/*! \cond DOXYGEN_PRIVATE
+** Hide API from this file in doxygen. Set DOXYGEN_PRIVATE in doxygen
+** config to enable this file for doxygen.
+*/
 /**
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0.
@@ -917,3 +921,4 @@ namespace Aws
         } // namespace Mqtt
     }     // namespace Crt
 } // namespace Aws
+/*! \endcond */


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The doxygen would fail on the functions that was declared in private header as it could not find the function declaration. Disable doxygen for files with private headers. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
