### PR TITLE
add binding for sts web identity provider

### DIFF
--- a/include/aws/crt/auth/Credentials.h
+++ b/include/aws/crt/auth/Credentials.h
@@ -448,6 +448,48 @@ namespace Aws
             };
 
             /**
+             * Configuration options for the STS Web Identity credentials provider
+             */
+            struct AWS_CRT_CPP_API CredentialsProviderSTSWebIdentityConfig
+            {
+                CredentialsProviderSTSWebIdentityConfig();
+
+                /**
+                 * Arn of the role to assume by fetching credentials for
+                 */
+                String RoleArn;
+
+                /**
+                 * Assumed role session identifier to be associated with the sourced credentials
+                 */
+                String SessionName;
+
+                /**
+                 * Region used for STS call
+                 */
+                String Region;
+
+                /**
+                 * The OAuth 2.0 access token or OpenID Connect ID token
+                 */
+                String TokenFilePath;
+
+                /**
+                 * Connection bootstrap to use to create the http connection required to
+                 * query credentials from the STS provider
+                 *
+                 * Note: If null, then the default ClientBootstrap is used
+                 * (see Aws::Crt::ApiHandle::GetOrCreateStaticDefaultClientBootstrap)
+                 */
+                Io::ClientBootstrap *Bootstrap;
+
+                /**
+                 * TLS configuration for secure socket connections.
+                 */
+                Io::TlsContext TlsCtx;
+            };
+
+            /**
              * Simple credentials provider implementation that wraps one of the internal C-based implementations.
              *
              * Contains a set of static factory methods for building each supported provider, as well as one for the
@@ -572,6 +614,10 @@ namespace Aws
                  */
                 static std::shared_ptr<ICredentialsProvider> CreateCredentialsProviderSTS(
                     const CredentialsProviderSTSConfig &config,
+                    Allocator *allocator = ApiAllocator());
+
+                static std::shared_ptr<ICredentialsProvider> CreateCredentialsProviderSTSWebIdentity(
+                    const CredentialsProviderSTSWebIdentityConfig &config,
                     Allocator *allocator = ApiAllocator());
 
               private:

--- a/source/auth/Credentials.cpp
+++ b/source/auth/Credentials.cpp
@@ -475,6 +475,29 @@ namespace Aws
 
                 return s_CreateWrappedProvider(aws_credentials_provider_new_sts(allocator, &raw_config), allocator);
             }
+
+            CredentialsProviderSTSWebIdentityConfig::CredentialsProviderSTSWebIdentityConfig() : Bootstrap(nullptr) {}
+
+            std::shared_ptr<ICredentialsProvider> CredentialsProvider::CreateCredentialsProviderSTSWebIdentity(
+                const CredentialsProviderSTSWebIdentityConfig &config,
+                Allocator *allocator)
+            {
+                struct aws_credentials_provider_sts_web_identity_options raw_config;
+                AWS_ZERO_STRUCT(raw_config);
+
+                raw_config.region = aws_byte_cursor_from_c_str(config.Region.c_str());
+                raw_config.role_arn = aws_byte_cursor_from_c_str(config.RoleArn.c_str());
+                raw_config.role_session_name = aws_byte_cursor_from_c_str(config.SessionName.c_str());
+                raw_config.token_file_path = aws_byte_cursor_from_c_str(config.TokenFilePath.c_str());
+
+                raw_config.bootstrap =
+                    config.Bootstrap ? config.Bootstrap->GetUnderlyingHandle()
+                                     : ApiHandle::GetOrCreateStaticDefaultClientBootstrap()->GetUnderlyingHandle();
+
+                raw_config.tls_ctx = config.TlsCtx.GetUnderlyingHandle();
+                return s_CreateWrappedProvider(
+                    aws_credentials_provider_new_sts_web_identity(allocator, &raw_config), allocator);
+            }
         } // namespace Auth
     } // namespace Crt
 } // namespace Aws

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -126,6 +126,7 @@ add_test_case(TestProviderImdsGet)
 if(NOT BYO_CRYPTO)
     add_net_test_case(TestProviderDefaultChainGet)
     add_net_test_case(TestProviderDefaultChainManualTlsContextGet)
+    add_test_case(STSWebIdentityCredentialsProviderFailureTest)
 endif()
 
 add_test_case(TestProviderDelegateGet)


### PR DESCRIPTION
*Description of changes:*

Adds a binding for [`credentials_provider_sts_web_identity.`](https://github.com/awslabs/aws-c-auth/blob/main/include/aws/auth/credentials.h#L1166-L1177). almost identical to what we have for the normal [STS provider](https://github.com/awslabs/aws-crt-cpp/blob/main/include/aws/crt/auth/Credentials.h#L570-L575).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
