### PR TITLE
Add TlsConnectionOptions param to profile credentials provider configuration

### DIFF
--- a/include/aws/crt/auth/Credentials.h
+++ b/include/aws/crt/auth/Credentials.h
@@ -204,11 +204,13 @@ namespace Aws
                  * Client TLS context to use for any secure network connections made while sourcing credentials
                  * (for example, a profile that uses assume-role will need to query STS).
                  *
-                 * If a TLS context is needed, and you did not pass one in, it will be created automatically.
-                 * However, you are encouraged to pass in a shared one since these are expensive objects.
-                 * If using BYO_CRYPTO, you must provide the TLS context since it cannot be created automatically.
+                 * If a TLS context is needed, and you did not pass one in, the content of TlsConnectionOptions will be
+                 * used which may be default contructed. However, you are encouraged to pass in a shared one since these
+                 * are expensive objects. If using BYO_CRYPTO, you must provide the TLS context since it cannot be
+                 * created automatically.
                  */
                 Io::TlsContext *TlsContext;
+                Io::TlsConnectionOptions TlsConnectionOptions;
 
                 /**
                  * (Optional) Http proxy configuration for the http request that fetches credentials.

--- a/source/auth/Credentials.cpp
+++ b/source/auth/Credentials.cpp
@@ -237,7 +237,15 @@ namespace Aws
                 raw_config.credentials_file_name_override = config.CredentialsFileNameOverride;
                 raw_config.profile_name_override = config.ProfileNameOverride;
                 raw_config.bootstrap = config.Bootstrap ? config.Bootstrap->GetUnderlyingHandle() : nullptr;
-                raw_config.tls_ctx = config.TlsContext ? config.TlsContext->GetUnderlyingHandle() : nullptr;
+                if (config.TlsContext != nullptr)
+                {
+                    raw_config.tls_ctx = config.TlsContext->GetUnderlyingHandle();
+                }
+                else if (config.TlsConnectionOptions)
+                {
+                    const auto *const connectionOptions = config.TlsConnectionOptions.GetUnderlyingHandle();
+                    raw_config.tls_ctx = connectionOptions->ctx;
+                }
                 struct proxy_env_var_settings proxy_options;
                 AWS_ZERO_STRUCT(proxy_options);
                 if (config.ProxyEnvVarOptions.has_value())


### PR DESCRIPTION
*Description of changes:*

Currently for the configuration object `CredentialsProviderProfileConfig` for TLS customization only `Io::TlsContext *TlsContext` is exposed to plugin in custom TLS contexts. this is different from how the other configuration objects are

[CredentialsProviderSTSWebIdentityConfig](https://github.com/awslabs/aws-crt-cpp/blob/main/include/aws/crt/auth/Credentials.h#L463-L505)
```c++
struct AWS_CRT_CPP_API CredentialsProviderSTSWebIdentityConfig
{
    //...omitted
    Io::TlsConnectionOptions TlsConnectionOptions;
};
```

[CredentialsProviderX509Config](https://github.com/awslabs/aws-crt-cpp/blob/main/include/aws/crt/auth/Credentials.h#L297-L337)
```c++
struct AWS_CRT_CPP_API CredentialsProviderX509Config
{
    //...omitted
    Io::TlsConnectionOptions TlsOptions;
};
```

[CredentialsProviderLoginConfig](https://github.com/awslabs/aws-crt-cpp/blob/main/include/aws/crt/auth/Credentials.h#L507-L543)
```c++
struct AWS_CRT_CPP_API CredentialsProviderLoginConfig
{
    //...omitted
    Io::TlsConnectionOptions TlsConnectionOptions;
}
```

Only the default chain and profile credentials provider uses `Io::TlsContext *` presumably because that was the original way it was done.

The reason I care about this is that the C++ SDK stores a `Io::TlsConnectionOptions` at the [global level for re-use between clients](https://github.com/aws/aws-sdk-cpp/blob/main/src/aws-cpp-sdk-core/source/Aws.cpp#L94-L104). since our customization point for custom TLS returns connection options and not context.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
