### PR TITLE
Keep reference to proxy strategy options on connection

### DIFF
--- a/source/http/HttpConnection.cpp
+++ b/source/http/HttpConnection.cpp
@@ -23,6 +23,7 @@ namespace Aws
                 Allocator *allocator;
                 OnConnectionSetup onConnectionSetup;
                 OnConnectionShutdown onConnectionShutdown;
+                std::shared_ptr<HttpProxyStrategy> proxyStrategy;
             };
 
             class UnmanagedConnection final : public HttpClientConnection
@@ -172,6 +173,11 @@ namespace Aws
                     proxyOpts.InitializeRawProxyOptions(proxyOptions);
 
                     options.proxy_options = &proxyOptions;
+                    /* Note: this is a bit atypical from what we usually do, but c proxy strategy can have a weak ref to
+                       c++ class, looking at you AdaptiveHttpProxyStrategy. And we need lifetime of ProxyStrategy to be
+                       inline with underlying c structs. So keeping a ref to shared ptr, to make sure it survives after
+                       options are gone. */
+                    callbackData->proxyStrategy = proxyOpts.ProxyStrategy;
                 }
 
                 if (aws_http_client_connect(&options))

--- a/source/http/HttpConnection.cpp
+++ b/source/http/HttpConnection.cpp
@@ -177,7 +177,7 @@ namespace Aws
                        c++ class, looking at you AdaptiveHttpProxyStrategy. And we need lifetime of ProxyStrategy to be
                        inline with underlying c structs. So keeping a ref to shared ptr, to make sure it survives after
                        options are gone. */
-                    callbackData->proxyStrategy = proxyOpts.ProxyStrategy;
+                    //callbackData->proxyStrategy = proxyOpts.ProxyStrategy;
                 }
 
                 if (aws_http_client_connect(&options))

--- a/source/http/HttpConnection.cpp
+++ b/source/http/HttpConnection.cpp
@@ -177,7 +177,7 @@ namespace Aws
                        c++ class, looking at you AdaptiveHttpProxyStrategy. And we need lifetime of ProxyStrategy to be
                        inline with underlying c structs. So keeping a ref to shared ptr, to make sure it survives after
                        options are gone. */
-                    //callbackData->proxyStrategy = proxyOpts.ProxyStrategy;
+                    callbackData->proxyStrategy = proxyOpts.ProxyStrategy;
                 }
 
                 if (aws_http_client_connect(&options))

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -180,6 +180,9 @@ if(ENABLE_PROXY_INTEGRATION_TESTS AND NOT BYO_CRYPTO)
     add_test_case(DirectConnectionTunnelingProxyBasicAuthDeprecated)
     add_test_case(DirectConnectionTunnelingProxyBasicAuth)
 
+    # proxy strategy lifetime regression test
+    add_test_case(AdaptiveProxyStrategyLifetime)
+
     # x509 provider proxy tests
     add_test_case(X509ProxyHttpGetCredentials)
     add_test_case(X509ProxyHttpsGetCredentials)

--- a/tests/ProxyTest.cpp
+++ b/tests/ProxyTest.cpp
@@ -566,6 +566,7 @@ static int s_TestDirectConnectionTunnelingProxyHttp(struct aws_allocator *alloca
         s_InitializeProxiedRawConnection(testState, aws_byte_cursor_from_string(s_https_endpoint));
 
         ASSERT_TRUE(testState.m_connection != nullptr);
+        ASSERT_INT_EQUALS(testState.m_proxyOptions.ProxyStrategy.use_count(), 3);
     }
 
     /* now let everything tear down and make sure we don't leak or deadlock.*/
@@ -698,9 +699,6 @@ static int s_TestDirectConnectionTunnelingProxyBasicAuth(struct aws_allocator *a
 
         s_InitializeProxiedRawConnection(testState, aws_byte_cursor_from_string(s_https_endpoint));
         ASSERT_TRUE(testState.m_connection != nullptr);
-
-        testState.m_proxyOptions.ProxyStrategy.reset();
-        testState.m_connectionOptions.ProxyOptions->ProxyStrategy.reset();
     }
 
     /* now let everything tear down and make sure we don't leak or deadlock.*/

--- a/tests/ProxyTest.cpp
+++ b/tests/ProxyTest.cpp
@@ -566,6 +566,7 @@ static int s_TestDirectConnectionTunnelingProxyHttp(struct aws_allocator *alloca
         s_InitializeProxiedRawConnection(testState, aws_byte_cursor_from_string(s_https_endpoint));
 
         ASSERT_TRUE(testState.m_connection != nullptr);
+        ASSERT_INT_EQUALS(testState.m_proxyOptions.ProxyStrategy.use_count(), 3);
     }
 
     /* now let everything tear down and make sure we don't leak or deadlock.*/
