### PR TITLE
CborDecoder initialize m_lastError in constructor

### DIFF
--- a/source/cbor/Cbor.cpp
+++ b/source/cbor/Cbor.cpp
@@ -120,6 +120,7 @@ namespace Aws
              *
              *****************************************************/
             CborDecoder::CborDecoder(ByteCursor src, Crt::Allocator *allocator) noexcept
+                : m_lastError(AWS_ERROR_SUCCESS)
             {
                 m_decoder = aws_cbor_decoder_new(allocator, src);
             }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -316,6 +316,7 @@ endif()
 
 add_test_case(CborSanityTest)
 add_test_case(CborTimeStampTest)
+add_test_case(CborLastErrorTest)
 
 generate_cpp_test_driver(${TEST_BINARY_NAME})
 

--- a/tests/CborTest.cpp
+++ b/tests/CborTest.cpp
@@ -240,3 +240,20 @@ static int s_CborTimeStampTest(struct aws_allocator *allocator, void *ctx)
 }
 
 AWS_TEST_CASE(CborTimeStampTest, s_CborTimeStampTest)
+
+static int s_CborLastErrorTest(struct aws_allocator *allocator, void *ctx)
+{
+    /**
+     * Test the last error is initialzed correctly.
+     */
+    (void)ctx;
+    {
+        ApiHandle apiHandle(allocator);
+        Cbor::CborDecoder decoder({});
+        ASSERT_INT_EQUALS(decoder.LastError(), AWS_ERROR_UNKNOWN);
+    }
+
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(CborLastErrorTest, s_CborLastErrorTest)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
CborDecoder initialize m_lastError in constructor to AWS_ERROR_SUCCESS instead of it holding a garbage value

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
