### PR TITLE
Fix Arm based ci steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,6 @@ jobs:
       with:
         role-to-assume: ${{ env.CRT_CI_ROLE }}
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
-    - name: Install qemu/docker
-      run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
     - name: Build ${{ env.PACKAGE_NAME }}
       run: |
         aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
@@ -121,7 +119,7 @@ jobs:
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
     # set arm arch
     - name: Install qemu/docker
-      run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      run: docker run --privileged --rm tonistiigi/binfmt --install linux/arm/v7
 
     - name: Build ${{ env.PACKAGE_NAME }}
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
   # that are up-to-date (AL2) or don't provide OpenSSL development packages that is found in CMake (alpine)
   # or are not able to connect on the socket even with the correct setup (manylinux2014)
   linux-compat:
-    runs-on: ubuntu-22.04 # temporarily downgrade to old ubuntu until https://github.com/actions/runner-images/issues/11471 resolves
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -68,7 +68,7 @@ jobs:
         role-to-assume: ${{ env.CRT_CI_ROLE }}
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
     - name: Install qemu/docker
-      run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      run: docker run --privileged --rm tonistiigi/binfmt --install all
     - name: Build ${{ env.PACKAGE_NAME }}
       run: |
         aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We rely on qemu to test aarch64 on x86-64 github runners.
Qemu had a bug where they had a bug with incorrectly mapping address space. That mostly worked fine until kernel patch that increased entropy in their address randomization. TLDR; qemu likes to segfault a lot against new kernels on our aarch64 test. Solution is to switch to a different github qemu user static image that forces a latest version of qemu, that has the bug fixed.
if you want to read more - https://github.com/tonistiigi/binfmt/issues/240


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
