### PR TITLE
Use latest version of aws-crt-builder

### DIFF
--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  BUILDER_VERSION: v0.9.92
+  BUILDER_VERSION: latest
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-crt-cpp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - 'docs'
 
 env:
-  BUILDER_VERSION: v0.9.97
+  BUILDER_VERSION: latest
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-crt-cpp

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -2,7 +2,7 @@ version: 0.2
 env:
   shell: bash
   variables:
-    BUILDER_VERSION: v0.9.44
+    BUILDER_VERSION: latest
     BUILDER_SOURCE: releases
     BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
     PACKAGE_NAME: aws-crt-cpp

--- a/codebuild/mqtt5-cpp-canary-test.yml
+++ b/codebuild/mqtt5-cpp-canary-test.yml
@@ -7,7 +7,7 @@ env:
     CANARY_TPS: 50
     CANARY_CLIENT_COUNT: 10
     CANARY_LOG_LEVEL: 'ERROR'
-    BUILDER_VERSION: v0.9.44
+    BUILDER_VERSION: latest
     BUILDER_SOURCE: releases
     BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
     PACKAGE_NAME: aws-crt-cpp


### PR DESCRIPTION
Update aws-crt-builder version to `latest`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
