### PR TITLE
Fix flaky CBOR test

### DIFF
--- a/tests/CborTest.cpp
+++ b/tests/CborTest.cpp
@@ -184,8 +184,8 @@ static int s_decode_timestamp_helper(Cbor::CborDecoder &decoder, std::chrono::sy
         {
             double double_val = decoder.PopNextFloatVal().value();
             std::chrono::duration<double, std::chrono::seconds::period> timestamp(double_val);
-            outTimePoint =
-                std::chrono::system_clock::time_point(std::chrono::duration_cast<std::chrono::milliseconds>(timestamp));
+            outTimePoint = std::chrono::system_clock::time_point(
+                std::chrono::duration_cast<std::chrono::system_clock::duration>(timestamp));
             return AWS_OP_SUCCESS;
         }
         default:


### PR DESCRIPTION
**Issue:**

Rare random failure of  "CborTimeStampTest" (see [logs](https://github.com/awslabs/aws-crt-cpp/actions/runs/13912044756/job/38928108124?pr=717#step:3:3011))

**Diagnosis:**

This test does:
- get timestamp from current `std::chrono::time_point<std::chrono::system_clock>
- CBOR encode timestamp as seconds-as-64bit-floating-point
- decode timestamp
- compare original timestamp with encoded/decoded timestam
  - deal with floating point precision differences by casting to milliseconds-as-integer before comparing

The flow above seems good. There are some differences in floating point precision, but we ultimately compare the values at lower precision (milliseconds-as-integer). So what's up???

**Description of changes:**

Fix helper function that loses lots of precision, due to too much casting back and forth between `floating-point` -> `integer` -> `floating-point` -> `integer`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
