### PR TITLE
Add a method to report library version from ApiHandle

### DIFF
--- a/include/aws/crt/Api.h
+++ b/include/aws/crt/Api.h
@@ -176,6 +176,20 @@ namespace Aws
              */
             static Io::HostResolver *GetOrCreateStaticDefaultHostResolver();
 
+#pragma pack(push, 1)
+            struct Version
+            {
+                uint16_t major;
+                uint16_t minor;
+                uint16_t patch;
+            };
+#pragma pack(pop)
+            /**
+             * Gets the version of the AWS-CRT-CPP library
+             * @return Version representing the library version
+             */
+            Version GetCrtVersion() const;
+
           private:
             void InitializeLoggingCommon(struct aws_logger_standard_options &options);
 
@@ -195,6 +209,8 @@ namespace Aws
             static Io::HostResolver *s_static_default_host_resolver;
             static std::mutex s_lock_default_host_resolver;
             static void ReleaseStaticDefaultHostResolver();
+
+            Version m_version = {0, 0, 0};
         };
 
         /**

--- a/source/Api.cpp
+++ b/source/Api.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 #include <aws/crt/Api.h>
+#include <aws/crt/Config.h>
 #include <aws/crt/JsonObject.h>
 #include <aws/crt/StlAllocator.h>
 #include <aws/crt/io/TlsOptions.h>
@@ -37,7 +38,8 @@ namespace Aws
         std::mutex ApiHandle::s_lock_default_host_resolver;
 
         ApiHandle::ApiHandle(Allocator *allocator) noexcept
-            : m_logger(), m_shutdownBehavior(ApiHandleShutdownBehavior::Blocking)
+            : m_logger(), m_shutdownBehavior(ApiHandleShutdownBehavior::Blocking),
+              m_version({AWS_CRT_CPP_VERSION_MAJOR, AWS_CRT_CPP_VERSION_MINOR, AWS_CRT_CPP_VERSION_PATCH})
         {
             // sets up the StlAllocator for use.
             g_allocator = allocator;
@@ -372,6 +374,8 @@ namespace Aws
         {
             return s_BYOCryptoIsTlsAlpnSupportedCallback;
         }
+
+        ApiHandle::Version ApiHandle::GetCrtVersion() const { return m_version; }
 
         const char *ErrorDebugString(int error) noexcept { return aws_error_debug_str(error); }
 

--- a/tests/ApiTest.cpp
+++ b/tests/ApiTest.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 #include <aws/crt/Api.h>
+#include <aws/crt/Config.h>
 #include <aws/crt/Types.h>
 #include <aws/testing/aws_test_harness.h>
 
@@ -54,3 +55,18 @@ static int s_TestApiStaticDefaultCreateDestroy(struct aws_allocator *allocator, 
 }
 
 AWS_TEST_CASE(ApiStaticDefaultCreateDestroy, s_TestApiStaticDefaultCreateDestroy)
+
+static int s_TestApiVersionReporting(struct aws_allocator *allocator, void *)
+{
+    {
+        Aws::Crt::ApiHandle apiHandle(allocator);
+        Aws::Crt::ApiHandle::Version version = apiHandle.GetCrtVersion();
+        ASSERT_UINT_EQUALS(version.major, AWS_CRT_CPP_VERSION_MAJOR);
+        ASSERT_UINT_EQUALS(version.minor, AWS_CRT_CPP_VERSION_MINOR);
+        ASSERT_UINT_EQUALS(version.patch, AWS_CRT_CPP_VERSION_PATCH);
+    }
+
+    return AWS_ERROR_SUCCESS;
+}
+
+AWS_TEST_CASE(ApiStaticVersionReporting, s_TestApiVersionReporting)


### PR DESCRIPTION
*Issue #, if available:*
CRT-CPP package does not expose it's version.
*Description of changes:*
Add a method that will return the version declared at the build time.

update: update clang format

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
