### PR TITLE
Fix HTTP proxy bug in Mqtt5ClientBuilder

### DIFF
--- a/source/iot/Mqtt5Client.cpp
+++ b/source/iot/Mqtt5Client.cpp
@@ -571,6 +571,8 @@ namespace Aws
                 m_options->WithConnectOptions(m_connectOptions);
             }
 
+            bool proxyOptionsSet = false;
+
             if (m_websocketConfig.has_value())
             {
                 auto websocketConfig = m_websocketConfig.value();
@@ -595,13 +597,16 @@ namespace Aws
                 if (useWebsocketProxyOptions)
                 {
                     m_options->WithHttpProxyOptions(m_websocketConfig->ProxyOptions.value());
+                    proxyOptionsSet = true;
                 }
                 else if (m_proxyOptions.has_value())
                 {
                     m_options->WithHttpProxyOptions(m_proxyOptions.value());
+                    proxyOptionsSet = true;
                 }
             }
-            else if (m_proxyOptions.has_value())
+
+            if (m_proxyOptions.has_value() && !proxyOptionsSet)
             {
                 m_options->WithHttpProxyOptions(m_proxyOptions.value());
             }

--- a/source/iot/Mqtt5Client.cpp
+++ b/source/iot/Mqtt5Client.cpp
@@ -601,6 +601,10 @@ namespace Aws
                     m_options->WithHttpProxyOptions(m_proxyOptions.value());
                 }
             }
+            else if (m_proxyOptions.has_value())
+            {
+                m_options->WithHttpProxyOptions(m_proxyOptions.value());
+            }
 
             return Crt::Mqtt5::Mqtt5Client::NewMqtt5Client(*m_options, m_allocator);
         }


### PR DESCRIPTION
The `Mqtt5ClientBuilder` does not properly set the `Mqtt5ClientOptions` `m_options` field in the non-WebSocket case of the `Build()` function. Handle this case.