### PR TITLE
Add topic argument to publish callback in request-response stream client

### DIFF
--- a/include/aws/iot/MqttRequestResponseClient.h
+++ b/include/aws/iot/MqttRequestResponseClient.h
@@ -121,22 +121,10 @@ namespace Aws
                 /**
                  * Default constructor
                  */
-                IncomingPublishEvent() : m_payload(), m_topic()
+                IncomingPublishEvent() : m_topic(), m_payload()
                 {
-                    AWS_ZERO_STRUCT(m_payload);
                     AWS_ZERO_STRUCT(m_topic);
-                }
-
-                /**
-                 * Sets the message payload associated with this event.  The event does not own this payload.
-                 *
-                 * @param payload the message payload associated with this event
-                 * @return reference to this
-                 */
-                IncomingPublishEvent &WithPayload(Aws::Crt::ByteCursor payload)
-                {
-                    m_payload = payload;
-                    return *this;
+                    AWS_ZERO_STRUCT(m_payload);
                 }
 
                 /**
@@ -152,11 +140,16 @@ namespace Aws
                 }
 
                 /**
-                 * Gets the message payload associated with this event.
+                 * Sets the message payload associated with this event.  The event does not own this payload.
                  *
-                 * @return the message payload associated with this event
+                 * @param payload the message payload associated with this event
+                 * @return reference to this
                  */
-                Aws::Crt::ByteCursor GetPayload() const { return m_payload; }
+                IncomingPublishEvent &WithPayload(Aws::Crt::ByteCursor payload)
+                {
+                    m_payload = payload;
+                    return *this;
+                }
 
                 /**
                  * Gets the message response topic associated with this event.
@@ -165,9 +158,16 @@ namespace Aws
                  */
                 Aws::Crt::ByteCursor GetTopic() const { return m_topic; }
 
+                /**
+                 * Gets the message payload associated with this event.
+                 *
+                 * @return the message payload associated with this event
+                 */
+                Aws::Crt::ByteCursor GetPayload() const { return m_payload; }
+
               private:
-                Aws::Crt::ByteCursor m_payload;
                 Aws::Crt::ByteCursor m_topic;
+                Aws::Crt::ByteCursor m_payload;
             };
 
             /**

--- a/include/aws/iot/MqttRequestResponseClient.h
+++ b/include/aws/iot/MqttRequestResponseClient.h
@@ -121,22 +121,10 @@ namespace Aws
                 /**
                  * Default constructor
                  */
-                IncomingPublishEvent() : m_topic(), m_payload()
+                IncomingPublishEvent() : m_payload(), m_topic()
                 {
-                    AWS_ZERO_STRUCT(m_topic);
                     AWS_ZERO_STRUCT(m_payload);
-                }
-
-                /**
-                 * Sets the message response topic associated with this event.  The event does not own this topic.
-                 *
-                 * @param topic the message response topic associated with this event
-                 * @return reference to this
-                 */
-                IncomingPublishEvent &WithTopic(Aws::Crt::ByteCursor topic)
-                {
-                    m_topic = topic;
-                    return *this;
+                    AWS_ZERO_STRUCT(m_topic);
                 }
 
                 /**
@@ -152,11 +140,16 @@ namespace Aws
                 }
 
                 /**
-                 * Gets the message response topic associated with this event.
+                 * Sets the message response topic associated with this event.  The event does not own this topic.
                  *
-                 * @return the message response topic associated with this event
+                 * @param topic the message response topic associated with this event
+                 * @return reference to this
                  */
-                Aws::Crt::ByteCursor GetTopic() const { return m_topic; }
+                IncomingPublishEvent &WithTopic(Aws::Crt::ByteCursor topic)
+                {
+                    m_topic = topic;
+                    return *this;
+                }
 
                 /**
                  * Gets the message payload associated with this event.
@@ -165,9 +158,16 @@ namespace Aws
                  */
                 Aws::Crt::ByteCursor GetPayload() const { return m_payload; }
 
