### PR TITLE
Fix warnings for latest LLVM compiler update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
           - clang-12
           - clang-15
           - clang-17
+          - clang-21
           - gcc-4.8
           - gcc-5
           - gcc-6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
       - 'docs'
 
 env:
-  BUILDER_VERSION: clang_21
-  BUILDER_SOURCE: channels
+  BUILDER_VERSION: v0.9.76
+  BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-crt-cpp
   LINUX_BASE_IMAGE: ubuntu-18-x64
@@ -86,7 +86,6 @@ jobs:
           - clang-12
           - clang-15
           - clang-17
-          - clang-21
           - gcc-4.8
           - gcc-5
           - gcc-6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
       - 'docs'
 
 env:
-  BUILDER_VERSION: v0.9.76
-  BUILDER_SOURCE: releases
+  BUILDER_VERSION: clang_21
+  BUILDER_SOURCE: channels
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-crt-cpp
   LINUX_BASE_IMAGE: ubuntu-18-x64

--- a/include/aws/crt/mqtt/Mqtt5Client.h
+++ b/include/aws/crt/mqtt/Mqtt5Client.h
@@ -433,7 +433,7 @@ namespace Aws
                  */
                 const Mqtt5ClientOperationStatistics &GetOperationStatistics() noexcept;
 
-                virtual ~Mqtt5Client();
+                ~Mqtt5Client();
 
                 struct aws_mqtt5_client *GetUnderlyingHandle() const noexcept;
 
@@ -696,7 +696,7 @@ namespace Aws
                  */
                 bool initializeRawOptions(aws_mqtt5_client_options &raw_options) const noexcept;
 
-                virtual ~Mqtt5ClientOptions();
+                ~Mqtt5ClientOptions();
                 Mqtt5ClientOptions(const Mqtt5ClientOptions &) = delete;
                 Mqtt5ClientOptions(Mqtt5ClientOptions &&) = delete;
                 Mqtt5ClientOptions &operator=(const Mqtt5ClientOptions &) = delete;

--- a/include/aws/crt/mqtt/private/Mqtt5ClientCore.h
+++ b/include/aws/crt/mqtt/private/Mqtt5ClientCore.h
@@ -107,7 +107,7 @@ namespace Aws
                  */
                 void Close() noexcept;
 
-                virtual ~Mqtt5ClientCore();
+                ~Mqtt5ClientCore();
 
                 struct aws_mqtt5_client *GetUnderlyingHandle() const noexcept { return m_client; }
 

--- a/include/aws/iot/Mqtt5Client.h
+++ b/include/aws/iot/Mqtt5Client.h
@@ -474,7 +474,7 @@ namespace Aws
              */
             int LastError() const noexcept { return m_lastError ? m_lastError : AWS_ERROR_UNKNOWN; }
 
-            virtual ~Mqtt5ClientBuilder()
+            ~Mqtt5ClientBuilder()
             {
                 if (m_options)
                 {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
LLVM recently added a [new warning](https://github.com/llvm/llvm-project/pull/131188) for virtual methods in final classes. Mqtt5Client and Mqtt5ClientOptions are final and have virtual members, so they trigger this warning. Fixed it and add compiler validation for clang21

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
