### PR TITLE
bind out encoded and decoded length for base 64 encodings

### DIFF
--- a/include/aws/crt/Types.h
+++ b/include/aws/crt/Types.h
@@ -68,7 +68,11 @@ namespace Aws
         AWS_CRT_CPP_API ByteCursor ByteCursorFromArray(const uint8_t *array, size_t len) noexcept;
 
         AWS_CRT_CPP_API Vector<uint8_t> Base64Decode(const String &decode) noexcept;
+        AWS_CRT_CPP_API Vector<uint8_t> Base64Decode(ByteCursor decode) noexcept;
+        AWS_CRT_CPP_API size_t Base64DecodedLength(ByteCursor decode) noexcept;
         AWS_CRT_CPP_API String Base64Encode(const Vector<uint8_t> &encode) noexcept;
+        AWS_CRT_CPP_API String Base64Encode(ByteCursor encode) noexcept;
+        AWS_CRT_CPP_API size_t Base64EncodedLength(ByteCursor encode) noexcept;
 
         template <typename RawType, typename TargetType> using TypeConvertor = std::function<TargetType(RawType)>;
 

--- a/source/Types.cpp
+++ b/source/Types.cpp
@@ -78,10 +78,14 @@ namespace Aws
         Vector<uint8_t> Base64Decode(const String &decode) noexcept
         {
             ByteCursor toDecode = ByteCursorFromString(decode);
+            return Base64Decode(toDecode);
+        }
 
+        Vector<uint8_t> Base64Decode(ByteCursor decode) noexcept
+        {
             size_t allocationSize = 0;
 
-            if (AWS_OP_SUCCESS != aws_base64_compute_decoded_len(&toDecode, &allocationSize))
+            if (AWS_OP_SUCCESS != aws_base64_compute_decoded_len(&decode, &allocationSize))
             {
                 return {};
             }
@@ -89,7 +93,7 @@ namespace Aws
             Vector<uint8_t> output(allocationSize, 0x00);
             ByteBuf tempBuf = aws_byte_buf_from_empty_array(output.data(), output.size());
 
-            if (AWS_OP_SUCCESS != aws_base64_decode(&toDecode, &tempBuf))
+            if (AWS_OP_SUCCESS != aws_base64_decode(&decode, &tempBuf))
             {
                 return {};
             }
@@ -97,12 +101,23 @@ namespace Aws
             return output;
         }
 
+        size_t Base64DecodedLength(ByteCursor decode) noexcept
+        {
+            size_t allocationSize = 0;
+            (void)aws_base64_compute_decoded_len(&decode, &allocationSize);
+            return allocationSize;
+        }
+
         String Base64Encode(const Vector<uint8_t> &encode) noexcept
         {
             auto toEncode = aws_byte_cursor_from_array((const void *)encode.data(), encode.size());
+            return Base64Encode(toEncode);
+        }
 
+        String Base64Encode(ByteCursor encode) noexcept
+        {
             size_t allocationSize = 0;
-            if (AWS_OP_SUCCESS != aws_base64_compute_encoded_len(toEncode.len, &allocationSize))
+            if (AWS_OP_SUCCESS != aws_base64_compute_encoded_len(encode.len, &allocationSize))
             {
                 return {};
             }
@@ -110,7 +125,7 @@ namespace Aws
             String outputStr(allocationSize, 0x00);
             auto tempBuf = aws_byte_buf_from_empty_array(outputStr.data(), outputStr.size());
 
-            if (AWS_OP_SUCCESS != aws_base64_encode(&toEncode, &tempBuf))
+            if (AWS_OP_SUCCESS != aws_base64_encode(&encode, &tempBuf))
             {
                 return {};
             }
@@ -118,6 +133,13 @@ namespace Aws
             AWS_ASSERT(outputStr.length() == tempBuf.len);
 
             return outputStr;
+        }
+
+        size_t Base64EncodedLength(ByteCursor encode) noexcept
+        {
+            size_t allocationSize = 0;
+            (void)aws_base64_compute_encoded_len(encode.len, &allocationSize);
+            return allocationSize;
         }
     } // namespace Crt
 } // namespace Aws

--- a/tests/TypesTest.cpp
+++ b/tests/TypesTest.cpp
@@ -22,9 +22,13 @@ static int s_base64_round_trip(struct aws_allocator *allocator, void *ctx)
 
         Aws::Crt::String encoded = Aws::Crt::Base64Encode(test_vector);
         ASSERT_BIN_ARRAYS_EQUALS(expected.data(), expected.size(), encoded.data(), encoded.size());
+        ASSERT_UINT_EQUALS(
+            encoded.size(),
+            Aws::Crt::Base64EncodedLength(Aws::Crt::ByteCursorFromArray(test_vector.data(), test_vector.size())));
 
         Aws::Crt::Vector<uint8_t> decoded = Aws::Crt::Base64Decode(encoded);
         ASSERT_BIN_ARRAYS_EQUALS(test_vector.data(), test_vector.size(), decoded.data(), decoded.size());
+        ASSERT_UINT_EQUALS(decoded.size(), Aws::Crt::Base64DecodedLength(Aws::Crt::ByteCursorFromString(encoded)));
     }
 
     return 0;


### PR DESCRIPTION
*Description of changes:*

binds out `aws_base64_compute_decoded_len` / `aws_base64_compute_encoded_len` and adds byte cursor overrides for base64 fuctions to avoid copies.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
