### PR TITLE
Add const specifier to UUID comparison operators

### DIFF
--- a/include/aws/crt/UUID.h
+++ b/include/aws/crt/UUID.h
@@ -23,8 +23,8 @@ namespace Aws
 
             UUID &operator=(const String &str) noexcept;
 
-            bool operator==(const UUID &other) noexcept;
-            bool operator!=(const UUID &other) noexcept;
+            bool operator==(const UUID &other) const noexcept;
+            bool operator!=(const UUID &other) const noexcept;
             operator String() const;
             operator ByteBuf() const noexcept;
 

--- a/source/UUID.cpp
+++ b/source/UUID.cpp
@@ -31,12 +31,12 @@ namespace Aws
             return *this;
         }
 
-        bool UUID::operator==(const UUID &other) noexcept
+        bool UUID::operator==(const UUID &other) const noexcept
         {
             return aws_uuid_equals(&m_uuid, &other.m_uuid);
         }
 
-        bool UUID::operator!=(const UUID &other) noexcept
+        bool UUID::operator!=(const UUID &other) const noexcept
         {
             return !aws_uuid_equals(&m_uuid, &other.m_uuid);
         }


### PR DESCRIPTION
*Issue #, if available:*

Comparison operators in `UUID` don't have `const` specifier. For the C++20 standard, this leads to the following warning:
```
/home/runner/work/***/***/aws-crt-cpp/tests/UUIDTest.cpp:22:26: error: ISO C++20 considers use
of overloaded operator '==' (with operand types 'Aws::Crt::UUID' and 'Aws::Crt::UUID') to be ambiguous
despite there being a unique best viable function [-Werror,-Wambiguous-reversed-operator]
```

The reason is C++20 rules for generating reversed oeprators: https://timsong-cpp.github.io/cppwp/n4861/over.match#oper-3.4.4

See a live example: https://godbolt.org/z/PcEqY7x5z

**NOTE**: The warning for `UUID` appears only for clang-13, clang-14, and clang-15. In clang-16, they resolved
the `-Wambiguous-reversed-operator` warning for cases when a matching `operator!=` is implemented.

*Description of changes:*

Adding `const` specifier removes ambiguity.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
