### PR TITLE
Skip IoT WS tests when relevant environment variable is not set

### DIFF
--- a/tests/Mqtt5ClientTest.cpp
+++ b/tests/Mqtt5ClientTest.cpp
@@ -356,6 +356,11 @@ struct Mqtt5TestEnvVars
                 {
                     return;
                 }
+                if (m_hostname == NULL)
+                {
+                    m_error = AWS_OP_ERR;
+                    return;
+                }
                 m_hostname_string = aws_string_c_str(m_hostname);
                 break;
             }


### PR DESCRIPTION
Don't run IoT WS tests if iot host name environment variable is not set.

https://github.com/awslabs/aws-crt-cpp/issues/844


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
