### PR TITLE
 Fix: Zero-initialize m_metricsStorage in Mqtt5ClientOptions

### DIFF
--- a/source/mqtt/Mqtt5Client.cpp
+++ b/source/mqtt/Mqtt5Client.cpp
@@ -211,6 +211,7 @@ namespace Aws
                 m_sdkMetrics = Crt::ScopedResource<Mqtt::IoTDeviceSDKMetrics>(
                     Crt::New<Mqtt::IoTDeviceSDKMetrics>(allocator),
                     [allocator](Mqtt::IoTDeviceSDKMetrics *metrics) { Crt::Delete(metrics, allocator); });
+                AWS_ZERO_STRUCT(m_metricsStorage);
                 m_sdkMetrics->initializeRawOptions(m_metricsStorage);
                 m_socketOptions.SetSocketType(Io::SocketType::Stream);
                 AWS_ZERO_STRUCT(m_packetConnectViewStorage);


### PR DESCRIPTION
*Issue :*
CI tests were failing due to 
`member access within misaligned address 0xbebebebebebebebe for type 'const struct aws_mqtt_metadata_entry', which requires 8 byte alignment 0xbebebebebebebebe: note: pointer points here fue to aws_c_mqtt `                                                                                                                                                        

*Description of changes:*
Initializing metrics_metadata_entries to `AWS_ZERO_STRUCT`. Earlier the initializeRawOptions()  only sets library_name leaving metrics-> metadata_entries and metadata_count uninitialized garbage

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
