### PR TITLE
Fix CMake error when BUILD_DEPS=OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,6 +314,7 @@ aws_use_package(aws-checksums)
 aws_use_package(aws-c-event-stream)
 aws_use_package(aws-c-s3)
 
+include(AwsSanitizers)
 aws_add_sanitizers(${PROJECT_NAME})
 
 target_link_libraries(${PROJECT_NAME} PUBLIC ${DEP_AWS_LIBS})


### PR DESCRIPTION
*Issue #:* https://github.com/awslabs/aws-crt-cpp/issues/548


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
