### PR TITLE
Add msan CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
       - 'docs'
 
 env:
-  BUILDER_VERSION: v0.9.96
-  BUILDER_SOURCE: releases
+  BUILDER_VERSION: ubuntu-22-msan-image # TODO: switch back to release tag (e.g. v0.9.97) once builder image is released
+  BUILDER_SOURCE: channels
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-crt-cpp
   LINUX_BASE_IMAGE: ubuntu-18-x64
@@ -418,19 +418,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - sanitizers: "thread"
-            compiler: clang-latest
-            extra-cmake: ""
-          - sanitizers: "address,undefined"
-            compiler: clang-latest
-            extra-cmake: ""
-          - sanitizers: "memory"
-            compiler: clang-latest
-            extra-cmake: >-
-              --cmake-extra=-DCMAKE_CXX_FLAGS=-stdlib=libc++
-              --cmake-extra=-DCMAKE_EXE_LINKER_FLAGS=-stdlib=libc++
-              --cmake-extra=-DCMAKE_C_FLAGS=-fsanitize-memory-track-origins=2
+        sanitizers: ["thread", "address,undefined"]
     steps:
     - uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -440,4 +428,26 @@ jobs:
     - name: Build ${{ env.PACKAGE_NAME }}
       run: |
         aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
-        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=${{ matrix.compiler }} --cmake-extra=-DENABLE_SANITIZERS=ON --cmake-extra=-DSANITIZERS="${{ matrix.sanitizers }}" ${{ matrix.extra-cmake }}
+        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=clang-latest --cmake-extra=-DENABLE_SANITIZERS=ON --cmake-extra=-DSANITIZERS="${{ matrix.sanitizers }}"
+
+  clang-msan:
+    # MemorySanitizer needs the whole stack instrumented, so it runs in its own job
+    # on a dedicated image (ubuntu-22-msan-x64) that ships an MSan-instrumented libc++
+    # at /opt/libcxx-msan. aws-lc is instrumented via the -DMSAN gate in CMakeLists.txt.
+    # clang-19 must match the compiler that built that libc++. Flag paths are hardcoded
+    # (not $LIBCXX_MSAN_ROOT) because that env var only exists inside the container.
+    # TODO: move these MSan flags into a CMake toolchain file baked into the image
+    # and pass a single -DCMAKE_TOOLCHAIN_FILE, once the flag set is finalized.
+    runs-on: ubuntu-26.04 # latest
+    steps:
+    - uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ env.CRT_CI_ROLE }}
+        aws-region: ${{ env.AWS_DEFAULT_REGION }}
+    - name: Build ${{ env.PACKAGE_NAME }}
+      run: |
+        aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
+        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-ubuntu-22-msan-x64 build -p ${{ env.PACKAGE_NAME }} --compiler=clang-19 --cmake-extra=-DENABLE_SANITIZERS=ON --cmake-extra=-DSANITIZERS=memory \
+          --cmake-extra="-DCMAKE_C_FLAGS=-fsanitize=memory -fsanitize-memory-track-origins=2" \
+          --cmake-extra="-DCMAKE_CXX_FLAGS=-fsanitize=memory -fsanitize-memory-track-origins=2 -nostdinc++ -isystem /opt/libcxx-msan/include/c++/v1" \
+          --cmake-extra="-DCMAKE_EXE_LINKER_FLAGS=-fsanitize=memory -nostdlib++ -L/opt/libcxx-msan/lib -Wl,-rpath,/opt/libcxx-msan/lib -lc++ -lc++abi -lgcc_s"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -433,11 +433,8 @@ jobs:
   clang-msan:
     # MemorySanitizer needs the whole stack instrumented, so it runs in its own job
     # on a dedicated image (ubuntu-22-msan-x64) that ships an MSan-instrumented libc++
-    # at /opt/libcxx-msan. aws-lc is instrumented via the -DMSAN gate in CMakeLists.txt.
-    # clang-19 must match the compiler that built that libc++. Flag paths are hardcoded
-    # (not $LIBCXX_MSAN_ROOT) because that env var only exists inside the container.
-    # TODO: move these MSan flags into a CMake toolchain file baked into the image
-    # and pass a single -DCMAKE_TOOLCHAIN_FILE, once the flag set is finalized.
+    # and a matching toolchain file. aws-lc is instrumented via the -DMSAN gate in
+    # CMakeLists.txt. clang-19 must match the compiler that built that libc++.
     runs-on: ubuntu-26.04 # latest
     steps:
     - uses: aws-actions/configure-aws-credentials@v4
