### PR TITLE
Error handling added to EnforceSubmoduleVersions

### DIFF
--- a/tests/Mqtt5ClientTest.cpp
+++ b/tests/Mqtt5ClientTest.cpp
@@ -2927,7 +2927,7 @@ AWS_TEST_CASE(Mqtt5to3AdapterNewClientFull, s_TestMqtt5to3AdapterNewClientFull)
  */
 static int s_TestMqtt5to3AdapterDirectConnectionMinimalThroughMqtt3(Aws::Crt::Allocator *allocator, void *)
 {
-    Mqtt5TestEnvVars mqtt5TestVars(allocator, MQTT5CONNECT_IOT_CORE);
+    Mqtt5TestEnvVars mqtt5TestVars(allocator, MQTT5CONNECT_DIRECT);
     if (!mqtt5TestVars)
     {
         printf("Environment Variables are not set for the test, skip the test");


### PR DESCRIPTION
EnforceSubmoduleVersions.cmake function `check_submodule_commit()` could fail on `execute_process()` function calls silently causing the submodule check itself to fail.

Changed the function to return with a STATUS message if an errors and if at any point during the submodule check outside of the final check itself. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
