### PR TITLE
Fix "std-compat" CI to actually test what it's supposed to

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
     strategy:
       matrix:
         compiler: [gcc-8, clang-9]
-        cxx-std: ["11", "14", "17", "20", "23"]
+        cxx-std: ["11", "14", "17", "20"]
     steps:
     - uses: aws-actions/configure-aws-credentials@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
     - name: Build ${{ env.PACKAGE_NAME }} with cxx${{ matrix.cxx-std }}
       run: |
         aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
-        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=${{ matrix.compiler }} --cmake-extra=-DUSE_OPENSSL=ON --cmake-extra=-DCMAKE_CXX_STANDARD=${{ matrix.cxx-std }}
+        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=${{ matrix.compiler }} --cmake-extra=-DUSE_OPENSSL=ON --cmake-extra=-DCMAKE_CXX_STANDARD=${{ matrix.cxx-std }} --cmake-extra=-DCMAKE_VERBOSE_MAKEFILE=ON
 
   byo-crypto:
     runs-on: ubuntu-24.04 # latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,18 +131,17 @@ jobs:
     strategy:
       matrix:
         compiler: [gcc-8, clang-9]
-        std: [c++11, c++14, c++17, c++2a]
+        cxx-std: ["11", "14", "17", "20", "23"]
     steps:
     - uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ env.CRT_CI_ROLE }}
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
     # We can't use the `uses: docker://image` version yet, GitHub lacks authentication for actions -> packages
-    - name: Build ${{ env.PACKAGE_NAME }} with ${{ matrix.std }}
+    - name: Build ${{ env.PACKAGE_NAME }} with cxx${{ matrix.cxx-std }}
       run: |
-        export CXXFLAGS=-std=${{ matrix.std }}
         aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
-        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=${{ matrix.compiler }} --cmake-extra=-DUSE_OPENSSL=ON
+        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=${{ matrix.compiler }} --cmake-extra=-DUSE_OPENSSL=ON --cmake-extra=-DCMAKE_CXX_STANDARD=${{ matrix.cxx-std }}
 
   byo-crypto:
     runs-on: ubuntu-24.04 # latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - 'docs'
 
 env:
-  BUILDER_VERSION: v0.9.73
+  BUILDER_VERSION: v0.9.76
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-crt-cpp
@@ -141,7 +141,7 @@ jobs:
     - name: Build ${{ env.PACKAGE_NAME }} with cxx${{ matrix.cxx-std }}
       run: |
         aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
-        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=${{ matrix.compiler }} --cmake-extra=-DUSE_OPENSSL=ON --cmake-extra=-DCMAKE_CXX_STANDARD=${{ matrix.cxx-std }} --cmake-extra=-DCMAKE_VERBOSE_MAKEFILE=ON
+        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=${{ matrix.compiler }} --cmake-extra=-DUSE_OPENSSL=ON --cmake-extra=-DCMAKE_CXX_STANDARD=${{ matrix.cxx-std }}
 
   byo-crypto:
     runs-on: ubuntu-24.04 # latest


### PR DESCRIPTION
**Issue:**

The "std-compat" CI isn't doing what it's supposed to: building aws-crt-cpp with different versions of the C++ std.

It broke accidentally when [this commit](https://github.com/awslabs/aws-crt-cpp/commit/eaaaa60e3810ae33435c08c515f0be888e1af55d) stopped passing `--env CXXFLAGS` to the container.

**Description of changes:**

Fix it, so C++ version is passed to the container.

Set it via `CMAKE_CXX_STANDARD=11`, instead of via `CXXFLAGS=-std=c++11`, since this is the "more correct" way to tell CMake the C++ standard you want. Doing it via `CXXFLAGS=-std=c++11` can (depending on the version of CMake you're using) force compiler extensions to be disabled.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