@@ -447,7 +444,4 @@ jobs:
     - name: Build ${{ env.PACKAGE_NAME }}
       run: |
         aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
-        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-ubuntu-22-msan-x64 build -p ${{ env.PACKAGE_NAME }} --compiler=clang-19 --cmake-extra=-DENABLE_SANITIZERS=ON --cmake-extra=-DSANITIZERS=memory \
-          --cmake-extra="-DCMAKE_C_FLAGS=-fsanitize=memory -fsanitize-memory-track-origins=2" \
-          --cmake-extra="-DCMAKE_CXX_FLAGS=-fsanitize=memory -fsanitize-memory-track-origins=2 -nostdinc++ -isystem /opt/libcxx-msan/include/c++/v1" \
-          --cmake-extra="-DCMAKE_EXE_LINKER_FLAGS=-fsanitize=memory -nostdlib++ -L/opt/libcxx-msan/lib -Wl,-rpath,/opt/libcxx-msan/lib -lc++ -lc++abi -lgcc_s"
+        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-ubuntu-22-msan-x64 build -p ${{ env.PACKAGE_NAME }} --compiler=clang-19 --cmake-extra=-DENABLE_SANITIZERS=ON --cmake-extra=-DSANITIZERS=memory --cmake-extra=-DCMAKE_TOOLCHAIN_FILE=/opt/msan-toolchain.cmake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -418,7 +418,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sanitizers: ["thread", "address,undefined", "memory"]
+        include:
+          - sanitizers: "thread"
+            compiler: clang-21
+            extra-cmake: ""
+          - sanitizers: "address,undefined"
+            compiler: clang-21
+            extra-cmake: ""
+          - sanitizers: "memory"
+            compiler: clang-21
+            extra-cmake: >-
+              --cmake-extra=-DCMAKE_CXX_FLAGS=-stdlib=libc++
+              --cmake-extra=-DCMAKE_EXE_LINKER_FLAGS=-stdlib=libc++
+              --cmake-extra=-DCMAKE_C_FLAGS=-fsanitize-memory-track-origins=2
     steps:
     - uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -428,4 +440,4 @@ jobs:
     - name: Build ${{ env.PACKAGE_NAME }}
       run: |
         aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