@@ -573,74 +574,6 @@ static int s_TestDirectConnectionTunnelingProxyHttp(struct aws_allocator *alloca
 }
 
 AWS_TEST_CASE(DirectConnectionTunnelingProxyHttp, s_TestDirectConnectionTunnelingProxyHttp)
-
-/*
- * Regression test for the AdaptiveHttpProxyStrategy lifetime bug:
- * CreateAdaptiveHttpProxyStrategy() stores a raw pointer (user_data) to the C++ AdaptiveHttpProxyStrategy
- * in the C-layer aws_http_proxy_strategy. If the C++ shared_ptr is not retained by the connection
- * infrastructure, the C++ object gets destroyed when the caller's options go out of scope, leaving a
- * dangling user_data pointer in the still-alive C strategy.
- *
- * This test verifies that CreateConnection retains the ProxyStrategy shared_ptr so it outlives
- * the caller's options struct, preventing use-after-free when the C layer invokes strategy callbacks.
- */
-static int s_TestAdaptiveProxyStrategyLifetime(struct aws_allocator *allocator, void *ctx)
-{
-    (void)ctx;
-    {
-        Aws::Crt::ApiHandle apiHandle(allocator);
-
-        ProxyIntegrationTestState testState(allocator);
-        s_InitializeProxyEnvironmentalOptions(testState, HttpProxyTestHostType::Http);
-        testState.m_proxyOptions.ProxyConnectionType = AwsHttpProxyConnectionType::Tunneling;
-
-        HttpProxyStrategyAdaptiveConfig adaptiveConfig;
-        adaptiveConfig.KerberosGetToken = [](String &token)
-        {
-            token = "fake-kerberos-token";
-            return true;
-        };
-        adaptiveConfig.NtlmGetCredential = [](String &credential)
-        {
-            credential = "fake-ntlm-credential";
-            return true;
-        };
-        adaptiveConfig.NtlmGetToken = [](const String &, String &token)
-        {
-            token = "fake-ntlm-token";
-            return true;
-        };
-
-        testState.m_proxyOptions.ProxyStrategy =
-            HttpProxyStrategy::CreateAdaptiveHttpProxyStrategy(adaptiveConfig, allocator);
-        ASSERT_NOT_NULL(testState.m_proxyOptions.ProxyStrategy.get());
-
-        /* Grab a weak_ptr to the strategy so we can observe its lifetime independently. */
-        std::weak_ptr<HttpProxyStrategy> strategyObserver = testState.m_proxyOptions.ProxyStrategy;
-
-        s_InitializeProxiedRawConnection(testState, aws_byte_cursor_from_string(s_https_endpoint));
-
-        ASSERT_TRUE(testState.m_connection != nullptr);
-
-        /*
-         * Simulate the documented usage pattern: the caller's options go out of scope.
-         * Reset the ProxyStrategy in the options struct - if CreateConnection did NOT retain
-         * a copy, the strategy would be destroyed here (use_count drops to 0).
-         */
-        testState.m_proxyOptions.ProxyStrategy.reset();
-
-        /* The strategy must still be alive - the connection infrastructure must hold a reference. */
-        ASSERT_FALSE(strategyObserver.expired());
-
-        /* The connection is still active. In the buggy code, the underlying C strategy would now hold
-         * a dangling user_data pointer to the freed AdaptiveHttpProxyStrategy object. */
-    }
-
-    /* now let everything tear down and make sure we don't leak or deadlock.*/
-    return AWS_OP_SUCCESS;
-}
-
-AWS_TEST_CASE(AdaptiveProxyStrategyLifetime, s_TestAdaptiveProxyStrategyLifetime)
 
 static int s_TestDirectConnectionTunnelingProxyHttps(struct aws_allocator *allocator, void *ctx)
 {

--- a/tests/ProxyTest.cpp
+++ b/tests/ProxyTest.cpp
@@ -698,6 +698,9 @@ static int s_TestDirectConnectionTunnelingProxyBasicAuth(struct aws_allocator *a
 
         s_InitializeProxiedRawConnection(testState, aws_byte_cursor_from_string(s_https_endpoint));
         ASSERT_TRUE(testState.m_connection != nullptr);
+
+        testState.m_proxyOptions.ProxyStrategy.reset();
+        testState.m_connectionOptions.ProxyOptions->ProxyStrategy.reset();
     }
 
     /* now let everything tear down and make sure we don't leak or deadlock.*/

--- a/tests/ProxyTest.cpp
+++ b/tests/ProxyTest.cpp
@@ -566,7 +566,6 @@ static int s_TestDirectConnectionTunnelingProxyHttp(struct aws_allocator *alloca
         s_InitializeProxiedRawConnection(testState, aws_byte_cursor_from_string(s_https_endpoint));
 
         ASSERT_TRUE(testState.m_connection != nullptr);
-        ASSERT_INT_EQUALS(testState.m_proxyOptions.ProxyStrategy.use_count(), 3);
     }
 
     /* now let everything tear down and make sure we don't leak or deadlock.*/
@@ -574,6 +573,74 @@ static int s_TestDirectConnectionTunnelingProxyHttp(struct aws_allocator *alloca
 }
 
 AWS_TEST_CASE(DirectConnectionTunnelingProxyHttp, s_TestDirectConnectionTunnelingProxyHttp)
+
+/*
+ * Regression test for the AdaptiveHttpProxyStrategy lifetime bug:
+ * CreateAdaptiveHttpProxyStrategy() stores a raw pointer (user_data) to the C++ AdaptiveHttpProxyStrategy
+ * in the C-layer aws_http_proxy_strategy. If the C++ shared_ptr is not retained by the connection
+ * infrastructure, the C++ object gets destroyed when the caller's options go out of scope, leaving a
+ * dangling user_data pointer in the still-alive C strategy.
+ *
+ * This test verifies that CreateConnection retains the ProxyStrategy shared_ptr so it outlives
+ * the caller's options struct, preventing use-after-free when the C layer invokes strategy callbacks.
+ */
+static int s_TestAdaptiveProxyStrategyLifetime(struct aws_allocator *allocator, void *ctx)
+{
+    (void)ctx;
+    {
+        Aws::Crt::ApiHandle apiHandle(allocator);
+
+        ProxyIntegrationTestState testState(allocator);
+        s_InitializeProxyEnvironmentalOptions(testState, HttpProxyTestHostType::Http);
+        testState.m_proxyOptions.ProxyConnectionType = AwsHttpProxyConnectionType::Tunneling;
+
+        HttpProxyStrategyAdaptiveConfig adaptiveConfig;
+        adaptiveConfig.KerberosGetToken = [](String &token)
+        {
+            token = "fake-kerberos-token";
+            return true;
+        };
+        adaptiveConfig.NtlmGetCredential = [](String &credential)
+        {
+            credential = "fake-ntlm-credential";
+            return true;
+        };
+        adaptiveConfig.NtlmGetToken = [](const String &, String &token)
+        {
+            token = "fake-ntlm-token";
+            return true;
+        };
+
+        testState.m_proxyOptions.ProxyStrategy =
+            HttpProxyStrategy::CreateAdaptiveHttpProxyStrategy(adaptiveConfig, allocator);
+        ASSERT_NOT_NULL(testState.m_proxyOptions.ProxyStrategy.get());
+
+        /* Grab a weak_ptr to the strategy so we can observe its lifetime independently. */
+        std::weak_ptr<HttpProxyStrategy> strategyObserver = testState.m_proxyOptions.ProxyStrategy;
+
+        s_InitializeProxiedRawConnection(testState, aws_byte_cursor_from_string(s_https_endpoint));
+
+        ASSERT_TRUE(testState.m_connection != nullptr);
+
+        /*
+         * Simulate the documented usage pattern: the caller's options go out of scope.
+         * Reset the ProxyStrategy in the options struct - if CreateConnection did NOT retain
+         * a copy, the strategy would be destroyed here (use_count drops to 0).
+         */
+        testState.m_proxyOptions.ProxyStrategy.reset();
+
+        /* The strategy must still be alive - the connection infrastructure must hold a reference. */
+        ASSERT_FALSE(strategyObserver.expired());
+
+        /* The connection is still active. In the buggy code, the underlying C strategy would now hold
+         * a dangling user_data pointer to the freed AdaptiveHttpProxyStrategy object. */
+    }
+
+    /* now let everything tear down and make sure we don't leak or deadlock.*/
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(AdaptiveProxyStrategyLifetime, s_TestAdaptiveProxyStrategyLifetime)
 
 static int s_TestDirectConnectionTunnelingProxyHttps(struct aws_allocator *allocator, void *ctx)
 {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
proxy strategy option can be help by underlying c structs. so we need to make sure to hold on to it for duration of connection

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
