### PR TITLE
make variant index casts more explicit

### DIFF
--- a/include/aws/crt/Variant.h
+++ b/include/aws/crt/Variant.h
@@ -148,14 +148,14 @@ namespace Aws
             {
                 AWS_FATAL_ASSERT(other.m_index != -1);
                 m_index = other.m_index;
-                VisitorUtil<(Variant::IndexT)0, Ts...>::VisitBinary(this, other, CopyMoveConstructor());
+                VisitorUtil<0, Ts...>::VisitBinary(this, other, CopyMoveConstructor());
             }
 
             Variant(Variant &&other)
             {
                 AWS_FATAL_ASSERT(other.m_index != -1);
                 m_index = other.m_index;
-                VisitorUtil<(Variant::IndexT)0, Ts...>::VisitBinary(this, std::move(other), CopyMoveConstructor());
+                VisitorUtil<0, Ts...>::VisitBinary(this, std::move(other), CopyMoveConstructor());
             }
 
             template <typename T, EnableIfOtherIsThisVariantAlternative<T> = 1> Variant(const T &val)
@@ -213,11 +213,11 @@ namespace Aws
                     {
                         Destroy();
                         m_index = other.m_index;
-                        VisitorUtil<(Variant::IndexT)0, Ts...>::VisitBinary(this, other, CopyMoveConstructor());
+                        VisitorUtil<0, Ts...>::VisitBinary(this, other, CopyMoveConstructor());
                     }
                     else
                     {
-                        VisitorUtil<(Variant::IndexT)0, Ts...>::VisitBinary(this, other, CopyMoveAssigner());
+                        VisitorUtil<0, Ts...>::VisitBinary(this, other, CopyMoveAssigner());
                     }
                 }
                 return *this;
@@ -232,11 +232,11 @@ namespace Aws
                     {
                         Destroy();
                         m_index = other.m_index;
-                        VisitorUtil<(Variant::IndexT)0, Ts...>::VisitBinary(this, std::move(other), CopyMoveConstructor());
+                        VisitorUtil<0, Ts...>::VisitBinary(this, std::move(other), CopyMoveConstructor());
                     }
                     else
                     {
-                        VisitorUtil<(Variant::IndexT)0, Ts...>::VisitBinary(this, std::move(other), CopyMoveAssigner());
+                        VisitorUtil<0, Ts...>::VisitBinary(this, std::move(other), CopyMoveAssigner());
                     };
                 }
                 return *this;
@@ -386,7 +386,7 @@ namespace Aws
 
             template <typename VisitorT> void Visit(VisitorT &&visitor)
             {
-                return VisitorUtil<(Variant::IndexT)0, Ts...>::Visit(this, std::forward<VisitorT>(visitor));
+                return VisitorUtil<0, Ts...>::Visit(this, std::forward<VisitorT>(visitor));
             }
 
           private:
@@ -473,7 +473,7 @@ namespace Aws
                     }
                     else
                     {
-                        VisitorUtil<Index + (IndexT)1, Second, Rest...>::Visit(pThis, std::forward<VisitorStruct>(visitor));
+                        VisitorUtil<Index + 1, Second, Rest...>::Visit(pThis, std::forward<VisitorStruct>(visitor));
                     }
                 }
 
@@ -490,7 +490,7 @@ namespace Aws
                     }
                     else
                     {
-                        VisitorUtil<Index + (IndexT)1, Second, Rest...>::VisitBinary(
+                        VisitorUtil<Index + 1, Second, Rest...>::VisitBinary(
                             pThis, std::forward<Variant<Ts...>>(other), std::forward<VisitorStruct>(visitor));
                     }
                 }
@@ -509,7 +509,7 @@ namespace Aws
                     }
                     else
                     {
-                        VisitorUtil<Index + (IndexT)1, Second, Rest...>::VisitBinary(
+                        VisitorUtil<Index + 1, Second, Rest...>::VisitBinary(
                             pThis, other, std::forward<VisitorStruct>(visitor));
                     }
                 }

--- a/include/aws/crt/Variant.h
+++ b/include/aws/crt/Variant.h
@@ -473,7 +473,8 @@ namespace Aws
                     }
                     else
                     {
-                        VisitorUtil<static_cast<IndexT>(Index + 1), Second, Rest...>::Visit(pThis, std::forward<VisitorStruct>(visitor));
+                        VisitorUtil<static_cast<IndexT>(Index + 1), Second, Rest...>::Visit(
+                            pThis, std::forward<VisitorStruct>(visitor));
                     }
                 }
 

--- a/include/aws/crt/Variant.h
+++ b/include/aws/crt/Variant.h
@@ -473,7 +473,7 @@ namespace Aws
                     }
                     else
                     {
-                        VisitorUtil<Index + 1, Second, Rest...>::Visit(pThis, std::forward<VisitorStruct>(visitor));
+                        VisitorUtil<static_cast<IndexT>(Index + 1), Second, Rest...>::Visit(pThis, std::forward<VisitorStruct>(visitor));
                     }
                 }
 
@@ -490,7 +490,7 @@ namespace Aws
                     }
                     else
                     {
-                        VisitorUtil<Index + 1, Second, Rest...>::VisitBinary(
+                        VisitorUtil<static_cast<IndexT>(Index + 1), Second, Rest...>::VisitBinary(
                             pThis, std::forward<Variant<Ts...>>(other), std::forward<VisitorStruct>(visitor));
                     }
                 }