-        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=clang-22 --cmake-extra=-DENABLE_SANITIZERS=ON --cmake-extra=-DSANITIZERS="${{ matrix.sanitizers }}"
+        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=${{ matrix.compiler }} --cmake-extra=-DENABLE_SANITIZERS=ON --cmake-extra=-DSANITIZERS="${{ matrix.sanitizers }}" ${{ matrix.extra-cmake }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - 'docs'
 
 env:
-  BUILDER_VERSION: v0.9.93
+  BUILDER_VERSION: v0.9.96
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-crt-cpp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,7 +397,7 @@ jobs:
         ./make-docs.py
 
   check-submodules:
-    runs-on: ubuntu-26.04 # latest
+    runs-on: ubuntu-24.04 # latest
     steps:
     - uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -414,7 +414,7 @@ jobs:
       uses: awslabs/aws-crt-builder/.github/actions/check-submodules@main
 
   clang-sanitizers:
-    runs-on: ubuntu-24.04 # latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -431,11 +431,12 @@ jobs:
         ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=clang-latest --cmake-extra=-DENABLE_SANITIZERS=ON --cmake-extra=-DSANITIZERS="${{ matrix.sanitizers }}"
 
   clang-msan:
-    # MemorySanitizer needs the whole stack instrumented, so it runs in its own job
-    # on a dedicated image (ubuntu-22-msan-x64) that ships an MSan-instrumented libc++
-    # and a matching toolchain file. aws-lc is instrumented via the -DMSAN gate in
-    # CMakeLists.txt. clang-19 must match the compiler that built that libc++.
-    runs-on: ubuntu-24.04 # latest
+    # MemorySanitizer needs the whole stack instrumented, so it runs in its own job on a dedicated image
+    # that ships an MSan-instrumented libc++ and a matching toolchain file.
+    runs-on: ubuntu-24.04
+    env:
+      # Must match the clang that built the instrumented libc++ in the image; do not bump this alone.
+      MSAN_COMPILER: clang-19
     steps:
     - uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -444,4 +445,4 @@ jobs:
     - name: Build ${{ env.PACKAGE_NAME }}
       run: |
         aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
-        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-ubuntu-22-msan-x64 build -p ${{ env.PACKAGE_NAME }} --compiler=clang-19 --cmake-extra=-DENABLE_SANITIZERS=ON --cmake-extra=-DSANITIZERS=memory --cmake-extra=-DCMAKE_TOOLCHAIN_FILE=/opt/msan-toolchain.cmake
+        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-ubuntu-22-msan-x64 build -p ${{ env.PACKAGE_NAME }} --compiler=${{ env.MSAN_COMPILER }} --cmake-extra=-DENABLE_SANITIZERS=ON --cmake-extra=-DSANITIZERS=memory --cmake-extra=-DCMAKE_TOOLCHAIN_FILE=/opt/msan-toolchain.cmake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -418,7 +418,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sanitizers: ["thread", "address,undefined"]
+        sanitizers: ["thread", "address,undefined", "memory"]
     steps:
     - uses: aws-actions/configure-aws-credentials@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
       - 'docs'
 
 env:
-  BUILDER_VERSION: ubuntu-22-msan-image # TODO: switch back to release tag (e.g. v0.9.97) once builder image is released
-  BUILDER_SOURCE: channels
+  BUILDER_VERSION: v0.9.97
+  BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-crt-cpp
   LINUX_BASE_IMAGE: ubuntu-18-x64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,19 +414,19 @@ jobs:
       uses: awslabs/aws-crt-builder/.github/actions/check-submodules@main
 
   clang-sanitizers:
-    runs-on: ubuntu-24.04 # latest
+    runs-on: ubuntu-26.04 # latest
     strategy:
       fail-fast: false
       matrix:
         include:
           - sanitizers: "thread"
-            compiler: clang-21
+            compiler: clang-latest
             extra-cmake: ""
           - sanitizers: "address,undefined"
-            compiler: clang-21
+            compiler: clang-latest
             extra-cmake: ""
           - sanitizers: "memory"
-            compiler: clang-21
+            compiler: clang-latest
             extra-cmake: >-
               --cmake-extra=-DCMAKE_CXX_FLAGS=-stdlib=libc++
               --cmake-extra=-DCMAKE_EXE_LINKER_FLAGS=-stdlib=libc++

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,7 +397,7 @@ jobs:
         ./make-docs.py
 
   check-submodules:
-    runs-on: ubuntu-24.04 # latest
+    runs-on: ubuntu-26.04 # latest
     steps:
     - uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -428,4 +428,4 @@ jobs:
     - name: Build ${{ env.PACKAGE_NAME }}
       run: |
         aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
-        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=clang-12 --cmake-extra=-DENABLE_SANITIZERS=ON --cmake-extra=-DSANITIZERS="${{ matrix.sanitizers }}"
+        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=clang-22 --cmake-extra=-DENABLE_SANITIZERS=ON --cmake-extra=-DSANITIZERS="${{ matrix.sanitizers }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,7 +414,7 @@ jobs:
       uses: awslabs/aws-crt-builder/.github/actions/check-submodules@main
 
   clang-sanitizers:
-    runs-on: ubuntu-26.04 # latest
+    runs-on: ubuntu-24.04 # latest
     strategy:
       fail-fast: false
       matrix:
@@ -435,7 +435,7 @@ jobs:
     # on a dedicated image (ubuntu-22-msan-x64) that ships an MSan-instrumented libc++
     # and a matching toolchain file. aws-lc is instrumented via the -DMSAN gate in
     # CMakeLists.txt. clang-19 must match the compiler that built that libc++.
-    runs-on: ubuntu-26.04 # latest
+    runs-on: ubuntu-24.04 # latest
     steps:
     - uses: aws-actions/configure-aws-credentials@v4
       with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ if(BUILD_DEPS)
 
             set(AWSLC_SANITIZER_ARGUMENTS "")
             if(ENABLE_SANITIZERS AND SANITIZERS MATCHES "memory")
+                # OPENSSL_NO_ASM is used because MSan can't see into asm.
                 list(APPEND AWSLC_SANITIZER_ARGUMENTS -DMSAN=1 -DOPENSSL_NO_ASM=1)
             endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,11 @@ if(BUILD_DEPS)
                 endif()
             endif()
 
+            set(AWSLC_SANITIZER_ARGUMENTS "")
+            if(ENABLE_SANITIZERS AND SANITIZERS MATCHES "memory")
+                list(APPEND AWSLC_SANITIZER_ARGUMENTS -DMSAN=1 -DOPENSSL_NO_ASM=1)
+            endif()
+
             # s2n-tls uses libcrypto during its configuration, so we need to prebuild aws-lc.
             aws_prebuild_dependency(
                 DEPENDENCY_NAME AWSLC
@@ -97,6 +102,7 @@ if(BUILD_DEPS)
                     -DBUILD_LIBSSL=OFF
                     -DBUILD_TESTING=OFF
                     -DCMAKE_C_FLAGS=${AWSLC_CMAKE_C_FLAGS}
+                    ${AWSLC_SANITIZER_ARGUMENTS}
             )
         endif()
 

--- a/source/mqtt/Mqtt5Client.cpp
+++ b/source/mqtt/Mqtt5Client.cpp
@@ -211,7 +211,7 @@ namespace Aws
                 m_sdkMetrics = Crt::ScopedResource<Mqtt::IoTDeviceSDKMetrics>(
                     Crt::New<Mqtt::IoTDeviceSDKMetrics>(allocator),
                     [allocator](Mqtt::IoTDeviceSDKMetrics *metrics) { Crt::Delete(metrics, allocator); });
-                // AWS_ZERO_STRUCT(m_metricsStorage);
+                AWS_ZERO_STRUCT(m_metricsStorage);
                 m_sdkMetrics->initializeRawOptions(m_metricsStorage);
                 m_socketOptions.SetSocketType(Io::SocketType::Stream);
                 AWS_ZERO_STRUCT(m_packetConnectViewStorage);

--- a/source/mqtt/Mqtt5Client.cpp
+++ b/source/mqtt/Mqtt5Client.cpp
@@ -211,7 +211,7 @@ namespace Aws
                 m_sdkMetrics = Crt::ScopedResource<Mqtt::IoTDeviceSDKMetrics>(
                     Crt::New<Mqtt::IoTDeviceSDKMetrics>(allocator),
                     [allocator](Mqtt::IoTDeviceSDKMetrics *metrics) { Crt::Delete(metrics, allocator); });
-                AWS_ZERO_STRUCT(m_metricsStorage);
+                // AWS_ZERO_STRUCT(m_metricsStorage);
                 m_sdkMetrics->initializeRawOptions(m_metricsStorage);
                 m_socketOptions.SetSocketType(Io::SocketType::Stream);
                 AWS_ZERO_STRUCT(m_packetConnectViewStorage);

--- a/tests/Mqtt5ClientTest.cpp
+++ b/tests/Mqtt5ClientTest.cpp
@@ -516,6 +516,7 @@ static Mqtt5TestContext createTestContext(
 
     Mqtt5ClientOptions mqtt5Options(allocator);
     mqtt5Options.WithHostName(mqtt5TestVars.m_hostname_string);
+    fprintf(stderr, "=== port is %lu\n", static_cast<unsigned long>(mqtt5TestVars.m_port_value));
     mqtt5Options.WithPort(mqtt5TestVars.m_port_value);
 
     s_setupConnectionLifeCycle(mqtt5Options, context.connectionPromise, context.stoppedPromise);

--- a/tests/Mqtt5ClientTest.cpp
+++ b/tests/Mqtt5ClientTest.cpp
@@ -479,7 +479,7 @@ struct Mqtt5TestEnvVars
     struct aws_string *m_httpproxy_port = NULL;
 
     Aws::Crt::String m_hostname_string;
-    uint32_t m_port_value;
+    uint32_t m_port_value = 0;
     Aws::Crt::String m_username_string;
     Aws::Crt::ByteCursor m_password_cursor;
     Aws::Crt::String m_certificate_path_string;
@@ -516,7 +516,6 @@ static Mqtt5TestContext createTestContext(
 
     Mqtt5ClientOptions mqtt5Options(allocator);
     mqtt5Options.WithHostName(mqtt5TestVars.m_hostname_string);
-    fprintf(stderr, "=== port is %lu\n", static_cast<unsigned long>(mqtt5TestVars.m_port_value));
     mqtt5Options.WithPort(mqtt5TestVars.m_port_value);
 
     s_setupConnectionLifeCycle(mqtt5Options, context.connectionPromise, context.stoppedPromise);


### PR DESCRIPTION
- New clang-msan job running on the ubuntu-22-msan-x64 image.
- aws-lc MSan support in CMakeLists.txt: when the memory sanitizer is enabled, build the prebuilt aws-lc with additional options required for msan.
- Fix an uninitialized m_port_value in the MQTT5 test helper, surfaced by MSan.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
