### PR TITLE
Remove fix for s2n-tls on macOS x64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,6 +345,36 @@ jobs:
         chmod a+x builder
         ./builder build -p ${{ env.PACKAGE_NAME }} --spec=downstream
 
+  macos-s2n-openssl:
+    runs-on: macos-14 # latest
+    env:
+      AWS_CRT_USE_NON_FIPS_TLS_13: 1
+    steps:
+    - uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ env.CRT_CI_ROLE }}
+        aws-region: ${{ env.AWS_DEFAULT_REGION }}
+    - name: Build ${{ env.PACKAGE_NAME }} + consumers
+      run: |
+        python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
+        chmod a+x builder
+        ./builder build -p ${{ env.PACKAGE_NAME }} --spec=downstream --cmake-extra=-DUSE_OPENSSL=ON
+
+  macos-x64-s2n-openssl:
+    runs-on: macos-14-large # latest
+    env:
+      AWS_CRT_USE_NON_FIPS_TLS_13: 1
+    steps:
+    - uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ env.CRT_CI_ROLE }}
+        aws-region: ${{ env.AWS_DEFAULT_REGION }}
+    - name: Build ${{ env.PACKAGE_NAME }} + consumers
+      run: |
+        python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
+        chmod a+x builder
+        ./builder build -p ${{ env.PACKAGE_NAME }} --spec=downstream --cmake-extra=-DUSE_OPENSSL=ON
+
   # cross-compile for iOS
   # Skip signing the code on iOS.
   # Otherwise it will not compile with error that Bundle identifier is missing.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,18 +105,7 @@ if(BUILD_DEPS)
             check_submodule_commit("s2n" "crt/s2n")
         endif()
 
-        # On Intel Macs, Homebrew installs to /usr/local which is in the default header search path.
-        # Without this, s2n's libcrypto detection picks up Homebrew's OpenSSL instead of bundled aws-lc.
-        # ARM Macs use /opt/homebrew (not in default search paths) so they don't need this.
-        if(APPLE AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")
-            set(_AWS_CRT_PREV_NO_SYSTEM_FROM_IMPORTED ${CMAKE_NO_SYSTEM_FROM_IMPORTED})
-            set(CMAKE_NO_SYSTEM_FROM_IMPORTED ON)
-        endif()
         add_subdirectory(crt/s2n)
-        if(APPLE AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")
-            set(CMAKE_NO_SYSTEM_FROM_IMPORTED ${_AWS_CRT_PREV_NO_SYSTEM_FROM_IMPORTED})
-            unset(_AWS_CRT_PREV_NO_SYSTEM_FROM_IMPORTED)
-        endif()
     endif()
 
     if(ENFORCE_SUBMODULE_VERSIONS)


### PR DESCRIPTION
*Issue #, if available:*

On macOS x64, XCode's Clang has -I/usr/local/include baked in, which can shadow libcrypto headers from imported targets (propagated with -isystem). Currently, CMake config sets`NO_SYSTEM_FROM_IMPORTED` flag forcing `-I` for imported target. With s2n-tls implemented this fix on their side, the local fix is not needed anymore.

*Description of changes:*

Update s2n-tls to get the fix. Remove the local fix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
