### PR TITLE
Update CborDecoder class's lastErrror to be initialized

### DIFF
--- a/include/aws/crt/cbor/Cbor.h
+++ b/include/aws/crt/cbor/Cbor.h
@@ -359,7 +359,7 @@ namespace Aws
               private:
                 struct aws_cbor_decoder *m_decoder;
                 /* Error */
-                int m_lastError;
+                int m_lastError = AWS_ERROR_UNKNOWN;
             };
         } // namespace Cbor
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
CborDecoder class's lastErrror to be initialized with AWS_ERROR_UNKNOWN

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