@@ -509,7 +509,7 @@ namespace Aws
                     }
                     else
                     {
-                        VisitorUtil<Index + 1, Second, Rest...>::VisitBinary(
+                        VisitorUtil<static_cast<IndexT>(Index + 1), Second, Rest...>::VisitBinary(
                             pThis, other, std::forward<VisitorStruct>(visitor));
                     }
                 }

--- a/include/aws/crt/Variant.h
+++ b/include/aws/crt/Variant.h
@@ -148,14 +148,14 @@ namespace Aws
             {
                 AWS_FATAL_ASSERT(other.m_index != -1);
                 m_index = other.m_index;
-                VisitorUtil<0, Ts...>::VisitBinary(this, other, CopyMoveConstructor());
+                VisitorUtil<(Variant::IndexT)0, Ts...>::VisitBinary(this, other, CopyMoveConstructor());
             }
 
             Variant(Variant &&other)
             {
                 AWS_FATAL_ASSERT(other.m_index != -1);
                 m_index = other.m_index;
-                VisitorUtil<0, Ts...>::VisitBinary(this, std::move(other), CopyMoveConstructor());
+                VisitorUtil<(Variant::IndexT)0, Ts...>::VisitBinary(this, std::move(other), CopyMoveConstructor());
             }
 
             template <typename T, EnableIfOtherIsThisVariantAlternative<T> = 1> Variant(const T &val)
@@ -213,11 +213,11 @@ namespace Aws
                     {
                         Destroy();
                         m_index = other.m_index;
-                        VisitorUtil<0, Ts...>::VisitBinary(this, other, CopyMoveConstructor());
+                        VisitorUtil<(Variant::IndexT)0, Ts...>::VisitBinary(this, other, CopyMoveConstructor());
                     }
                     else
                     {
-                        VisitorUtil<0, Ts...>::VisitBinary(this, other, CopyMoveAssigner());
+                        VisitorUtil<(Variant::IndexT)0, Ts...>::VisitBinary(this, other, CopyMoveAssigner());
                     }
                 }
                 return *this;
@@ -232,11 +232,11 @@ namespace Aws
                     {
                         Destroy();
                         m_index = other.m_index;
-                        VisitorUtil<0, Ts...>::VisitBinary(this, std::move(other), CopyMoveConstructor());
+                        VisitorUtil<(Variant::IndexT)0, Ts...>::VisitBinary(this, std::move(other), CopyMoveConstructor());
                     }
                     else
                     {
-                        VisitorUtil<0, Ts...>::VisitBinary(this, std::move(other), CopyMoveAssigner());
+                        VisitorUtil<(Variant::IndexT)0, Ts...>::VisitBinary(this, std::move(other), CopyMoveAssigner());
                     };
                 }
                 return *this;
@@ -386,7 +386,7 @@ namespace Aws
 
             template <typename VisitorT> void Visit(VisitorT &&visitor)
             {
-                return VisitorUtil<0, Ts...>::Visit(this, std::forward<VisitorT>(visitor));
+                return VisitorUtil<(Variant::IndexT)0, Ts...>::Visit(this, std::forward<VisitorT>(visitor));
             }
 
           private:
@@ -473,7 +473,7 @@ namespace Aws
                     }
                     else
                     {
-                        VisitorUtil<Index + 1, Second, Rest...>::Visit(pThis, std::forward<VisitorStruct>(visitor));
+                        VisitorUtil<Index + (IndexT)1, Second, Rest...>::Visit(pThis, std::forward<VisitorStruct>(visitor));
                     }
                 }
 
@@ -490,7 +490,7 @@ namespace Aws
                     }
                     else
                     {
-                        VisitorUtil<Index + 1, Second, Rest...>::VisitBinary(
+                        VisitorUtil<Index + (IndexT)1, Second, Rest...>::VisitBinary(
                             pThis, std::forward<Variant<Ts...>>(other), std::forward<VisitorStruct>(visitor));
                     }
                 }
@@ -509,7 +509,7 @@ namespace Aws
                     }
                     else
                     {
-                        VisitorUtil<Index + 1, Second, Rest...>::VisitBinary(
+                        VisitorUtil<Index + (IndexT)1, Second, Rest...>::VisitBinary(
                             pThis, other, std::forward<VisitorStruct>(visitor));
                     }
                 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -286,7 +286,7 @@ if(AWS_WARNINGS_ARE_ERRORS)
     if(MSVC)
         target_compile_options(${TEST_BINARY_NAME} PRIVATE /W4 /WX /wd4068)
     else()
-        target_compile_options(${TEST_BINARY_NAME} PRIVATE -Wall -Wno-long-long -Werror -Wconversion)
+        target_compile_options(${TEST_BINARY_NAME} PRIVATE -Wall -Wno-long-long -Werror)
     endif()
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -286,7 +286,7 @@ if(AWS_WARNINGS_ARE_ERRORS)
     if(MSVC)
         target_compile_options(${TEST_BINARY_NAME} PRIVATE /W4 /WX /wd4068)
     else()
-        target_compile_options(${TEST_BINARY_NAME} PRIVATE -Wall -Wno-long-long -Werror)
+        target_compile_options(${TEST_BINARY_NAME} PRIVATE -Wall -Wno-long-long -Werror -Wconversion)
     endif()
 endif()
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
result of short + short is always an int (one of those weird c++ standard quirks), so when we write the result back to a short field some compilers might raise a warning for it if -Wconversion is on (which it is typically not, since its not part of -Wall, etc...). So be more explicit casting back

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
