### PR TITLE
update web identity context to use connection options instead of context

### DIFF
--- a/include/aws/crt/auth/Credentials.h
+++ b/include/aws/crt/auth/Credentials.h
@@ -491,7 +491,7 @@ namespace Aws
                 /**
                  * TLS configuration for secure socket connections.
                  */
-                Io::TlsContext TlsCtx;
+                Io::TlsConnectionOptions TlsConnectionOptions;
             };
 
             /**

--- a/source/auth/Credentials.cpp
+++ b/source/auth/Credentials.cpp
@@ -506,7 +506,11 @@ namespace Aws
                     config.Bootstrap ? config.Bootstrap->GetUnderlyingHandle()
                                      : ApiHandle::GetOrCreateStaticDefaultClientBootstrap()->GetUnderlyingHandle();
 
-                raw_config.tls_ctx = config.TlsCtx.GetUnderlyingHandle();
+                const auto connectionOptions = config.TlsConnectionOptions.GetUnderlyingHandle();
+                if (connectionOptions != nullptr)
+                {
+                    raw_config.tls_ctx = connectionOptions->ctx;
+                }
                 return s_CreateWrappedProvider(
                     aws_credentials_provider_new_sts_web_identity(allocator, &raw_config), allocator);
             }

--- a/tests/CredentialsTest.cpp
+++ b/tests/CredentialsTest.cpp
@@ -637,10 +637,11 @@ static int s_DoSTSWebIdentityCredentialsProviderFailureTest(struct aws_allocator
 
         Aws::Crt::Io::TlsContextOptions tlsOptions = Aws::Crt::Io::TlsContextOptions::InitDefaultClient(allocator);
         Aws::Crt::Io::TlsContext tlsContext(tlsOptions, Aws::Crt::Io::TlsMode::CLIENT, allocator);
+        const auto connectionOptions = tlsContext.NewConnectionOptions();
 
         CredentialsProviderSTSWebIdentityConfig config;
         config.Bootstrap = &clientBootstrap;
-        config.TlsCtx = tlsContext;
+        config.TlsConnectionOptions = connectionOptions;
         config.RoleArn = "arn:aws:iam::123456789012:role/role-name";
         config.Region = "us-east-1";
         config.TokenFilePath = "/not/a/real/file/path";


### PR DESCRIPTION
*Description of changes:*

Coming from https://github.com/aws/aws-sdk-cpp/pull/3505 its apparently that `TlsContext` should be `TlsConnectionOptions` instead as that is what the SDK overrides, and `TlsContext` has a helper method to spawn new connection options but not the other way around. This is acutally how it is also done in [`CredentialsProviderX509Config`](https://github.com/awslabs/aws-crt-cpp/blob/main/include/aws/crt/auth/Credentials.h#L312)



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
