### PR TITLE
noCertificateRevocation option binding

### DIFF
--- a/include/aws/crt/io/TlsOptions.h
+++ b/include/aws/crt/io/TlsOptions.h
@@ -173,6 +173,20 @@ namespace Aws
                 void SetVerifyPeer(bool verifyPeer) noexcept;
 
                 /**
+                 * Set to true to disable certificate revocation checking during TLS negotiation.
+                 *
+                 * On Windows (SChannel), this prevents the TLS handshake from making outbound network calls
+                 * to CRL/OCSP revocation endpoints, which can block for minutes when the endpoints are unreachable
+                 * (e.g., in private subnets without internet access).
+                 *
+                 * On Linux (s2n), this disables validation of OCSP stapled responses provided by the server.
+                 *
+                 * On Apple platforms, this is a no-op as revocation checking is not enabled by default.
+                 * @param noCertificateRevocation: Set true to disable revocation checking.
+                 */
+                void SetNoCertificateRevocation(bool noCertificateRevocation) noexcept;
+
+                /**
                  * Sets the minimum TLS version allowed.
                  * @param minimumTlsVersion: The minimum TLS version.
                  */

--- a/include/aws/crt/io/TlsOptions.h
+++ b/include/aws/crt/io/TlsOptions.h
@@ -182,6 +182,7 @@ namespace Aws
                  * On Linux (s2n), this disables validation of OCSP stapled responses provided by the server.
                  *
                  * On Apple platforms, this is a no-op as revocation checking is not enabled by default.
+                 *
                  * @param noCertificateRevocation: Set true to disable revocation checking.
                  */
                 void SetNoCertificateRevocation(bool noCertificateRevocation) noexcept;

--- a/source/io/TlsOptions.cpp
+++ b/source/io/TlsOptions.cpp
@@ -164,6 +164,12 @@ namespace Aws
                 aws_tls_ctx_options_set_verify_peer(&m_options, verify_peer);
             }
 
+            void TlsContextOptions::SetNoCertificateRevocation(bool no_certificate_revocation) noexcept
+            {
+                AWS_ASSERT(m_isInit);
+                aws_tls_ctx_options_set_no_certificate_revocation(&m_options, no_certificate_revocation);
+            }
+
             void TlsContextOptions::SetMinimumTlsVersion(aws_tls_versions minimumTlsVersion)
             {
                 AWS_ASSERT(m_isInit);


### PR DESCRIPTION
Bind the tls option to disable certificate revocation checks.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
