### PR TITLE
Use AWS_WARNINGS_ARE_ERRORS to restrict -Werror in elasticurl_cpp.

### DIFF
--- a/bin/elasticurl_cpp/CMakeLists.txt
+++ b/bin/elasticurl_cpp/CMakeLists.txt
@@ -20,7 +20,7 @@ if (MSVC)
         target_compile_options(${ELASTICURL_CPP_PROJECT_NAME} PRIVATE "/MD$<$<CONFIG:Debug>:d>")
     endif()
     target_compile_options(${ELASTICURL_CPP_PROJECT_NAME} PRIVATE /W4 /WX)
-else ()
+elseif (AWS_WARNINGS_ARE_ERRORS)
     target_compile_options(${ELASTICURL_CPP_PROJECT_NAME} PRIVATE -Wall -Wno-long-long -pedantic -Werror)
 endif ()
 

--- a/bin/mqtt5_app/CMakeLists.txt
+++ b/bin/mqtt5_app/CMakeLists.txt
@@ -20,7 +20,7 @@ if (MSVC)
         target_compile_options(${MQTT5_APP_PROJECT_NAME} PRIVATE "/MD$<$<CONFIG:Debug>:d>")
     endif()
     target_compile_options(${MQTT5_APP_PROJECT_NAME} PRIVATE /W4 /WX)
-else ()
+elseif (AWS_WARNINGS_ARE_ERRORS)
     target_compile_options(${MQTT5_APP_PROJECT_NAME} PRIVATE -Wall -Wno-long-long -pedantic -Werror)
 endif ()
 

--- a/bin/mqtt5_canary/CMakeLists.txt
+++ b/bin/mqtt5_canary/CMakeLists.txt
@@ -21,7 +21,7 @@ if (MSVC)
         target_compile_options(${MQTT5_CANARY_PROJECT_NAME} PRIVATE "/MD$<$<CONFIG:Debug>:d>")
     endif()
     target_compile_options(${MQTT5_CANARY_PROJECT_NAME} PRIVATE /W4 /WX)
-else ()
+elseif (AWS_WARNINGS_ARE_ERRORS)
     target_compile_options(${MQTT5_CANARY_PROJECT_NAME} PRIVATE -Wall -Wno-long-long -pedantic -Werror)
 endif ()
 


### PR DESCRIPTION
Found by Gentoo tinderbox: https://bugs.gentoo.org/977183

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
