### PR TITLE
Fix crashes in GCC 4.x shared-libs builds, due to recent symbol visibility changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ env:
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   AWS_REGION: us-east-1
 
+# cancel in-progress builds after a new commit
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+  
 jobs:
   linux-compat-use-openssl:
     runs-on: ubuntu-22.04 # latest
@@ -62,6 +67,7 @@ jobs:
   linux-compiler-compat:
     runs-on: ubuntu-22.04 # latest
     strategy:
+      fail-fast: false
       matrix:
         compiler:
           - clang-3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,6 @@ jobs:
   linux-compiler-compat:
     runs-on: ubuntu-22.04 # latest
     strategy:
-      fail-fast: false
       matrix:
         compiler:
           - clang-3
@@ -90,7 +89,7 @@ jobs:
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
           aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
-          ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=${{ matrix.compiler }} --cmake-extra=-DUSE_OPENSSL=ON  --cmake-extra=-DBUILD_SHARED_LIBS=ON
+          ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=${{ matrix.compiler }} --cmake-extra=-DUSE_OPENSSL=ON
 
   raspberry:
     runs-on: ubuntu-22.04 # latest
@@ -134,12 +133,16 @@ jobs:
 
   linux-shared-libs:
     runs-on: ubuntu-22.04 # latest
+    strategy:
+      matrix:
+        compiler: [gcc-4.8, gcc-11] # oldest, latest
+
     steps:
         # We can't use the `uses: docker://image` version yet, GitHub lacks authentication for actions -> packages
     - name: Build ${{ env.PACKAGE_NAME }}
       run: |
         aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
-        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DBUILD_SHARED_LIBS=ON
+        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=${{ matrix.compiler }} --cmake-extra=-DBUILD_SHARED_LIBS=ON
 
   linux-openssl-static:
     runs-on: ubuntu-22.04 # latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,6 @@ jobs:
     strategy:
       matrix:
         compiler: [gcc-4.8, gcc-11] # oldest, latest
-
     steps:
         # We can't use the `uses: docker://image` version yet, GitHub lacks authentication for actions -> packages
     - name: Build ${{ env.PACKAGE_NAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
           aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
-          ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=${{ matrix.compiler }} --cmake-extra=-DUSE_OPENSSL=ON
+          ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=${{ matrix.compiler }} --cmake-extra=-DUSE_OPENSSL=ON  --cmake-extra=-DBUILD_SHARED_LIBS=ON
 
   raspberry:
     runs-on: ubuntu-22.04 # latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,7 +302,13 @@ endif()
 
 set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE CXX)
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD ${CMAKE_CXX_STANDARD})
-set_target_properties(${PROJECT_NAME} PROPERTIES CXX_VISIBILITY_PRESET hidden VISIBILITY_INLINES_HIDDEN ON)
+
+# Hide symbols by default
+# Except for ancient GCC, because it leads to crashes in shared-lib builds
+# see: https://github.com/awslabs/aws-crt-cpp/pull/675
+if(NOT (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "5.0"))
+    set_target_properties(${PROJECT_NAME} PROPERTIES CXX_VISIBILITY_PRESET hidden VISIBILITY_INLINES_HIDDEN ON)
+endif()
 
 aws_prepare_symbol_visibility_args(${PROJECT_NAME} "AWS_CRT_CPP")
 

--- a/include/aws/crt/StlAllocator.h
+++ b/include/aws/crt/StlAllocator.h
@@ -17,7 +17,7 @@ namespace Aws
          * Stateful allocator variant that uses an underlying CRT allocator
          * @tparam T type that allocator can allocate
          */
-        template <typename T> class AWS_CRT_CPP_API StlAllocator : public std::allocator<T>
+        template <typename T> class StlAllocator : public std::allocator<T>
         {
           public:
             using Base = std::allocator<T>;

--- a/include/aws/crt/StlAllocator.h
+++ b/include/aws/crt/StlAllocator.h
@@ -17,7 +17,7 @@ namespace Aws
          * Stateful allocator variant that uses an underlying CRT allocator
          * @tparam T type that allocator can allocate
          */
-        template <typename T> class StlAllocator : public std::allocator<T>
+        template <typename T> class AWS_CRT_CPP_API StlAllocator : public std::allocator<T>
         {
           public:
             using Base = std::allocator<T>;


### PR DESCRIPTION
**Issue:**
When building with GCC 4.8 and 4.9 and `-DBUILD_SHARED_LIBS=ON`, many tests were crashing. The crashes would say something like "free(): invalid pointer" and the stack trace would point into the c++ string headers.

**Things we tried**
- Crash stopped if we commented out the [recently-added line in CMakeLists.txt](https://github.com/awslabs/aws-crt-cpp/blob/80f4736126e14223a0c3882d3b734607143731f3/CMakeLists.txt#L305) line that sets `CXX_VISIBILITY_PRESET hidden`. So obviously symbol visibility has something to do with it.
- We tried adding adding `AWS_CRT_CPP_API` to the templated `StlAllocator` class (see https://github.com/awslabs/aws-crt-cpp/pull/675/commits/edfed1419841cd20bd21c0421861329f2deb2aad), which stopped GCC 4.x from crashing, but then the [Windows compiler didn't like that](https://github.com/awslabs/aws-crt-cpp/actions/runs/11636848409/job/32409003392#step:2:2373).

**Description of Changes:** 
Don't set visibility to hidden for GCC < 5. That's how we had it before. GCC 4.x is very old. This isn't the first time it's disappointed us

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
