### PR TITLE
stop building s2n via aws_prebuild_dependency()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,8 +83,8 @@ if(BUILD_DEPS)
     add_subdirectory(crt/aws-c-common)
 
     if(UNIX AND NOT APPLE AND NOT BYO_CRYPTO)
-        include(AwsPrebuildDependency)
         if(NOT USE_OPENSSL)
+            include(AwsPrebuildDependency)
 
             set(AWSLC_CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
 
@@ -116,14 +116,8 @@ if(BUILD_DEPS)
             )
         endif()
 
-        # prebuild s2n-tls.
-        aws_prebuild_dependency(
-            DEPENDENCY_NAME S2N
-            SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/crt/s2n
-            CMAKE_ARGUMENTS
-                -DUNSAFE_TREAT_WARNINGS_AS_ERRORS=OFF
-                -DBUILD_TESTING=OFF
-        )
+        set(UNSAFE_TREAT_WARNINGS_AS_ERRORS OFF CACHE BOOL "Disable warnings-as-errors when building S2N")
+        add_subdirectory(crt/s2n)
     endif()
 
     add_subdirectory(crt/aws-c-sdkutils)


### PR DESCRIPTION
**Issue:**
aws-sdk-cpp could no longer cross-compile for Android, after we switched to building S2N via [aws_prebuild_dependency()](https://github.com/awslabs/aws-c-common/blob/bb29dc816ac6fe8678765c3b869f47326b942367/cmake/AwsPrebuildDependency.cmake) in this PR: https://github.com/awslabs/aws-crt-cpp/pull/665

**Description of changes:**
Go back to building s2n via CMake's `add_subdirectory()`. This does a better job picking up misc CMake settings (like toolchains for cross-compilation) than `aws_prebuild_dependency()`

We'll continue building AWS-LC via `aws_prebuild_dependency()` for now, since we still need `libcrypto` fully built before S2N's configure stage. But that won't be a problem for `aws-sdk-cpp` which always passes `-DUSE_OPENSSL=ON` to skip building AWS-LC and use the system's pre-existing libcrypto instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
