### PR TITLE
fix MSVC most vexing parse

### DIFF
--- a/include/aws/crt/StringView.h
+++ b/include/aws/crt/StringView.h
@@ -13,6 +13,7 @@
 #include <iterator>
 #include <limits>
 #include <stddef.h>
+#include <string>
 #include <type_traits>
 
 #if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
@@ -859,6 +860,6 @@ namespace std
         const Aws::Crt::basic_string_view<CharT, Traits> &val) const noexcept
     {
         auto str = std::basic_string<CharT, Traits>(val.data(), val.size());
-        return std::hash<std::basic_string<CharT, Traits>>()(str);
+        return std::hash<std::basic_string<CharT, Traits>>{}(str);
     }
 } // namespace std


### PR DESCRIPTION
*Description of changes:*

[Currently CI is failing mainline on msvc with](https://github.com/awslabs/aws-crt-cpp/actions/runs/10619842225/job/29438306844)

```
D:\a\work\aws-crt-cpp\include\aws\crt\StringView.h(861,51): error C2760: syntax error: '>' was unexpected here; expected 'declaration' [D:\a\work\aws-crt-cpp\build\aws-crt-cpp\aws-crt-cpp-header-check-cxx20.vcxproj]
  (compiling source file '../../header-checker-cxx20/headerchecker_aws_crt_Api_h.cpp')
```

fixes [most vexing parse](https://en.wikipedia.org/wiki/Most_vexing_parse) by adding braced init + include string directly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