+                /**
+                 * Gets the message response topic associated with this event.
+                 *
+                 * @return the message response topic associated with this event
+                 */
+                Aws::Crt::ByteCursor GetTopic() const { return m_topic; }
+
               private:
-                Aws::Crt::ByteCursor m_topic;
                 Aws::Crt::ByteCursor m_payload;
+                Aws::Crt::ByteCursor m_topic;
             };
 
             /**

--- a/include/aws/iot/MqttRequestResponseClient.h
+++ b/include/aws/iot/MqttRequestResponseClient.h
@@ -121,12 +121,28 @@ namespace Aws
                 /**
                  * Default constructor
                  */
-                IncomingPublishEvent() : m_payload() { AWS_ZERO_STRUCT(m_payload); }
+                IncomingPublishEvent() : m_topic(), m_payload()
+                {
+                    AWS_ZERO_STRUCT(m_topic);
+                    AWS_ZERO_STRUCT(m_payload);
+                }
+
+                /**
+                 * Sets the message response topic associated with this event.  The event does not own this topic.
+                 *
+                 * @param topic the message response topic associated with this event
+                 * @return reference to this
+                 */
+                IncomingPublishEvent &WithTopic(Aws::Crt::ByteCursor topic)
+                {
+                    m_topic = topic;
+                    return *this;
+                }
 
                 /**
                  * Sets the message payload associated with this event.  The event does not own this payload.
                  *
-                 * @param payload he message payload associated with this event
+                 * @param payload the message payload associated with this event
                  * @return reference to this
                  */
                 IncomingPublishEvent &WithPayload(Aws::Crt::ByteCursor payload)
