### PR TITLE
Increase Operation Timeout in CI for Req/Resp Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on:
+on: 
   push:
     branches-ignore:
       - 'main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: 
+on:
   push:
     branches-ignore:
       - 'main'

--- a/tests/MqttRequestResponse.cpp
+++ b/tests/MqttRequestResponse.cpp
@@ -259,7 +259,7 @@ static TestContext s_CreateClient(
     {
         finalOptions.WithMaxRequestResponseSubscriptions(4);
         finalOptions.WithMaxStreamingSubscriptions(2);
-        finalOptions.WithOperationTimeoutInSeconds(5);
+        finalOptions.WithOperationTimeoutInSeconds(30);
     }
 
     if (protocol == ProtocolType::Mqtt5)


### PR DESCRIPTION
Bump up the operation timeout for Request Response client test from 5 seconds to 30. 

MqttRequestResponse_UpdateNamedShadowSuccessAccepted311 was potentially failing due to the timeout on a successful subscribe not receiving a suback within 5 seconds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
