### PR TITLE
Update MacOS to arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,8 +220,8 @@ jobs:
         python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
         python builder.pyz build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DUSE_CPU_EXTENSIONS=OFF
 
-  osx:
-    runs-on: macos-13 # latest
+  macos:
+    runs-on: macos-14 # latest
     steps:
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
       run: |
@@ -229,24 +229,20 @@ jobs:
         chmod a+x builder
         ./builder build -p ${{ env.PACKAGE_NAME }} --spec=downstream
 
-  # cross-compile for Apple silicon
-  # it would be better to run tests natively on one of these machines,
-  # but we don't have access to one in the cloud, so for now just cross-compile
-  osx-arm64-cross-compile:
-    runs-on: macos-13 # latest
+  macos-x64:
+    runs-on: macos-14-large # latest
     steps:
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
       run: |
         python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
         chmod a+x builder
-        ./builder build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DCMAKE_OSX_ARCHITECTURES=arm64 run_tests=false
-        test `lipo aws-crt-cpp/build/install/lib/libaws-crt-cpp.a -archs` = "arm64"
+        ./builder build -p ${{ env.PACKAGE_NAME }} --spec=downstream
 
   # cross-compile for iOS
   # Skip signing the code on iOS.
   # Otherwise it will not compile with error that Bundle identifier is missing.
   ios-cross-compile:
-    runs-on: macos-13 # latest
+    runs-on: macos-14 # latest
     steps:
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
       run: |


### PR DESCRIPTION
*Description of changes:*
- MacOS CI now defaults to arm-64
- Add a new macos-x64 CI.
- Update the naming from osx to macos.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