@@ -136,6 +152,13 @@ namespace Aws
                 }
 
                 /**
+                 * Gets the message response topic associated with this event.
+                 *
+                 * @return the message response topic associated with this event
+                 */
+                Aws::Crt::ByteCursor GetTopic() const { return m_topic; }
+
+                /**
                  * Gets the message payload associated with this event.
                  *
                  * @return the message payload associated with this event
@@ -143,6 +166,7 @@ namespace Aws
                 Aws::Crt::ByteCursor GetPayload() const { return m_payload; }
 
               private:
+                Aws::Crt::ByteCursor m_topic;
                 Aws::Crt::ByteCursor m_payload;
             };
 

--- a/source/iot/MqttRequestResponseClient.cpp
+++ b/source/iot/MqttRequestResponseClient.cpp
@@ -89,7 +89,10 @@ namespace Aws
                     int error_code,
                     void *user_data);
 
-                static void OnIncomingPublishCallback(struct aws_byte_cursor payload, void *user_data);
+                static void OnIncomingPublishCallback(
+                    struct aws_byte_cursor payload,
+                    struct aws_byte_cursor topic,
+                    void *user_data);
 
                 static void OnTerminatedCallback(void *user_data);
 
@@ -187,7 +190,10 @@ namespace Aws
                 }
             }
 
-            void StreamingOperationImpl::OnIncomingPublishCallback(struct aws_byte_cursor payload, void *user_data)
+            void StreamingOperationImpl::OnIncomingPublishCallback(
+                struct aws_byte_cursor payload,
+                struct aws_byte_cursor topic,
+                void *user_data)
             {
                 auto *handle = static_cast<StreamingOperationImplHandle *>(user_data);
                 StreamingOperationImpl *impl = handle->m_impl.get();
@@ -198,7 +204,7 @@ namespace Aws
                     if (!impl->m_closed && impl->m_config.incomingPublishEventHandler)
                     {
                         IncomingPublishEvent event;
-                        event.WithPayload(payload);
+                        event.WithTopic(topic).WithPayload(payload);
 
                         impl->m_config.incomingPublishEventHandler(std::move(event));
                     }

--- a/tests/MqttRequestResponse.cpp
+++ b/tests/MqttRequestResponse.cpp
@@ -42,8 +42,8 @@ struct ResponseTracker
 
 struct TestPublishEvent
 {
-    Aws::Crt::String topic;
     Aws::Crt::String payload;
+    Aws::Crt::String topic;
 };
 
 struct TestState
@@ -174,13 +174,13 @@ static void s_onIncomingPublishEvent(Aws::Iot::RequestResponse::IncomingPublishE
     {
         std::unique_lock<std::mutex> lock(state->lock);
 
-        auto topicCursor = event.GetTopic();
-        Aws::Crt::String topicAsString((const char *)topicCursor.ptr, topicCursor.len);
-
         auto payloadCursor = event.GetPayload();
         Aws::Crt::String payloadAsString((const char *)payloadCursor.ptr, payloadCursor.len);
 
-        state->incomingPublishEvents.push_back({std::move(topicAsString), std::move(payloadAsString)});
+        auto topicCursor = event.GetTopic();
+        Aws::Crt::String topicAsString((const char *)topicCursor.ptr, topicCursor.len);
+
+        state->incomingPublishEvents.push_back({std::move(payloadAsString), std::move(topicAsString)});
     }
     state->signal.notify_one();
 }
@@ -1088,7 +1088,7 @@ static int s_doShadowUpdatedStreamIncomingPublishTest(Aws::Crt::Allocator *alloc
     s_waitForIncomingPublishWithPredicate(
         &state,
         [&uuid](const TestPublishEvent &publishEvent)
-        { return publishEvent.topic == uuid && publishEvent.payload == Aws::Crt::String(s_publishPayload); });
+        { return publishEvent.payload == Aws::Crt::String(s_publishPayload) && publishEvent.topic == uuid; });
 
     return AWS_OP_SUCCESS;
 }

--- a/tests/MqttRequestResponse.cpp
+++ b/tests/MqttRequestResponse.cpp
@@ -42,8 +42,8 @@ struct ResponseTracker
 
 struct TestPublishEvent
 {
-    Aws::Crt::String payload;
     Aws::Crt::String topic;
+    Aws::Crt::String payload;
 };
 
 struct TestState
@@ -174,13 +174,13 @@ static void s_onIncomingPublishEvent(Aws::Iot::RequestResponse::IncomingPublishE
     {
         std::unique_lock<std::mutex> lock(state->lock);
 
-        auto payloadCursor = event.GetPayload();
-        Aws::Crt::String payloadAsString((const char *)payloadCursor.ptr, payloadCursor.len);
-
         auto topicCursor = event.GetTopic();
         Aws::Crt::String topicAsString((const char *)topicCursor.ptr, topicCursor.len);
 
-        state->incomingPublishEvents.push_back({std::move(payloadAsString), std::move(topicAsString)});
+        auto payloadCursor = event.GetPayload();
+        Aws::Crt::String payloadAsString((const char *)payloadCursor.ptr, payloadCursor.len);
+
+        state->incomingPublishEvents.push_back({std::move(topicAsString), std::move(payloadAsString)});
     }
     state->signal.notify_one();
 }
@@ -1088,7 +1088,7 @@ static int s_doShadowUpdatedStreamIncomingPublishTest(Aws::Crt::Allocator *alloc
     s_waitForIncomingPublishWithPredicate(
         &state,
         [&uuid](const TestPublishEvent &publishEvent)
-        { return publishEvent.payload == Aws::Crt::String(s_publishPayload) && publishEvent.topic == uuid; });
+        { return publishEvent.topic == uuid && publishEvent.payload == Aws::Crt::String(s_publishPayload); });
 
     return AWS_OP_SUCCESS;
 }


### PR DESCRIPTION
*Issue #, if available:*
Service client might need a topic where a stream's publish message was received.

Description of changes:
Add a topic argument to incoming publish callback.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
