### PR TITLE
Set the soname for the library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,6 +302,9 @@ endif()
 
 set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE CXX)
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD ${CMAKE_CXX_STANDARD})
+set_target_properties(${PROJECT_NAME} PROPERTIES VERSION 0.0.0)
+set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION 0)
+
 
 aws_prepare_symbol_visibility_args(${PROJECT_NAME} "AWS_CRT_CPP")
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Greetings,
The pull request appends soname for library to make version management more easier.
Most Linux distros treat libraries without ABI version as development part of package, and link applications with them directly is not correct.
So, the change provides SONAME, SOVERSION for runtime and development library.
For your convenience ABI version begins from zero, it partially corresponds with project major version.
I believe that the project developers know the details of ABI development and in the case of an already appointed informal versioning system, they will correct the proposed change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
