### PR TITLE
CI Jobs fail-fast False

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
   linux-compat-use-openssl:
     runs-on: ubuntu-24.04 # latest
     strategy:
+      fail-fast: false
       matrix:
         image:
           - fedora-34-x64
@@ -76,6 +77,7 @@ jobs:
   linux-compiler-compat:
     runs-on: ubuntu-24.04 # latest
     strategy:
+      fail-fast: false
       matrix:
         compiler:
           - clang-6
@@ -130,6 +132,7 @@ jobs:
   std-compat:
     runs-on: ubuntu-24.04 # latest
     strategy:
+      fail-fast: false
       matrix:
         compiler: [gcc-8, clang-9]
         cxx-std: ["11", "14", "17", "20"]
@@ -160,6 +163,7 @@ jobs:
   linux-shared-libs:
     runs-on: ubuntu-24.04 # latest
     strategy:
+      fail-fast: false
       matrix:
         compiler: [gcc-4.8, gcc-11] # oldest, latest
     steps:
@@ -239,6 +243,7 @@ jobs:
   windows-vc17:
     runs-on: windows-2025 # latest
     strategy:
+      fail-fast: false
       matrix:
         arch: [x86, x64]
     steps:
@@ -339,6 +344,7 @@ jobs:
     name: Cross Compile ${{matrix.arch}}
     runs-on: ubuntu-24.04 # latest
     strategy:
+      fail-fast: false
       matrix:
         arch: [linux-armv6, linux-armv7, linux-arm64, android-armv7]
 
@@ -389,6 +395,7 @@ jobs:
   clang-sanitizers:
     runs-on: ubuntu-24.04 # latest
     strategy:
+      fail-fast: false
       matrix:
         sanitizers: ["thread", "address,undefined"]
     steps:


### PR DESCRIPTION
Set fail-fast to false on all CI jobs using a matrix. This will allow us to better track what is failing and why.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
